### PR TITLE
Add support to set special options for the encoder

### DIFF
--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -277,10 +277,10 @@ public:
     /// <param name="interleave_mode">Configures the interleave mode the encoder should use.</param>
     /// <param name="encoding_options">Configures the special options the encoder should use.</param>
     /// <returns>Container with the JPEG-LS encoded bytes.</returns>
-    template<typename Container, typename ValueType = typename Container::value_type>
-    static auto encode(const Container& source, const charls::frame_info& frame,
-                       const charls::interleave_mode interleave_mode = charls::interleave_mode::none,
-                       const encoding_options encoding_options = charls::encoding_options::none)
+    template<typename Container>
+    static Container encode(const Container& source, const charls::frame_info& frame,
+                            const charls::interleave_mode interleave_mode = charls::interleave_mode::none,
+                            const encoding_options encoding_options = charls::encoding_options::none)
     {
         jpegls_encoder encoder;
         encoder.frame_info(frame).interleave_mode(interleave_mode).encoding_options(encoding_options);
@@ -394,11 +394,14 @@ public:
     /// <param name="destination_container">
     /// The STL like container, that supports the functions data() and size() and the typedef value_type.
     /// </param>
-    template<typename Container, typename ValueType = typename Container::value_type>
-    jpegls_encoder& destination(CHARLS_OUT Container& destination_container)
+    template<typename Container>
+    jpegls_encoder& destination(Container& destination_container)
     {
-        return destination(destination_container.data(), destination_container.size() * sizeof(ValueType));
+        return destination(destination_container.data(), destination_container.size() * sizeof(typename Container::value_type));
     }
+
+    template<typename Container>
+    jpegls_encoder& destination(const Container& destination_container) = delete;
 
     /// <summary>
     /// Writes a standard SPIFF header to the destination. The additional values are computed from the current encoder
@@ -449,7 +452,10 @@ public:
     /// Writes a string as JPEG comment to the JPEG-LS bit stream.
     /// </summary>
     /// <remarks>The null terminator is also written to the output destination, if the string is not empty.</remarks>
-    /// <param name="comment">The text of the comment as null terminated string. Text encoding is application specific.</param>
+    /// <param name="comment">
+    /// The text of the comment as null terminated string.
+    /// Text encoding is application specific and not defined by the JPEG-LS standard.
+    /// </param>
     jpegls_encoder& write_comment(CHARLS_IN_Z const char* comment)
     {
         const size_t size{std::strlen(comment)};
@@ -496,10 +502,10 @@ public:
     /// Stride is sometimes called pitch. If padding bytes are present, the stride is wider than the width of the image.
     /// </param>
     /// <returns>The number of bytes written to the destination.</returns>
-    template<typename Container, typename ValueType = typename Container::value_type>
+    template<typename Container>
     size_t encode(const Container& source_container, const uint32_t stride = 0) const
     {
-        return encode(source_container.data(), source_container.size() * sizeof(ValueType), stride);
+        return encode(source_container.data(), source_container.size() * sizeof(typename Container::value_type), stride);
     }
 
     /// <summary>

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -446,17 +446,18 @@ public:
     }
 
     /// <summary>
-    /// Writes a JPEG comment to the destination.
+    /// Writes a string as JPEG comment to the JPEG-LS bit stream.
     /// </summary>
-    /// <remarks>The null terminator is not written to the output destination.</remarks>
-    /// <param name="comment">The text of the comment as null terminated string. Encoding is application specific.</param>
+    /// <remarks>The null terminator is also written to the output destination, if the string is not empty.</remarks>
+    /// <param name="comment">The text of the comment as null terminated string. Text encoding is application specific.</param>
     jpegls_encoder& write_comment(CHARLS_IN_Z const char* comment)
     {
-        return write_comment(comment, std::strlen(comment));
+        const size_t size{std::strlen(comment)};
+        return write_comment(comment, size == 0 ? 0 : size + 1);
     }
 
     /// <summary>
-    /// Writes a JPEG comment to the destination.
+    /// Writes a JPEG comment to the JPEG-LS bit stream.
     /// </summary>
     /// <param name="comment">The bytes of the comment: application specific.</param>
     /// <param name="size">The size of the comment in bytes.</param>

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -59,6 +59,11 @@ CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLI
 charls_jpegls_encoder_set_near_lossless(CHARLS_IN charls_jpegls_encoder* encoder, int32_t near_lossless) CHARLS_NOEXCEPT
     CHARLS_ATTRIBUTE((nonnull));
 
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_jpegls_encoder_set_encoding_options(CHARLS_IN charls_jpegls_encoder* encoder,
+                                           charls_encoding_options encoding_options) CHARLS_NOEXCEPT
+    CHARLS_ATTRIBUTE((nonnull));
+
 /// <summary>
 /// Configures the interleave mode the encoder should use. The default is none.
 /// The encoder expects the input buffer in the same format as the interleave mode.
@@ -268,15 +273,17 @@ public:
     /// Encoded pixel data in 1 simple operation into a JPEG-LS encoded buffer.
     /// </summary>
     /// <param name="source">Source container with the pixel data bytes that need to be encoded.</param>
-    /// <param name="info">Information about the frame that needs to be encoded.</param>
+    /// <param name="frame">Information about the frame that needs to be encoded.</param>
     /// <param name="interleave_mode">Configures the interleave mode the encoder should use.</param>
+    /// <param name="encoding_options">Configures the special options the encoder should use.</param>
     /// <returns>Container with the JPEG-LS encoded bytes.</returns>
     template<typename Container, typename ValueType = typename Container::value_type>
-    static auto encode(const Container& source, const charls::frame_info& info,
-                       const charls::interleave_mode interleave_mode = charls::interleave_mode::none)
+    static auto encode(const Container& source, const charls::frame_info& frame,
+                       const charls::interleave_mode interleave_mode = charls::interleave_mode::none,
+                       const encoding_options encoding_options = charls::encoding_options::none)
     {
         jpegls_encoder encoder;
-        encoder.frame_info(info).interleave_mode(interleave_mode);
+        encoder.frame_info(frame).interleave_mode(interleave_mode).encoding_options(encoding_options);
 
         Container destination(encoder.estimated_destination_size());
         encoder.destination(destination);
@@ -316,6 +323,12 @@ public:
     jpegls_encoder& interleave_mode(const interleave_mode interleave_mode)
     {
         check_jpegls_errc(charls_jpegls_encoder_set_interleave_mode(encoder_.get(), interleave_mode));
+        return *this;
+    }
+
+    jpegls_encoder& encoding_options(const encoding_options encoding_options)
+    {
+        check_jpegls_errc(charls_jpegls_encoder_set_encoding_options(encoder_.get(), encoding_options));
         return *this;
     }
 

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -485,7 +485,7 @@ enum class encoding_options
     /// The Java Advanced Imaging (JAI) JPEG-LS codec has a defect that causes it to use invalid
     /// preset coding parameters for these types of images.
     /// Most users of this codec are aware of this problem and have implemented a work-around.
-    /// This option is not default enabled for the new API, but is enabled for the legacy API.
+    /// This option is default enabled. Will not be default enabled in the next major version upgrade.
     /// </summary>
     include_pc_parameters_jai = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI
 };

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -65,6 +65,7 @@ enum charls_jpegls_errc
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_SIZE = 110,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COLOR_TRANSFORMATION = 111,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_STRIDE = 112,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_ENCODING_OPTIONS = 113,
     CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_WIDTH = 200,
     CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_HEIGHT = 201,
     CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COMPONENT_COUNT = 202,
@@ -370,6 +371,11 @@ enum class CHARLS_NO_DISCARD jpegls_errc
     /// The stride argument does not match with the frame info and buffer size.
     /// </summary>
     invalid_argument_stride = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_STRIDE,
+
+    /// <summary>
+    /// The encoding options argument has an invalid value.
+    /// </summary>
+    invalid_argument_encoding_options = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_ENCODING_OPTIONS,
 
     /// <summary>
     /// This error is returned when the stream contains a width parameter defined more then once or in an incompatible way.

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -86,7 +86,7 @@ enum charls_encoding_options
     CHARLS_ENCODING_OPTIONS_NONE = 0,
     CHARLS_ENCODING_OPTIONS_EVEN_DESTINATION_SIZE = 1,
     CHARLS_ENCODING_OPTIONS_INCLUDE_VERSION_NUMBER = 2,
-    CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_12_BIT = 4
+    CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI = 4
 };
 
 enum charls_color_transformation
