### PR TITLE
Improve API docs and decode perf measurement

### DIFF
--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -59,6 +59,12 @@ CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLI
 charls_jpegls_encoder_set_near_lossless(CHARLS_IN charls_jpegls_encoder* encoder, int32_t near_lossless) CHARLS_NOEXCEPT
     CHARLS_ATTRIBUTE((nonnull));
 
+/// <summary>
+/// Configures the encoding options the encoder should use. Default is charls_encoding_options::include_pc_parameters_jai
+/// </summary>
+/// <param name="encoder">Reference to the encoder instance.</param>
+/// <param name="encoding_options">Options to use.</param>
+/// <returns>The result of the operation: success or a failure code.</returns>
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
 charls_jpegls_encoder_set_encoding_options(CHARLS_IN charls_jpegls_encoder* encoder,
                                            charls_encoding_options encoding_options) CHARLS_NOEXCEPT
@@ -276,6 +282,8 @@ public:
     /// <param name="frame">Information about the frame that needs to be encoded.</param>
     /// <param name="interleave_mode">Configures the interleave mode the encoder should use.</param>
     /// <param name="encoding_options">Configures the special options the encoder should use.</param>
+    /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
+    /// <exception cref="std::bad_alloc">Thrown when memory for the encoder could not be allocated.</exception>
     /// <returns>Container with the JPEG-LS encoded bytes.</returns>
     template<typename Container>
     static Container encode(const Container& source, const charls::frame_info& frame,
@@ -299,6 +307,7 @@ public:
     /// This information will be written to the Start of Frame (SOF) segment during the encode phase.
     /// </summary>
     /// <param name="frame_info">Information about the frame that needs to be encoded.</param>
+    /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& frame_info(const frame_info& frame_info)
     {
         check_jpegls_errc(charls_jpegls_encoder_set_frame_info(encoder_.get(), &frame_info));
@@ -309,6 +318,7 @@ public:
     /// Configures the NEAR parameter the encoder should use. A value of 0 means lossless, this is also the default.
     /// </summary>
     /// <param name="near_lossless">Value of the NEAR parameter.</param>
+    /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& near_lossless(const int32_t near_lossless)
     {
         check_jpegls_errc(charls_jpegls_encoder_set_near_lossless(encoder_.get(), near_lossless));
@@ -320,12 +330,18 @@ public:
     /// The encoder expects the input buffer in the same format as the interleave mode.
     /// </summary>
     /// <param name="interleave_mode">Value of the interleave mode.</param>
+    /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& interleave_mode(const interleave_mode interleave_mode)
     {
         check_jpegls_errc(charls_jpegls_encoder_set_interleave_mode(encoder_.get(), interleave_mode));
         return *this;
     }
 
+    /// <summary>
+    /// Configures the encoding options the encoder should use. Default is charls_encoding_options::include_pc_parameters_jai
+    /// </summary>
+    /// <param name="encoding_options">Options to use. Options can be combined.</param>
+    /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& encoding_options(const encoding_options encoding_options)
     {
         check_jpegls_errc(charls_jpegls_encoder_set_encoding_options(encoder_.get(), encoding_options));
@@ -397,7 +413,8 @@ public:
     template<typename Container>
     jpegls_encoder& destination(Container& destination_container)
     {
-        return destination(destination_container.data(), destination_container.size() * sizeof(typename Container::value_type));
+        return destination(destination_container.data(),
+                           destination_container.size() * sizeof(typename Container::value_type));
     }
 
     template<typename Container>

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -119,15 +119,20 @@ void decode_performance_tests(const int loop_count)
 {
     cout << "Test decode performance with loop count " << loop_count << "\n";
 
-    const vector<uint8_t> jpegls_compressed{read_file("decodetest.jls")};
+    const vector<uint8_t> encoded_source{read_file("decodetest.jls")};
 
     try
     {
+        // Pre-allocate the destination outside the measurement loop.
+        // std::vector initializes its elements and this step needs to be excluded from the measurement.
+        vector<uint8_t> destination(jpegls_decoder{encoded_source, true}.destination_size());
+
         const auto start{steady_clock::now()};
         for (int i{}; i != loop_count; ++i)
         {
-            vector<uint8_t> uncompressed;
-            jpegls_decoder::decode(jpegls_compressed, uncompressed);
+            const jpegls_decoder decoder{encoded_source, true};
+
+            decoder.decode(destination);
         }
 
         const auto end{steady_clock::now()};

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -54,6 +54,9 @@ public:
         constexpr array<uint8_t, 10> buffer{};
         decoder3.source(buffer.data(), buffer.size());
         decoder3 = std::move(decoder2);
+
+        jpegls_decoder decoder4(buffer.data(), buffer.size(), false);
+        Assert::AreEqual(decoder4.frame_info().bits_per_sample, 0);
     }
 
     TEST_METHOD(set_source_twice_throws) // NOLINT


### PR DESCRIPTION
- Add missing API docs
- std::vector perform an initialization when its size is resized. This has a significant impact
on the performance measurements. Ensure that this step is done outside the timed loop.