### PR TITLE
Ensure CHARLS_CHECK_RETURN is the first statement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     -Wuseless-cast
     -Wvector-operation-performance
     -Wsized-deallocation
+    -Wattributes
   )
   if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
       set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}

--- a/src/util.h
+++ b/src/util.h
@@ -275,7 +275,7 @@ CHARLS_CHECK_RETURN T byte_swap(T /*value*/) noexcept
 }
 
 template<>
-inline CHARLS_CHECK_RETURN uint16_t byte_swap<uint16_t>(const uint16_t value) noexcept
+CHARLS_CHECK_RETURN inline uint16_t byte_swap<uint16_t>(const uint16_t value) noexcept
 {
 #ifdef _MSC_VER
     return _byteswap_ushort(value);
@@ -286,7 +286,7 @@ inline CHARLS_CHECK_RETURN uint16_t byte_swap<uint16_t>(const uint16_t value) no
 }
 
 template<>
-inline CHARLS_CHECK_RETURN uint32_t byte_swap<uint32_t>(const uint32_t value) noexcept
+CHARLS_CHECK_RETURN inline uint32_t byte_swap<uint32_t>(const uint32_t value) noexcept
 {
 #ifdef _MSC_VER
     return _byteswap_ulong(value);
@@ -297,7 +297,7 @@ inline CHARLS_CHECK_RETURN uint32_t byte_swap<uint32_t>(const uint32_t value) no
 }
 
 template<>
-inline CHARLS_CHECK_RETURN uint64_t byte_swap(const uint64_t value) noexcept
+CHARLS_CHECK_RETURN inline uint64_t byte_swap(const uint64_t value) noexcept
 {
 #ifdef _MSC_VER
     return _byteswap_uint64(value);


### PR DESCRIPTION
When CHARLS_CHECK_RETURN is expanded to [[noignore]] is needs to before inline