@@ -453,20 +453,41 @@ enum class interleave_mode
 };
 
 /// <summary>
-/// TODO
+/// Defines options that can be enabled during the encoding process.
+/// These options can be combined.
 /// </summary>
 enum class encoding_options
 {
     /// <summary>
-    /// No option defined.
+    /// No special encoding option is defined.
     /// </summary>
     none = impl::CHARLS_ENCODING_OPTIONS_NONE,
 
+    /// <summary>
+    /// Ensures that the generated encoded data has an even size by adding
+    /// an extra 0xFF byte to the End Of Image (EOI) marker.
+    /// DICOM requires that data is always even. This can be done by adding a zero padding byte
+    /// after the encoded data or with this option.
+    /// This option is not default enabled.
+    /// </summary>
     even_destination_size = impl::CHARLS_ENCODING_OPTIONS_EVEN_DESTINATION_SIZE,
 
+    /// <summary>
+    /// Add a comment (COM) segment with the content: "charls [version-number]" to the encoded data.
+    /// Storing the used encoder version can be helpful for long term archival of images.
+    /// This option is not default enabled.
+    /// </summary>
     include_version_number = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_VERSION_NUMBER,
 
-    include_pc_parameters_12_bit = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_12_BIT
+    /// <summary>
+    /// Writes explicitly the default JPEG-LS preset coding parameters when the
+    /// bits per sample is larger then 12 bits.
+    /// The Java Advanced Imaging (JAI) JPEG-LS codec has a defect that causes it to use invalid
+    /// preset coding parameters for these types of images.
+    /// Most users of this codec are aware of this problem and have implemented a work-around.
+    /// This option is not default enabled for the new API, but is enabled for the legacy API.
+    /// </summary>
+    include_pc_parameters_jai = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI
 };
 
 constexpr encoding_options operator|(const encoding_options lhs, const encoding_options rhs) noexcept

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -81,6 +81,14 @@ enum charls_interleave_mode
     CHARLS_INTERLEAVE_MODE_SAMPLE = 2
 };
 
