### PR TITLE
Add support to encode\decode oversized images

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following JPEG-LS options are not supported by the CharLS implementation. Mo
 * No support for multi component frames with mixed component counts in a single scan.
   While technical possible all known JPEG-LS codecs put multi-component (color) images in a single scan
   or in multiple scans, but not use a mix of these in one file.
-* No support for oversize image dimension. Maximum supported image dimensions are [1, 65535] by [1, 65535].
+* No support to encode\decode images with the height defined after the first scan (DNL marker).
 * No support for JPEG-LS mapping tables.
 * No support for point transform.
   Point transform is a lossly encoding mechanism and not used in lossless scenarios.

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -72,7 +72,7 @@ enum charls_jpegls_errc
     CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_BITS_PER_SAMPLE = 203,
     CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_INTERLEAVE_MODE = 204,
     CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_NEAR_LOSSLESS = 205,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PC_PARAMETERS = 206
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PRESET_PARAMETERS = 206
 };
 
 enum charls_interleave_mode
@@ -410,9 +410,9 @@ enum class CHARLS_NO_DISCARD jpegls_errc
     invalid_parameter_near_lossless = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_NEAR_LOSSLESS,
 
     /// <summary>
-    /// This error is returned when the stream contains an invalid JPEG-LS preset coding parameters segment.
+    /// This error is returned when the stream contains an invalid JPEG-LS preset parameters segment.
     /// </summary>
-    invalid_parameter_jpegls_pc_parameters = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PC_PARAMETERS,
+    invalid_parameter_jpegls_preset_parameters = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PRESET_PARAMETERS,
 
     // Legacy enumerator names, will be removed in next major release. Not tagged with [[deprecated]] as that is a C++17
     // extension.

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -37,8 +37,8 @@ struct charls_jpegls_encoder final
 
     void frame_info(const charls_frame_info& frame_info)
     {
-        check_argument(frame_info.width > 0 && frame_info.width <= maximum_width, jpegls_errc::invalid_argument_width);
-        check_argument(frame_info.height > 0 && frame_info.height <= maximum_height, jpegls_errc::invalid_argument_height);
+        check_argument(frame_info.width > 0, jpegls_errc::invalid_argument_width);
+        check_argument(frame_info.height > 0, jpegls_errc::invalid_argument_height);
         check_argument(frame_info.bits_per_sample >= minimum_bits_per_sample &&
                            frame_info.bits_per_sample <= maximum_bits_per_sample,
                        jpegls_errc::invalid_argument_bits_per_sample);
@@ -160,7 +160,11 @@ struct charls_jpegls_encoder final
 
         transition_to_tables_and_miscellaneous_state();
 
-        writer_.write_start_of_frame_segment(frame_info_);
+        const bool oversized_image{writer_.write_start_of_frame_segment(frame_info_)};
+        if (oversized_image)
+        {
+            writer_.write_jpegls_preset_parameters_segment(frame_info_.height, frame_info_.width);
+        }
 
         if (color_transformation_ != charls::color_transformation::none)
         {

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,8 +18,6 @@ constexpr int default_threshold3{21}; // BASIC_T3
 
 constexpr int default_reset_value{64}; // Default RESET value as defined in ISO/IEC 14495-1, table C.2
 
-constexpr int maximum_width{65535};
-constexpr int maximum_height{65535};
 constexpr int maximum_component_count{255};
 constexpr int minimum_bits_per_sample{2};
 constexpr int maximum_bits_per_sample{16};

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -262,7 +262,7 @@ USE_DECL_ANNOTATIONS jpegls_pc_parameters jpeg_stream_reader::get_validated_pres
 
     if (UNLIKELY(!is_valid(preset_coding_parameters_, calculate_maximum_sample_value(frame_info_.bits_per_sample),
                            parameters_.near_lossless, &preset_coding_parameters)))
-        throw_jpegls_error(jpegls_errc::invalid_parameter_jpegls_pc_parameters);
+        throw_jpegls_error(jpegls_errc::invalid_parameter_jpegls_preset_parameters);
 
     return preset_coding_parameters;
 }
@@ -467,7 +467,7 @@ void jpeg_stream_reader::oversize_image_dimension()
         break;
 
     default:
-        throw_jpegls_error(jpegls_errc::invalid_marker_segment_size); // TODO: custom error code?
+        throw_jpegls_error(jpegls_errc::invalid_parameter_jpegls_preset_parameters);
     }
 
     frame_info_height(height);

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -101,6 +101,8 @@ private:
     void read_comment();
     void read_application_data() noexcept;
     void read_preset_parameters_segment();
+    void read_preset_coding_parameters();
+    void oversize_image_dimension();
     void read_define_restart_interval();
     void try_read_application_data8_segment(spiff_header* header, bool* spiff_header_found);
     void try_read_spiff_header_segment(CHARLS_OUT spiff_header& header, CHARLS_OUT bool& spiff_header_found);
@@ -110,6 +112,9 @@ private:
     void check_interleave_mode(interleave_mode mode) const;
     CHARLS_CHECK_RETURN uint32_t maximum_sample_value() const noexcept;
     void skip_remaining_segment_data() noexcept;
