### PR TITLE
Clarify limitation for palette color

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following JPEG-LS options are not supported by the CharLS implementation. Mo
   While technical possible all known JPEG-LS codecs put multi-component (color) images in a single scan
   or in multiple scans, but not use a mix of these in one file.
 * No support to encode\decode images with the height defined after the first scan (DNL marker).
-* No support for JPEG-LS mapping tables.
+* No support for JPEG-LS mapping tables (palette).
 * No support for point transform.
   Point transform is a lossly encoding mechanism and not used in lossless scenarios.
 


### PR DESCRIPTION
sample-mapping procedure is JPEG-LS specific, clarify limitation for palletized images.