### PR TITLE
Provide an application with a clear name djpls

### DIFF
--- a/samples/convert.c/CMakeLists.txt
+++ b/samples/convert.c/CMakeLists.txt
@@ -1,22 +1,26 @@
 # Copyright (c) Team CharLS.
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_executable(convert-c "")
+add_executable(djpls "")
 
-target_sources(convert-c
+target_sources(djpls
   PRIVATE
     main.c
 )
 
 if(WIN32 AND MSVC_VERSION GREATER_EQUAL 1920)
   # Only add the manifest file when building a Windows app
-  target_sources(convert-c PRIVATE app.manifest)
+  target_sources(djpls PRIVATE app.manifest)
 endif()
 
-target_link_libraries(convert-c PRIVATE charls)
+target_link_libraries(djpls PRIVATE charls)
+install(TARGETS djpls EXPORT charls_targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
 
 if(MSVC)
   # Not all compilers come with the secure C standard extension functions, making it difficult to use them.
   # Disable the MSVC warning about not using these functions to keep the sample code simple and easy to understand.
-  target_compile_definitions(convert-c PRIVATE _CRT_SECURE_NO_WARNINGS)
+  target_compile_definitions(djpls PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()


### PR DESCRIPTION
This is to mimic djpeg naming convention (as provided by libjpeg)