### PR TITLE
Don’t reopen namespace std

### DIFF
--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -729,14 +729,10 @@ using ColorTransformation CHARLS_DEPRECATED = color_transformation;
 
 } // namespace charls
 
-namespace std {
-
 template<>
-struct is_error_code_enum<charls::jpegls_errc> final : true_type
+struct std::is_error_code_enum<charls::jpegls_errc> final : std::true_type
 {
 };
-
-} // namespace std
 
 using charls_jpegls_errc = charls::jpegls_errc;
 using charls_interleave_mode = charls::interleave_mode;

--- a/unittest/jpeg_error_test.cpp
+++ b/unittest/jpeg_error_test.cpp
@@ -33,6 +33,13 @@ public:
         Assert::IsTrue(strlen(jpegls_category().name()) > 0);
     }
 
+    TEST_METHOD(is_error_code_enum) // NOLINT
+    {
+        std::is_error_code_enum<charls::jpegls_errc> test;
+
+        Assert::IsTrue(test);
+    }
+
     TEST_METHOD(jpegls_category_call_message) // NOLINT
     {
         const std::error_category& category{jpegls_category()};


### PR DESCRIPTION
Prefer to define partial specializations using explicit style.