+enum charls_encoding_options
+{
+    CHARLS_ENCODING_OPTIONS_NONE = 0,
+    CHARLS_ENCODING_OPTIONS_EVEN_DESTINATION_SIZE = 1,
+    CHARLS_ENCODING_OPTIONS_INCLUDE_VERSION_NUMBER = 2,
+    CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_12_BIT = 4
+};
+
 enum charls_color_transformation
 {
     CHARLS_COLOR_TRANSFORMATION_NONE = 0,
@@ -297,7 +305,8 @@ enum class CHARLS_NO_DISCARD jpegls_errc
     unexpected_restart_marker = impl::CHARLS_JPEGLS_ERRC_UNEXPECTED_RESTART_MARKER,
 
     /// <summary>
-    /// This error is returned when an expected restart marker is not found. It may indicate data corruption in the JPEG-LS byte stream.
+    /// This error is returned when an expected restart marker is not found. It may indicate data corruption in the JPEG-LS
+    /// byte stream.
     /// </summary>
     restart_marker_not_found = impl::CHARLS_JPEGLS_ERRC_RESTART_MARKER_NOT_FOUND,
 
@@ -442,6 +451,29 @@ enum class interleave_mode
     Line = line,
     Sample = sample
 };
+
+/// <summary>
+/// TODO
+/// </summary>
+enum class encoding_options
+{
+    /// <summary>
+    /// No option defined.
+    /// </summary>
+    none = impl::CHARLS_ENCODING_OPTIONS_NONE,
+
+    even_destination_size = impl::CHARLS_ENCODING_OPTIONS_EVEN_DESTINATION_SIZE,
+
+    include_version_number = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_VERSION_NUMBER,
+
+    include_pc_parameters_12_bit = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_12_BIT
+};
+
+constexpr encoding_options operator|(const encoding_options lhs, const encoding_options rhs) noexcept
+{
+    using T = std::underlying_type_t<encoding_options>;
+    return static_cast<encoding_options>(static_cast<T>(lhs) | static_cast<T>(rhs));
+}
 
 /// <summary>
 /// Defines color space transformations as defined and implemented by the JPEG-LS library of HP Labs.