+    void check_frame_info() const;
+    void frame_info_height(uint32_t height);
+    void frame_info_width(uint32_t width);
 
     enum class state
     {

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -149,11 +149,12 @@ void jpeg_stream_writer::write_jpegls_preset_parameters_segment(const jpegls_pc_
 
 void jpeg_stream_writer::write_jpegls_preset_parameters_segment(const uint32_t height, const uint32_t width)
 {
+    // Format is defined in ISO/IEC 14495-1, C.2.4.1.4
     write_segment_header(jpeg_marker_code::jpegls_preset_parameters, sizeof(uint32_t) * 2 + 1 + 1);
     write_uint8(to_underlying_type(jpegls_preset_parameters_type::oversize_image_dimension));
-    write_uint8(sizeof(uint32_t));
-    write_uint32(height); // Ye: : number of columns in the image.
-    write_uint32(width); // Xe: number of columns in the image.
+    write_uint8(sizeof(uint32_t)); // Wxy: number of bytes used to represent Ye and Xe [2..4]. Always 4 for simplicity.
+    write_uint32(height);          // Ye: number of lines in the image.
+    write_uint32(width);           // Xe: number of columns in the image.
 }
 
 

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -85,10 +85,10 @@ void jpeg_stream_writer::write_spiff_end_of_directory_entry()
 }
 
 
-void jpeg_stream_writer::write_start_of_frame_segment(const frame_info& frame)
+bool jpeg_stream_writer::write_start_of_frame_segment(const frame_info& frame)
 {
-    ASSERT(frame.width <= numeric_limits<uint16_t>::max());
-    ASSERT(frame.height <= numeric_limits<uint16_t>::max());
+    ASSERT(frame.width > 0);
+    ASSERT(frame.height > 0);
     ASSERT(frame.bits_per_sample >= minimum_bits_per_sample && frame.bits_per_sample <= maximum_bits_per_sample);
     ASSERT(frame.component_count > 0 && frame.component_count <= numeric_limits<uint8_t>::max());
 
@@ -96,8 +96,11 @@ void jpeg_stream_writer::write_start_of_frame_segment(const frame_info& frame)
     const size_t data_size{6 + (static_cast<size_t>(frame.component_count) * 3)};
     write_segment_header(jpeg_marker_code::start_of_frame_jpegls, data_size);
     write_uint8(frame.bits_per_sample); // P = Sample precision
-    write_uint16(frame.height);         // Y = Number of lines
-    write_uint16(frame.width);          // X = Number of samples per line
+
+    const bool oversized_image{frame.width > numeric_limits<uint16_t>::max() ||
+                               frame.height > numeric_limits<uint16_t>::max()};
+    write_uint16(oversized_image ? 0 : frame.height); // Y = Number of lines
+    write_uint16(oversized_image ? 0 : frame.width);  // X = Number of samples per line
 
     // Components
     write_uint8(frame.component_count); // Nf = Number of image components in frame
@@ -111,6 +114,8 @@ void jpeg_stream_writer::write_start_of_frame_segment(const frame_info& frame)
         write_uint8(0x11);         // Hi + Vi = Horizontal sampling factor + Vertical sampling factor
         write_uint8(0); // Tqi = Quantization table destination selector (reserved for JPEG-LS, should be set to 0)
     }
+
+    return oversized_image;
 }
 
 
@@ -139,6 +144,16 @@ void jpeg_stream_writer::write_jpegls_preset_parameters_segment(const jpegls_pc_
     write_uint16(preset_coding_parameters.threshold2);
     write_uint16(preset_coding_parameters.threshold3);
     write_uint16(preset_coding_parameters.reset_value);
+}
+
+
+void jpeg_stream_writer::write_jpegls_preset_parameters_segment(const uint32_t height, const uint32_t width)
+{
+    write_segment_header(jpeg_marker_code::jpegls_preset_parameters, sizeof(uint32_t) * 2 + 1 + 1);
+    write_uint8(to_underlying_type(jpegls_preset_parameters_type::oversize_image_dimension));
+    write_uint8(sizeof(uint32_t));
+    write_uint32(height); // Ye: : number of columns in the image.
+    write_uint32(width); // Xe: number of columns in the image.
 }
 
 

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -62,10 +62,17 @@ public:
     void write_jpegls_preset_parameters_segment(const jpegls_pc_parameters& preset_coding_parameters);
 
     /// <summary>
+    /// Writes a JPEG-LS preset parameters (LSE) segment for oversize image dimension.
+    /// </summary>
+    /// <param name="width">Height of the image.</param>
+    /// <param name="height">Width of the image.</param>
+    void write_jpegls_preset_parameters_segment(uint32_t height, uint32_t width);
+
+    /// <summary>
     /// Writes a JPEG-LS Start Of Frame (SOF-55) segment.
     /// </summary>
     /// <param name="frame">Properties of the frame.</param>
-    void write_start_of_frame_segment(const frame_info& frame);
+    bool write_start_of_frame_segment(const frame_info& frame);
 
     /// <summary>
     /// Writes a JPEG-LS Start Of Scan (SOS) segment.
