### PR TITLE
Replace Visual Studio 2017 with 2022 on CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ variables:
   solution: '*.sln'
 
 
+jobs:
 - job: 'cppVS2022'
   pool:
     vmImage: windows-2022
@@ -59,7 +60,6 @@ variables:
       cmakeArgs: --build $(Build.BinariesDirectory)/build
 
 
-jobs:
 - job: 'cppWindows'
   pool:
     vmImage: windows-2022
@@ -81,7 +81,6 @@ jobs:
         buildConfiguration: 'Release'
 
   steps:
-
   - task: NuGetCommand@2
     inputs:
       command: 'restore'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,11 +4,66 @@
 variables:
   solution: '*.sln'
 
+
+- job: 'cppVS2022'
+  pool:
+    vmImage: windows-2022
+  displayName: 'CMake - MSVC 2022'
+
+  strategy:
+    matrix:
+      x64 Debug:
+        BuildType: Debug
+        Architecture: x64
+
+      x64 Release:
+        BuildType: Release
+        Architecture: x64
+
+      x86 Debug:
+        BuildType: Debug
+        Architecture: x86
+
+      x86 Release:
+        BuildType: Release
+        Architecture: x86
+
+  steps:
+  - script: choco install ninja
+    displayName: Install Ninja
+
+  - task: BatchScript@1
+    inputs:
+      filename: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+      arguments: $(Architecture)
+      modifyEnvironment: true
+    displayName: Setup Environment Variables
+
+  - task: CMake@1
+    displayName: "Configure CharLS"
+    inputs:
+      workingDirectory: $(Build.BinariesDirectory)/build
+      cmakeArgs:
+        -G Ninja
+        -DCMAKE_C_COMPILER="cl.exe"
+        -DCMAKE_CXX_COMPILER="cl.exe"
+        -DCMAKE_BUILD_TYPE=$(buildType)
+        -DCHARLS_PEDANTIC_WARNINGS=On
+        -DCHARLS_TREAT_WARNING_AS_ERROR=On
+        $(Build.SourcesDirectory)
+
+  - task: CMake@1
+    displayName: "Build CharLS"
+    inputs:
+      workingDirectory: $(Build.BinariesDirectory)/build
+      cmakeArgs: --build $(Build.BinariesDirectory)/build
+
+
 jobs:
 - job: 'cppWindows'
   pool:
-    vmImage: windows-latest
-  displayName: 'Solution MSVC 2019'
+    vmImage: windows-2022
+  displayName: 'Solution MSVC 2022'
 
   strategy:
     matrix:
@@ -47,7 +102,7 @@ jobs:
 
 - job: 'cppVS2019'
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
   displayName: 'CMake - MSVC 2019'
 
   strategy:
@@ -108,60 +163,6 @@ jobs:
         -DCMAKE_CXX_COMPILER="cl.exe"
         -DCMAKE_BUILD_TYPE=$(buildType)
         -DBUILD_SHARED_LIBS=$(Shared)