@@ -755,6 +787,7 @@ struct std::is_error_code_enum<charls::jpegls_errc> final : std::true_type
 
 using charls_jpegls_errc = charls::jpegls_errc;
 using charls_interleave_mode = charls::interleave_mode;
+using charls_encoding_options = charls::encoding_options;
 using charls_color_transformation = charls::color_transformation;
 
 using charls_spiff_profile_id = charls::spiff_profile_id;
@@ -776,6 +809,7 @@ constexpr std::size_t ErrorMessageSize = 256;
 
 typedef enum charls_jpegls_errc charls_jpegls_errc;
 typedef enum charls_interleave_mode charls_interleave_mode;
+typedef enum charls_encoding_options charls_encoding_options;
 typedef enum charls_color_transformation charls_color_transformation;
 
 typedef int32_t charls_spiff_profile_id;
@@ -1050,7 +1084,8 @@ struct JlsParameters
 /// </remarks>
 /// <param name="data">Reference to the data of the COM segment.</param>
 /// <param name="size">Size in bytes of the data of the COM segment.</param>
-/// <param name="user_context">Free to use context information that can be set during the installation of the handler.</param>
+/// <param name="user_context">Free to use context information that can be set during the installation of the
+/// handler.</param>
 using charls_at_comment_handler = int32_t(CHARLS_API_CALLING_CONVENTION*)(const void* data, size_t size, void* user_context);
 
 namespace charls {

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -69,7 +69,7 @@ struct charls_jpegls_encoder final
                                                          encoding_options::include_version_number |
                                                          encoding_options::include_pc_parameters_jai;
         check_argument(encoding_options >= encoding_options::none && encoding_options <= all_options,
-                       jpegls_errc::invalid_argument_near_lossless); // TODO
+                       jpegls_errc::invalid_argument_encoding_options);
 
         encoding_options_ = encoding_options;
     }

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -338,7 +338,7 @@ int jpeg_stream_reader::read_marker_segment(const jpeg_marker_code marker_code, 
     case jpeg_marker_code::application_data8:
         return try_read_application_data8_segment(segment_size, header, spiff_header_found);
 
-    // Other tags not supported (among which DNL DRI)
+    // Other tags not supported (among which DNL)
     default:
         ASSERT(false);
         return 0;

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -26,8 +26,13 @@ void jpeg_stream_writer::write_start_of_image()
 }
 
 
-void jpeg_stream_writer::write_end_of_image()
+void jpeg_stream_writer::write_end_of_image(const bool even_destination_size)
 {
+    if (even_destination_size && bytes_written() % 2 != 0)
+    {
+        write_uint8(jpeg_marker_start_byte);
+    }
+
     write_segment_without_data(jpeg_marker_code::end_of_image);
 }
 

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -77,7 +77,7 @@ public:
     /// <param name="interleave_mode">The interleave mode of the components.</param>
     void write_start_of_scan_segment(int32_t component_count, int32_t near_lossless, interleave_mode interleave_mode);
 
