### PR TITLE
Add pkgconfig file description for charls  library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(GNUInstallDirs)
+CONFIGURE_FILE("charls.pc.in" "charls.pc" @ONLY)
+install(FILES "charls.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
 # Configure the supported C++ compilers: gcc, clang and MSVC
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(PEDANTIC_CXX_COMPILE_FLAGS

--- a/charls.pc.in
+++ b/charls.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Description: An optimized implementation of the JPEG-LS standard
+Name: CharLS
+Version: @VERSION@
+URL: https://github.com/team-charls/charls/
+Cflags: -I${includedir}
+Libs: -L${libdir} -lcharls


### PR DESCRIPTION
charls still does not provide pkgconfig library description.
using that file will be possible easy detect in build system charls
library availability, its version and development resources.