### PR TITLE
Update warnings used by Clang and MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Configure the supported C++ compilers: gcc, clang and MSVC
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(PEDANTIC_CXX_COMPILE_FLAGS
-    -pedantic-errors
     -Wall
     -Wextra
     -pedantic
+    -pedantic-errors
     -Wold-style-cast
     -Wfloat-equal
     -Wlogical-op
@@ -86,8 +86,30 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(PEDANTIC_CXX_COMPILE_FLAGS
-      -Weverything
+      -Wall
+      -Wextra # (-W is synonym)
+      -Wnon-gcc
       -Wpedantic
+      -Walloca
+      -Wcast-qual
+      -Wformat=2
+      -Wvla
+      -Warray-bounds-pointer-arithmetic
+      -Wassign-enum
+      -Wbad-function-cast
+      -Wconditional-uninitialized
+      -Widiomatic-parentheses
+      -Wimplicit-fallthrough
+      -Wloop-analysis
+      -Wpointer-arith
+      -Wshift-sign-overflow
+      -Wtautological-constant-in-range-compare
+      -Wunreachable-code-aggressive
+      -Wthread-safety
+      -Wthread-safety-beta
+      -Wcomma
+      # -Weverything provides the option to discover usefull Clang warnings.
+      # The list below ignores not useful Weverything warnings.
       -Wno-weak-vtables                       # Ignore, linker will remove the couple of extra vtables.
       -Wno-padded                             # Ignore, padding optimization is not needed.
       -Wno-c++98-compat                       # Ignore, CharLS 2.x targets C++14, ignore C++98 compatibility.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,12 +22,17 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- To ensure high quality C++ code use Warning level All and treat warnings as errors to ensure warnings are fixed promptly. -->
-      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <!-- To ensure high quality C++ code use Warning level 4 and treat warnings as errors to ensure warnings are fixed promptly. -->
+      <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <UseFullPaths>true</UseFullPaths>
 
       <!-- Explicit set the 'external' warning level to W3 (Supported since Visual Studio 2019 16.10) -->
       <ExternalWarningLevel>Level3</ExternalWarningLevel>
+
+      <!-- For development purposes, All warnings can be used to discover useful compiler warnings.
+           This requires also that some warnings need to be disabled from this all warning list. -->
+      <WarningLevel Condition="'$(CHARLS_ALL_WARNINGS)'!=''">EnableAllWarnings</WarningLevel>
 
       <!--
         Disable level All warnings that are not useful:
@@ -48,7 +53,7 @@
         C5027 = 'type': move assignment operator was implicitly defined as deleted [Just informational]
         C5045 = Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified [Just informational]
       -->
-      <DisableSpecificWarnings>4061;4365;4464;4514;4571;4623;4625;4626;4668;4710;4711;4738;4820;5026;5027;5045</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(CHARLS_ALL_WARNINGS)'!=''">4061;4365;4464;4514;4571;4623;4625;4626;4668;4710;4711;4738;4820;5026;5027;5045</DisableSpecificWarnings>
 
       <!--
         __cplusplus = Use the correct value for the __cplusplus macro

--- a/doc/style_and_design.md
+++ b/doc/style_and_design.md
@@ -151,11 +151,6 @@ The following features are available in C++20 (usable after 2023), or in dual la
 * \<span>
 * modules
 
-### Supported C# language
-
-CharLS currently targets C# 7.3 on the main branch. This will be done until C# 8.0 becomes available.
-Client code in C# 7.3 calling the CharLS assembly will be supported up to 3 years after the release of C# 8.0.
-
 ### Portable Anymap Format
 
 The de facto standard used by the JPEG standard to deliver test files is the Portable Anymap Format.
@@ -174,3 +169,38 @@ One of the missing features of C++ is a standard Package Manager. The following 
 * Cross-platform unit test library (for example Catch2)
 * Library to read Anymap files (for example Netpbm)
 * Library to parse command line parameters (for example Clara, CLI11)
+
+### Supported C++ Compilers
+
+#### Clang
+
+Recommended warnings:
+
+* -Wall (warning collection switch)
+* -Wextra (warning collection switch)
+* -Wnon-gcc (warning collection switch)
+* -Walloca (not included in Wall or Wextra)
+* -Wcast-qual (not included in Wall or Wextra)
+* -Wformat=2 (not included in Wall or Wextra)
+* -Wformat-security (enabled by -Wformat=2)
+* -Wnull-dereference (enabled by default)
+* -Wstack-protector (enabled by default)
+* -Wvla (not included in Wall or Wextra)
+* -Warray-bounds (enabled by default)
+* -Warray-bounds-pointer-arithmetic (not included in Wall or Wextra)
+* -Wassign-enum (not included in Wall or Wextra)
+* -Wbad-function-cast (not included in Wall or Wextra)
+* -Wconditional-uninitialized (not included in Wall or Wextra)
+* -Wconversion (enabled by Wnon-gcc)
+* -Widiomatic-parentheses (not included in Wall or Wextra)
+* -Wimplicit-fallthrough (not included in Wall or Wextra)
+* -Wloop-analysis (not included in Wall or Wextra)
+* -Wpointer-arith (not included in Wall or Wextra)
+* -Wshift-sign-overflow (not included in Wall or Wextra)
+* -Wshorten-64-to-32 (enabled by Wnon-gcc)
+* -Wswitch-enum (not included in Wall or Wextra)
+* -Wtautological-constant-in-range-compare (not included in Wall or Wextra)
+* -Wunreachable-code-aggressive (not included in Wall or Wextra)
+* -Wthread-safety (not included in Wall or Wextra)
+* -Wthread-safety-beta (not included in Wall or Wextra)
+* -Wcomma (not included in Wall or Wextra)

--- a/fuzztest/main.cpp
+++ b/fuzztest/main.cpp
@@ -4,13 +4,10 @@
 #include <charls/charls.h>
 
 #ifdef _MSC_VER
-
 #include <io.h>
-
 #else
 #include <unistd.h>
 
-#define _write write
 #define _read read
 #define _open open
 
@@ -62,8 +59,11 @@ int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-
             {
                 // Write some small-ish JPEG-LS file to stdout
                 const auto encoded_data{generate_once()};
-                const int result{
-                    static_cast<int>(_write(1, encoded_data.data(), static_cast<unsigned int>(encoded_data.size())))};
+#ifdef _MSC_VER
+                const int result{_write(1, encoded_data.data(), static_cast<unsigned int>(encoded_data.size()))};
+#else
+                const ssize_t result{write(1, encoded_data.data(), static_cast<unsigned int>(encoded_data.size()))};
+#endif
                 return result != -1 && result == static_cast<int>(encoded_data.size()) ? EXIT_SUCCESS : EXIT_FAILURE;
             }
             catch (const std::exception& error)


### PR DESCRIPTION
Reserve the usage of Weverything and EnableAllWarnings for interactive development.