-    void write_end_of_image();
+    void write_end_of_image(bool even_destination_size);
 
     size_t bytes_written() const noexcept
     {

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -72,7 +72,10 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
         return "The argument for the JPEG-LS preset coding parameters is not valid";
 
     case jpegls_errc::invalid_argument_stride:
-        return "The stride argument does not match with the frame info and buffer size.";
+        return "The stride argument does not match with the frame info and buffer size";
+
+    case jpegls_errc::invalid_argument_encoding_options:
+        return "The encoding options argument has an invalid value";
 
     case jpegls_errc::start_of_image_marker_not_found:
         return "Invalid JPEG-LS stream, first JPEG marker is not a Start Of Image (SOI) marker";

--- a/src/util.h
+++ b/src/util.h
@@ -70,6 +70,14 @@
 #define USE_DECL_ANNOTATIONS
 #endif
 
+// Turn A into a string literal without expanding macro definitions
+// (however, if invoked from a macro, macro arguments are expanded).
+#define TO_STRING_NX(A) #A // NOLINT(cppcoreguidelines-macro-usage)
+
+// Turn A into a string literal after macro-expanding it.
+#define TO_STRING(A) TO_STRING_NX(A) // NOLINT(cppcoreguidelines-macro-usage)
+
+
 namespace charls {
 
 inline jpegls_errc to_jpegls_errc() noexcept

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -5,12 +5,6 @@
 
 #include "util.h"
 
-// Turn A into a string literal without expanding macro definitions
-// (however, if invoked from a macro, macro arguments are expanded).
-#define TO_STRING_NX(A) #A // NOLINT(cppcoreguidelines-macro-usage)
-
-// Turn A into a string literal after macro-expanding it.
-#define TO_STRING(A) TO_STRING_NX(A) // NOLINT(cppcoreguidelines-macro-usage)
 
 using namespace charls;
 

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -69,6 +69,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="encoder_strategy_tester.h" />
+    <ClInclude Include="jpegls_preset_coding_parameters_test.h" />
     <ClInclude Include="jpeg_test_stream_writer.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="util.h" />

--- a/unittest/CharLSUnitTest.vcxproj.filters
+++ b/unittest/CharLSUnitTest.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="jpegls_preset_coding_parameters_test.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/unittest/golomb_table_test.cpp
+++ b/unittest/golomb_table_test.cpp
@@ -17,7 +17,7 @@ TEST_CLASS(golomb_table_test)
 public:
     TEST_METHOD(golomb_table_create) // NOLINT
     {
-        constexpr golomb_code_table golomb_table;
+        const golomb_code_table golomb_table;
 
         for (uint32_t i{}; i != 256U; i++)
         {

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -21,7 +21,7 @@ TEST_CLASS(jpeg_stream_writer_test)
 public:
     TEST_METHOD(remaining_destination_will_be_zero_after_create_with_default) // NOLINT
     {
-        constexpr jpeg_stream_writer writer;
+        const jpeg_stream_writer writer;
         Assert::AreEqual(static_cast<size_t>(0), writer.remaining_destination().size);
         Assert::IsNull(writer.remaining_destination().data);
     }

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -1200,6 +1200,13 @@ public:
         Assert::AreEqual(static_cast<size_t>(28), bytes_written);
     }
 
+    TEST_METHOD(set_invalid_encode_options_throws) // NOLINT
+    {
+        jpegls_encoder encoder;
+
+        assert_expect_exception(jpegls_errc::invalid_argument_encoding_options,
+                                [&encoder] { encoder.encoding_options(static_cast<encoding_options>(8)); });
+    }
 
 private:
     static void test_by_decoding(const vector<uint8_t>& encoded_source, const frame_info& source_frame_info,

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -15,8 +15,8 @@
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
 using std::ignore;
-using std::vector;
 using std::numeric_limits;
+using std::vector;
 
 constexpr size_t serialized_spiff_header_size = 34;
 
@@ -47,9 +47,8 @@ public:
     {
         jpegls_encoder encoder;
 
-        encoder.frame_info({1, 1, 2, 1});                      // minimum.
-        encoder.frame_info(
-            {std::numeric_limits<uint16_t>::max(), numeric_limits<uint16_t>::max(), 16, 255}); // maximum.
+        encoder.frame_info({1, 1, 2, 1});                                                                     // minimum.
+        encoder.frame_info({std::numeric_limits<uint16_t>::max(), numeric_limits<uint16_t>::max(), 16, 255}); // maximum.
     }
 
     TEST_METHOD(frame_info_bad_width) // NOLINT
@@ -1086,6 +1085,28 @@ public:
         test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
     }
 
+    TEST_METHOD(encode_black_odd) // NOLINT
+    {
+        constexpr frame_info frame_info{512, 512, 8, 1};
+        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+
+        const auto destination{jpegls_encoder::encode(source, frame_info)};
+
+        Assert::AreEqual(static_cast<size_t>(99), destination.size());
+        test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
+    }
+
+    TEST_METHOD(encode_black_odd_forced_even) // NOLINT
+    {
+        constexpr frame_info frame_info{512, 512, 8, 1};
+        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+
+        const auto destination{
+            jpegls_encoder::encode(source, frame_info, interleave_mode::none, encoding_options::even_destination_size)};
+
+        Assert::AreEqual(static_cast<size_t>(100), destination.size());
+        test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
+    }
 
 private:
     static void test_by_decoding(const vector<uint8_t>& encoded_source, const frame_info& source_frame_info,

--- a/unittest/jpegls_preset_coding_parameters_test.cpp
+++ b/unittest/jpegls_preset_coding_parameters_test.cpp
@@ -3,66 +3,15 @@
 
 #include "pch.h"
 
+#include "jpegls_preset_coding_parameters_test.h"
+
 #include "../src/jpegls_preset_coding_parameters.h"
+
+#include <limits>
+
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 
-namespace {
-
-struct thresholds final
-{
-    int32_t MaxVal;
-    int32_t T1;
-    int32_t T2;
-    int32_t T3;
-    int32_t Reset;
-};
-
-// Threshold function of JPEG-LS reference implementation.
-constexpr thresholds compute_defaults_using_reference_implementation(const int32_t max_value, const uint16_t near) noexcept
-{
-    thresholds result{max_value, 0, 0, 0, 64};
-
-    if (result.MaxVal >= 128)
-    {
-        int32_t factor{result.MaxVal};
-        if (factor > 4095)
-            factor = 4095;
-        factor = (factor + 128) >> 8;
-        result.T1 = factor * (3 - 2) + 2 + 3 * near;
-        if (result.T1 > result.MaxVal || result.T1 < near + 1)
-            result.T1 = near + 1;
-        result.T2 = factor * (7 - 3) + 3 + 5 * near;
-        if (result.T2 > result.MaxVal || result.T2 < result.T1)
-            result.T2 = result.T1;
-        result.T3 = factor * (21 - 4) + 4 + 7 * near;
-        if (result.T3 > result.MaxVal || result.T3 < result.T2)
-            result.T3 = result.T2;
-    }
-    else
-    {
-        const int32_t factor{256 / (result.MaxVal + 1)};
-        result.T1 = 3 / factor + 3 * near;
-        if (result.T1 < 2)
-            result.T1 = 2;
-        if (result.T1 > result.MaxVal || result.T1 < near + 1)
-            result.T1 = near + 1;
-        result.T2 = 7 / factor + 5 * near;
-        if (result.T2 < 3)
-            result.T2 = 3;
-        if (result.T2 > result.MaxVal || result.T2 < result.T1)
-            result.T2 = result.T1;
-        result.T3 = 21 / factor + 7 * near;
-        if (result.T3 < 4)
-            result.T3 = 4;
-        if (result.T3 > result.MaxVal || result.T3 < result.T2)
-            result.T3 = result.T2;
-    }
-
-    return result;
-}
-
-} // namespace
 
 namespace charls { namespace test {
 
@@ -82,14 +31,14 @@ public:
 
     TEST_METHOD(max_value_lossless) // NOLINT
     {
-        constexpr auto expected{compute_defaults_using_reference_implementation(65535, 0)};
+        constexpr auto expected{compute_defaults_using_reference_implementation(std::numeric_limits<uint16_t>::max(), 0)};
         const auto parameters{compute_default(65535, 0)};
 
-        Assert::AreEqual(expected.MaxVal, parameters.maximum_sample_value);
-        Assert::AreEqual(expected.T1, parameters.threshold1);
-        Assert::AreEqual(expected.T2, parameters.threshold2);
-        Assert::AreEqual(expected.T3, parameters.threshold3);
-        Assert::AreEqual(expected.Reset, parameters.reset_value);
+        Assert::AreEqual(expected.max_value, parameters.maximum_sample_value);
+        Assert::AreEqual(expected.t1, parameters.threshold1);
+        Assert::AreEqual(expected.t2, parameters.threshold2);
+        Assert::AreEqual(expected.t3, parameters.threshold3);
+        Assert::AreEqual(expected.reset, parameters.reset_value);
     }
 
     TEST_METHOD(min_value_lossless) // NOLINT
@@ -97,11 +46,11 @@ public:
         constexpr auto expected{compute_defaults_using_reference_implementation(3, 0)};
         const auto parameters{compute_default(3, 0)};
 
-        Assert::AreEqual(expected.MaxVal, parameters.maximum_sample_value);
-        Assert::AreEqual(expected.T1, parameters.threshold1);
-        Assert::AreEqual(expected.T2, parameters.threshold2);
-        Assert::AreEqual(expected.T3, parameters.threshold3);
-        Assert::AreEqual(expected.Reset, parameters.reset_value);
+        Assert::AreEqual(expected.max_value, parameters.maximum_sample_value);
+        Assert::AreEqual(expected.t1, parameters.threshold1);
+        Assert::AreEqual(expected.t2, parameters.threshold2);
+        Assert::AreEqual(expected.t3, parameters.threshold3);
+        Assert::AreEqual(expected.reset, parameters.reset_value);
     }
 
     TEST_METHOD(min_high_value_lossless) // NOLINT
@@ -109,11 +58,11 @@ public:
         constexpr auto expected{compute_defaults_using_reference_implementation(128, 0)};
         const auto parameters{compute_default(128, 0)};
 
-        Assert::AreEqual(expected.MaxVal, parameters.maximum_sample_value);
-        Assert::AreEqual(expected.T1, parameters.threshold1);
-        Assert::AreEqual(expected.T2, parameters.threshold2);
-        Assert::AreEqual(expected.T3, parameters.threshold3);
-        Assert::AreEqual(expected.Reset, parameters.reset_value);
+        Assert::AreEqual(expected.max_value, parameters.maximum_sample_value);
+        Assert::AreEqual(expected.t1, parameters.threshold1);
+        Assert::AreEqual(expected.t2, parameters.threshold2);
+        Assert::AreEqual(expected.t3, parameters.threshold3);
+        Assert::AreEqual(expected.reset, parameters.reset_value);
     }
 
     TEST_METHOD(max_low_value_lossless) // NOLINT
@@ -121,23 +70,23 @@ public:
         constexpr auto expected{compute_defaults_using_reference_implementation(127, 0)};
         const auto parameters{compute_default(127, 0)};
 
-        Assert::AreEqual(expected.MaxVal, parameters.maximum_sample_value);
-        Assert::AreEqual(expected.T1, parameters.threshold1);
-        Assert::AreEqual(expected.T2, parameters.threshold2);
-        Assert::AreEqual(expected.T3, parameters.threshold3);
-        Assert::AreEqual(expected.Reset, parameters.reset_value);
+        Assert::AreEqual(expected.max_value, parameters.maximum_sample_value);
+        Assert::AreEqual(expected.t1, parameters.threshold1);
+        Assert::AreEqual(expected.t2, parameters.threshold2);
+        Assert::AreEqual(expected.t3, parameters.threshold3);
+        Assert::AreEqual(expected.reset, parameters.reset_value);
     }
 
     TEST_METHOD(max_value_max_lossy) // NOLINT
     {
-        constexpr auto expected{compute_defaults_using_reference_implementation(65535, 255)};
+        constexpr auto expected{compute_defaults_using_reference_implementation(std::numeric_limits<uint16_t>::max(), 255)};
         const auto parameters{compute_default(65535, 255)};
 
-        Assert::AreEqual(expected.MaxVal, parameters.maximum_sample_value);
-        Assert::AreEqual(expected.T1, parameters.threshold1);
-        Assert::AreEqual(expected.T2, parameters.threshold2);
-        Assert::AreEqual(expected.T3, parameters.threshold3);
-        Assert::AreEqual(expected.Reset, parameters.reset_value);
+        Assert::AreEqual(expected.max_value, parameters.maximum_sample_value);
+        Assert::AreEqual(expected.t1, parameters.threshold1);
+        Assert::AreEqual(expected.t2, parameters.threshold2);
+        Assert::AreEqual(expected.t3, parameters.threshold3);
+        Assert::AreEqual(expected.reset, parameters.reset_value);
     }
 
     TEST_METHOD(min_value_max_lossy) // NOLINT
@@ -145,11 +94,11 @@ public:
         constexpr auto expected{compute_defaults_using_reference_implementation(3, 1)};
         const auto parameters{compute_default(3, 1)};
 
-        Assert::AreEqual(expected.MaxVal, parameters.maximum_sample_value);
-        Assert::AreEqual(expected.T1, parameters.threshold1);
-        Assert::AreEqual(expected.T2, parameters.threshold2);
-        Assert::AreEqual(expected.T3, parameters.threshold3);
-        Assert::AreEqual(expected.Reset, parameters.reset_value);
+        Assert::AreEqual(expected.max_value, parameters.maximum_sample_value);
+        Assert::AreEqual(expected.t1, parameters.threshold1);
+        Assert::AreEqual(expected.t2, parameters.threshold2);
+        Assert::AreEqual(expected.t3, parameters.threshold3);
+        Assert::AreEqual(expected.reset, parameters.reset_value);
     }
 
     TEST_METHOD(is_valid_default) // NOLINT

--- a/unittest/jpegls_preset_coding_parameters_test.h
+++ b/unittest/jpegls_preset_coding_parameters_test.h
@@ -1,0 +1,63 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstdint>
+
+namespace charls { namespace test {
+
+struct thresholds final
+{
+    int32_t max_value;
+    int32_t t1;
+    int32_t t2;
+    int32_t t3;
+    int32_t reset;
+};
+
+// Threshold function of JPEG-LS reference implementation.
+constexpr thresholds compute_defaults_using_reference_implementation(const int32_t max_value, const uint16_t near) noexcept
+{
+    thresholds result{max_value, 0, 0, 0, 64};
+
+    if (result.max_value >= 128)
+    {
+        int32_t factor{result.max_value};
+        if (factor > 4095)
+            factor = 4095;
+        factor = (factor + 128) >> 8;
+        result.t1 = factor * (3 - 2) + 2 + 3 * near;
+        if (result.t1 > result.max_value || result.t1 < near + 1)
+            result.t1 = near + 1;
+        result.t2 = factor * (7 - 3) + 3 + 5 * near;
+        if (result.t2 > result.max_value || result.t2 < result.t1)
+            result.t2 = result.t1;
+        result.t3 = factor * (21 - 4) + 4 + 7 * near;
+        if (result.t3 > result.max_value || result.t3 < result.t2)
+            result.t3 = result.t2;
+    }
+    else
+    {
+        const int32_t factor{256 / (result.max_value + 1)};
+        result.t1 = 3 / factor + 3 * near;
+        if (result.t1 < 2)
+            result.t1 = 2;
+        if (result.t1 > result.max_value || result.t1 < near + 1)
+            result.t1 = near + 1;
+        result.t2 = 7 / factor + 5 * near;
+        if (result.t2 < 3)
+            result.t2 = 3;
+        if (result.t2 > result.max_value || result.t2 < result.t1)
+            result.t2 = result.t1;
+        result.t3 = 21 / factor + 7 * near;
+        if (result.t3 < 4)
+            result.t3 = 4;
+        if (result.t3 > result.max_value || result.t3 < result.t2)
+            result.t3 = result.t2;
+    }
+
+    return result;
+}
+
+}} // namespace charls::test


### PR DESCRIPTION
Extend the functionality of the encoder with 3 boolean options:

1) An option to ensure that the generated output is always even: copy output into DICOM file scenario.
2) An option to write the version number as COM segment: allows tracking which encoder version was used.
3) An option to write always the pc_parameters for bit per sample > 12: needed for Java JAI JPEG-LS decoder
 (this option is on by default for 2.x).