### PR TITLE
Improve support for cmake sub projects

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@
 add_library(charls "")
 
 target_include_directories(charls PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${charls_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
 if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
This PR includes a small change to the src/CMakeLists.txt file such that charls header files can be more easily imported by projects that use charls as a cmake sub project.  With this change, a parent project can do:
#include <charls/charls.h>
rather than something like:
#include "../extern/charls/include/charls/charls.h"

Would be nice to have @malaterre review