@@ -118,6 +125,12 @@ private:
     void write_uint8(const int32_t value) noexcept
     {
         ASSERT(value >= 0 && value <= std::numeric_limits<uint8_t>::max());
+        write_uint8(static_cast<uint8_t>(value));
+    }
+
+    void write_uint8(const size_t value) noexcept
+    {
+        ASSERT(value <= std::numeric_limits<uint8_t>::max());
         write_uint8(static_cast<uint8_t>(value));
     }
 

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -177,8 +177,8 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
     case jpegls_errc::invalid_parameter_near_lossless:
         return "Invalid JPEG-LS stream, near-lossless is outside the range [0, min(255, MAXVAL/2)]";
 
-    case jpegls_errc::invalid_parameter_jpegls_pc_parameters:
-        return "Invalid JPEG-LS stream, JPEG-LS preset coding parameters segment contains invalid values";
+    case jpegls_errc::invalid_parameter_jpegls_preset_parameters:
+        return "Invalid JPEG-LS stream, JPEG-LS preset parameters segment contains invalid values";
     }
 
     return "Unknown";

--- a/src/jpegls_preset_parameters_type.h
+++ b/src/jpegls_preset_parameters_type.h
@@ -9,21 +9,67 @@ namespace charls {
 
 enum class jpegls_preset_parameters_type : uint8_t
 {
-    preset_coding_parameters = 0x1,    // JPEG-LS Baseline (ISO/IEC 14495-1): Preset coding parameters.
-    mapping_table_specification = 0x2, // JPEG-LS Baseline (ISO/IEC 14495-1): Mapping table specification.
-    mapping_table_continuation = 0x3,  // JPEG-LS Baseline (ISO/IEC 14495-1): Mapping table continuation.
-    extended_width_and_height =
-        0x4, // JPEG-LS Baseline (ISO/IEC 14495-1): X and Y parameters greater than 16 bits are defined.
-    coding_method_specification = 0x5,          // JPEG-LS Extended (ISO/IEC 14495-2): Coding method specification.
-    near_lossless_error_re_specification = 0x6, // JPEG-LS Extended (ISO/IEC 14495-2): NEAR value re-specification.
-    visually_oriented_quantization_specification =
-        0x7, // JPEG-LS Extended (ISO/IEC 14495-2): Visually oriented quantization specification.
-    extended_prediction_specification = 0x8, // JPEG-LS Extended (ISO/IEC 14495-2): Extended prediction specification.
-    start_of_fixed_length_coding =
-        0x9, // JPEG-LS Extended (ISO/IEC 14495-2): Specification of the start of fixed length coding.
-    end_of_fixed_length_coding = 0xA, // JPEG-LS Extended (ISO/IEC 14495-2): Specification of the end of fixed length coding.
-    extended_preset_coding_parameters = 0xC,    // JPEG-LS Extended (ISO/IEC 14495-2): JPEG-LS preset coding parameters.
-    inverse_color_transform_specification = 0xD // JPEG-LS Extended (ISO/IEC 14495-2): inverse color transform specification.
+    /// <summary>
+    /// JPEG-LS Baseline (ISO/IEC 14495-1): Preset coding parameters (defined in C.2.4.1.1).
+    /// </summary>
+    preset_coding_parameters = 0x1,
+
+    /// <summary>
+    /// JPEG-LS Baseline (ISO/IEC 14495-1): Mapping table specification (defined in C.2.4.1.2).
+    /// </summary>
+    mapping_table_specification = 0x2,
+
+    /// <summary>
+    /// JPEG-LS Baseline (ISO/IEC 14495-1): Mapping table continuation (defined in C.2.4.1.3).
+    /// </summary>
+    mapping_table_continuation = 0x3,
+
+    /// <summary>
+    /// JPEG-LS Baseline (ISO/IEC 14495-1): X and Y parameters are defined (defined in C.2.4.1.4).
+    /// </summary>
+    oversize_image_dimension = 0x4,
+
+    // The values below are from JPEG-LS Extended (ISO/IEC 14495-2) standard and defined only for better error reporting.
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): Coding method specification.
+    /// </summary>
+    coding_method_specification = 0x5,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): NEAR value re-specification.
+    /// </summary>
+    near_lossless_error_re_specification = 0x6,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): Visually oriented quantization specification.
+    /// </summary>
+    visually_oriented_quantization_specification = 0x7,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): Extended prediction specification.
+    /// </summary>
+    extended_prediction_specification = 0x8,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): Specification of the start of fixed length coding.
+    /// </summary>
+    start_of_fixed_length_coding = 0x9,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): Specification of the end of fixed length coding.
+    /// </summary>
+    end_of_fixed_length_coding = 0xA,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): JPEG-LS preset coding parameters.
+    /// </summary>
+    extended_preset_coding_parameters = 0xC,
+
+    /// <summary>
+    /// JPEG-LS Extended (ISO/IEC 14495-2): inverse color transform specification.
+    /// </summary>
+    inverse_color_transform_specification = 0xD
 };
 
 } // namespace charls


### PR DESCRIPTION
Remove the limit that height\width needs to be in the range [1, 65535].