-        -DCHARLS_PEDANTIC_WARNINGS=On
-        -DCHARLS_TREAT_WARNING_AS_ERROR=On
-        $(Build.SourcesDirectory)
-
-  - task: CMake@1
-    displayName: "Build CharLS"
-    inputs:
-      workingDirectory: $(Build.BinariesDirectory)/build
-      cmakeArgs: --build $(Build.BinariesDirectory)/build
-
-
-- job: 'cppVS2017'
-  pool:
-    vmImage: vs2017-win2016
-  displayName: 'CMake - MSVC 2017'
-
-  strategy:
-    matrix:
-      x64 Debug:
-        BuildType: Debug
-        Architecture: x64
-
-      x64 Release:
-        BuildType: Release
-        Architecture: x64
-
-      x86 Debug:
-        BuildType: Debug
-        Architecture: x86
-
-      x86 Release:
-        BuildType: Release
-        Architecture: x86
-
-  steps:
-  - script: choco install ninja
-    displayName: Install Ninja
-
-  - task: BatchScript@1
-    inputs:
-      filename: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
-      arguments: $(Architecture)
-      modifyEnvironment: true
-    displayName: Setup Environment Variables
-
-  - task: CMake@1
-    displayName: "Configure CharLS"
-    inputs:
-      workingDirectory: $(Build.BinariesDirectory)/build
-      cmakeArgs:
-        -G Ninja
-        -DCMAKE_C_COMPILER="cl.exe"
-        -DCMAKE_CXX_COMPILER="cl.exe"
-        -DCMAKE_BUILD_TYPE=$(buildType)
         -DCHARLS_PEDANTIC_WARNINGS=On
         -DCHARLS_TREAT_WARNING_AS_ERROR=On
         $(Build.SourcesDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,60 +6,6 @@ variables:
 
 
 jobs:
-- job: 'cppVS2022'
-  pool:
-    vmImage: windows-2022
-  displayName: 'CMake - MSVC 2022'
-
-  strategy:
-    matrix:
-      x64 Debug:
-        BuildType: Debug
-        Architecture: x64
-
-      x64 Release:
-        BuildType: Release
-        Architecture: x64
-
-      x86 Debug:
-        BuildType: Debug
-        Architecture: x86
-
-      x86 Release:
-        BuildType: Release
-        Architecture: x86
-
-  steps:
-  - script: choco install ninja
-    displayName: Install Ninja
-
-  - task: BatchScript@1
-    inputs:
-      filename: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
-      arguments: $(Architecture)
-      modifyEnvironment: true
-    displayName: Setup Environment Variables
-
-  - task: CMake@1
-    displayName: "Configure CharLS"
-    inputs:
-      workingDirectory: $(Build.BinariesDirectory)/build
-      cmakeArgs:
-        -G Ninja
-        -DCMAKE_C_COMPILER="cl.exe"
-        -DCMAKE_CXX_COMPILER="cl.exe"
-        -DCMAKE_BUILD_TYPE=$(buildType)
-        -DCHARLS_PEDANTIC_WARNINGS=On
-        -DCHARLS_TREAT_WARNING_AS_ERROR=On
-        $(Build.SourcesDirectory)
-
-  - task: CMake@1
-    displayName: "Build CharLS"
-    inputs:
-      workingDirectory: $(Build.BinariesDirectory)/build
-      cmakeArgs: --build $(Build.BinariesDirectory)/build
-
-
 - job: 'cppWindows'
   pool:
     vmImage: windows-2022
@@ -99,10 +45,10 @@ jobs:
       configuration: '$(buildConfiguration)'
 
 
-- job: 'cppVS2019'
+- job: 'cppVS2022'
   pool:
-    vmImage: windows-2019
-  displayName: 'CMake - MSVC 2019'
+    vmImage: windows-2022
+  displayName: 'CMake - MSVC 2022'
 
   strategy:
     matrix:
@@ -147,7 +93,7 @@ jobs:
 
   - task: BatchScript@1
     inputs:
-      filename: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+      filename: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
       arguments: $(Architecture)
       modifyEnvironment: true
     displayName: Setup Environment Variables
@@ -162,6 +108,60 @@ jobs:
         -DCMAKE_CXX_COMPILER="cl.exe"
         -DCMAKE_BUILD_TYPE=$(buildType)
         -DBUILD_SHARED_LIBS=$(Shared)
+        -DCHARLS_PEDANTIC_WARNINGS=On
+        -DCHARLS_TREAT_WARNING_AS_ERROR=On
+        $(Build.SourcesDirectory)
+
+  - task: CMake@1
+    displayName: "Build CharLS"
+    inputs:
+      workingDirectory: $(Build.BinariesDirectory)/build
+      cmakeArgs: --build $(Build.BinariesDirectory)/build
+
+
+- job: 'cppVS2019'
+  pool:
+    vmImage: windows-2019
+  displayName: 'CMake - MSVC 2019'
+
+  strategy:
+    matrix:
+      x64 Debug:
+        BuildType: Debug
+        Architecture: x64
+
+      x64 Release:
+        BuildType: Release
+        Architecture: x64
+
+      x86 Debug:
+        BuildType: Debug
+        Architecture: x86
+
+      x86 Release:
+        BuildType: Release
+        Architecture: x86
+
+  steps:
+  - script: choco install ninja
+    displayName: Install Ninja
+
+  - task: BatchScript@1
+    inputs:
+      filename: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+      arguments: $(Architecture)
+      modifyEnvironment: true
+    displayName: Setup Environment Variables
+
+  - task: CMake@1
+    displayName: "Configure CharLS"
+    inputs:
+      workingDirectory: $(Build.BinariesDirectory)/build
+      cmakeArgs:
+        -G Ninja
+        -DCMAKE_C_COMPILER="cl.exe"
+        -DCMAKE_CXX_COMPILER="cl.exe"
+        -DCMAKE_BUILD_TYPE=$(buildType)
         -DCHARLS_PEDANTIC_WARNINGS=On
         -DCHARLS_TREAT_WARNING_AS_ERROR=On
         $(Build.SourcesDirectory)


### PR DESCRIPTION
Visual Studio 2017 will be phased out. Replace VS 2017 with VS 2022 on the Azure Devops CI build.
Note: VS 2017 and VS 2015 are still supported compilers.