### PR TITLE
Improve missing EOI marker handling

### DIFF
--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -54,6 +54,7 @@ enum charls_jpegls_errc
     CHARLS_JPEGLS_ERRC_UNEXPECTED_RESTART_MARKER = 25,
     CHARLS_JPEGLS_ERRC_RESTART_MARKER_NOT_FOUND = 26,
     CHARLS_JPEGLS_ERRC_CALLBACK_FAILED = 27,
+    CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND = 28,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_WIDTH = 100,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_HEIGHT = 101,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COMPONENT_COUNT = 102,
@@ -304,6 +305,11 @@ enum class CHARLS_NO_DISCARD jpegls_errc
     /// This error is returned when a callback function returns a non zero value.
     /// </summary>
     callback_failed = impl::CHARLS_JPEGLS_ERRC_CALLBACK_FAILED,
+
+    /// <summary>
+    /// This error is returned when the End of Image (EOI) marker could not be found.
+    /// </summary>
+    end_of_image_marker_not_found = impl::CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND,
 
     /// <summary>
     /// The argument for the width parameter is outside the range [1, 65535].

--- a/src/decoder_strategy.h
+++ b/src/decoder_strategy.h
@@ -67,6 +67,9 @@ public:
 
     void end_scan()
     {
+        if (position_ >= end_position_)
+            impl::throw_jpegls_error(jpegls_errc::source_buffer_too_small);
+
         if (*position_ != jpeg_marker_start_byte)
         {
             read_bit();

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -43,9 +43,6 @@ public:
         return preset_coding_parameters_;
     }
 
-    void read(byte_span destination, size_t stride);
-    void read_header(spiff_header* header = nullptr, bool* spiff_header_found = nullptr);
-
     void output_bgr(const bool value) noexcept
     {
         parameters_.output_bgr = value;
@@ -62,10 +59,14 @@ public:
         comment_handler_user_context_ = user_context;
     }
 
+    void read_header(spiff_header* header = nullptr, bool* spiff_header_found = nullptr);
+    void read(byte_span destination, size_t stride);
+    void read_end_of_image();
+
     void read_start_of_scan();
-    uint8_t read_byte();
 
 private:
+    uint8_t read_byte();
     void skip_byte();
     uint16_t read_uint16();
     uint32_t read_uint24();
@@ -101,7 +102,8 @@ private:
         image_section,
         frame_section,
         scan_section,
-        bit_stream_section
+        bit_stream_section,
+        after_end_of_image
     };
 
     byte_span source_;

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -114,6 +114,9 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
     case jpegls_errc::callback_failed:
         return "Callback function returned a failure";
 
+    case jpegls_errc::end_of_image_marker_not_found:
+        return "Invalid JPEG-LS stream, missing End Of Image (EOI) marker";
+
     case jpegls_errc::invalid_parameter_bits_per_sample:
         return "Invalid JPEG-LS stream, The bit per sample (sample precision) parameter is not in the range [2, 16]";
 

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -792,11 +792,11 @@ public:
         Assert::IsNull(actual.data);
     }
 
-    TEST_METHOD(read_bad_comment) // NOLINT
+    TEST_METHOD(read_comment_from_too_small_buffer_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
-        writer.write_segment(jpeg_marker_code::comment, "", 10);
+        writer.write_segment(jpeg_marker_code::comment, "", 0);
 
         jpeg_stream_reader reader;
         reader.source({writer.buffer.data(), writer.buffer.size() - 1});


### PR DESCRIPTION
Every valid JPEG-LS bit stream has an End-Of-Image (EOI) marker at the end. Add a test to ensure CharLS throw if this marker is missing.

Also prevent that during decoding CharLS doesn't read out of bounds.