### PR TITLE
Enable IPO (LTO) for GCC builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ x64/
 .vscode/
 .vs/
 .idea
-build/
+build*/
 [Dd]ebug/
 [Rr]elease/
 [Cc]hecked/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,19 @@
 # Define the library "charls" target
 add_library(charls "")
 
+# Enable IPO (Interprocedural optimization) for shared lib in release mode with GCC for better performance.
+# Note: MSVC and Clang will create with IPO larger binaries that are not significant faster.
+if(BUILD_SHARED_LIBS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT ipo_supported)
+  if(ipo_supported)
+      message("-- IPO is supported and used")
+      set_property(TARGET charls PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+  else()
+      message("-- IPO is not supported")
+  endif()
+endif()
+
 target_include_directories(charls PUBLIC
   $<BUILD_INTERFACE:${charls_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -23,12 +23,10 @@ constexpr size_t checked_mul(const size_t a, const size_t b) noexcept
 size_t checked_mul(const size_t a, const size_t b)
 {
     const size_t result{a * b};
-    if (result < a || result < b)
-        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported); // overflow.
+    if (UNLIKELY(result < a || result < b)) // check for unsigned integer overflow.
+        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
     return result;
 }
-#else
-#error Unknown pointer size or missing size macros!
 #endif
 
 } // namespace


### PR DESCRIPTION
The shared library build with GCC (tested version 11.20) becomes smaller and faster.