### PR TITLE
Benchmark the update_variables for context

### DIFF
--- a/benchmark/benchmark.vcxproj
+++ b/benchmark/benchmark.vcxproj
@@ -194,6 +194,15 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="benchmark.cpp" />
+    <ClCompile Include="context_regular_mode.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\CharLS.vcxproj">
+      <Project>{1e31f9f1-f175-4082-b3e2-b1f0eca3f44c}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="context_regular_mode_v220.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/benchmark/benchmark.vcxproj.filters
+++ b/benchmark/benchmark.vcxproj.filters
@@ -18,5 +18,13 @@
     <ClCompile Include="benchmark.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="context_regular_mode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="context_regular_mode_v220.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/benchmark/context_regular_mode.cpp
+++ b/benchmark/context_regular_mode.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <benchmark/benchmark.h>
+
+#include "context_regular_mode_v220.h"
+
+using namespace charls;
+
+context_regular_mode g_context;
+jls_context_v220 g_context_v220;
+
+volatile int32_t error_value;
+volatile int32_t near_lossless;
+volatile int32_t reset_threshold = 64;
+
+static void bm_regular_mode_update_variables_220(benchmark::State& state)
+{
+    g_context_v220 = jls_context_v220();
+
+    for (const auto _ : state)
+    {
+        g_context_v220.update_variables(error_value, near_lossless, reset_threshold);
+    }
+}
+BENCHMARK(bm_regular_mode_update_variables_220);
+
+static void bm_regular_mode_update_variables(benchmark::State& state)
+{
+    g_context = context_regular_mode();
+
+    for (const auto _ : state)
+    {
+        g_context.update_variables_and_bias(error_value, near_lossless, reset_threshold);
+    }
+}
+BENCHMARK(bm_regular_mode_update_variables);
+
+static void bm_regular_mode_get_golomb_coding_parameter_v220(benchmark::State& state)
+{
+    g_context_v220 = jls_context_v220();
+    g_context_v220.update_variables(error_value, near_lossless, reset_threshold);
+
+    for (const auto _ : state)
+    {
+        benchmark::DoNotOptimize(g_context_v220.get_golomb_coding_parameter());
+    }
+}
+BENCHMARK(bm_regular_mode_get_golomb_coding_parameter_v220);
+
+static void bm_regular_mode_get_golomb_coding_parameter(benchmark::State& state)
+{
+    g_context = context_regular_mode();
+    g_context.update_variables_and_bias(error_value, near_lossless, reset_threshold);
+
+    for (const auto _ : state)
+    {
+        benchmark::DoNotOptimize(g_context.get_golomb_coding_parameter());
+    }
+}
+BENCHMARK(bm_regular_mode_get_golomb_coding_parameter);

--- a/benchmark/context_regular_mode_v220.h
+++ b/benchmark/context_regular_mode_v220.h
@@ -3,25 +3,23 @@
 
 #pragma once
 
-#include "util.h"
-#include "constants.h"
-
+#include "../src/context_regular_mode.h"
 #include <cassert>
 #include <cstdint>
 
 namespace charls {
 
 // Purpose: a JPEG-LS context with it's current statistics.
-struct jls_context final
+struct jls_context_v220 final
 {
     int32_t A{};
     int32_t B{};
     int16_t C{};
     int16_t N{1};
 
-    jls_context() = default;
+    jls_context_v220() = default;
 
-    explicit jls_context(const int32_t a) noexcept : A{a}
+    explicit jls_context_v220(const int32_t a) noexcept : A{a}
     {
     }
 

--- a/doc/style_and_design.md
+++ b/doc/style_and_design.md
@@ -192,6 +192,14 @@ Examples of decoding performance on a AMD 5950X x64 CPU:
 | 16 bit 512 * 512 (CT image) | 3.09 ms | 3.17 ms    | 3.06 ms    | 3.10 ms   |
 |  8 bit 5412 * 7216          | 517 ms  | 509 ms     | 507 ms     | 512 ms    |
 
+#### Using special "checked" functions for decoding
+
+The input data for decoding is untrusted. Additional checks are included to detect invalid bitstream data.
+Most of these routines are also shared with the encoding process.
+Measurements show that there is no impact by creating special functions that don't these checks.
+In normal cases the checks never fail and the unlikely branch is never taken. This makes is very easy for
+the CPU branch predictor to always the correct outcome based on the branch history.
+
 ### Supported C++ Compilers
 
 #### Clang

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ target_sources(charls
     "${CMAKE_CURRENT_LIST_DIR}/coding_parameters.h"
     "${CMAKE_CURRENT_LIST_DIR}/color_transform.h"
     "${CMAKE_CURRENT_LIST_DIR}/constants.h"
-    "${CMAKE_CURRENT_LIST_DIR}/context.h"
+    "${CMAKE_CURRENT_LIST_DIR}/context_regular_mode.h"
     "${CMAKE_CURRENT_LIST_DIR}/context_run_mode.h"
     "${CMAKE_CURRENT_LIST_DIR}/decoder_strategy.h"
     "${CMAKE_CURRENT_LIST_DIR}/default_traits.h"

--- a/src/CharLS.vcxproj
+++ b/src/CharLS.vcxproj
@@ -183,7 +183,7 @@
     <ClInclude Include="coding_parameters.h" />
     <ClInclude Include="color_transform.h" />
     <ClInclude Include="constants.h" />
-    <ClInclude Include="context.h" />
+    <ClInclude Include="context_regular_mode.h" />
     <ClInclude Include="context_run_mode.h" />
     <ClInclude Include="decoder_strategy.h" />
     <ClInclude Include="default_traits.h" />

--- a/src/CharLS.vcxproj.filters
+++ b/src/CharLS.vcxproj.filters
@@ -24,7 +24,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="context.h">
+    <ClInclude Include="context_regular_mode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="scan.h">

--- a/src/constants.h
+++ b/src/constants.h
@@ -30,6 +30,12 @@ constexpr int compute_maximum_near_lossless(const int maximum_sample_value) noex
     return std::min(maximum_near_lossless, maximum_sample_value / 2); // As defined by ISO/IEC 14495-1, C.2.3
 }
 
+// Computes the initial value for A. See ISO/IEC 14495-1, A.8, step 1.d and A.2.1
+constexpr int32_t initialization_value_for_a(const int32_t range) noexcept
+{
+    return std::max(2, (range + 32) / 64);
+}
+
 // ISO/IEC 14495-1, section 4.8.1 defines the SPIFF version numbers to be used for the SPIFF header in combination with
 // JPEG-LS.
 constexpr uint8_t spiff_major_revision_number{2};

--- a/src/context.h
+++ b/src/context.h
@@ -33,6 +33,7 @@ struct jls_context final
         return bit_wise_sign(2 * B + N - 1);
     }
 
+    /// <summary>Code segment A.12 – Variables update.</summary>
     FORCE_INLINE void update_variables(const int32_t error_value, const int32_t near_lossless,
                                        const int32_t reset_threshold)
     {
@@ -49,13 +50,13 @@ struct jls_context final
 
         if (n == reset_threshold)
         {
-            a = a >> 1;
-            b = b >> 1;
-            n = n >> 1;
+            a >>= 1;
+            b >>= 1;
+            n >>= 1;
         }
 
         A = a;
-        n = n + 1;
+        ++n;
         N = static_cast<int16_t>(n);
 
         if (b + n <= 0)

--- a/src/context_regular_mode.h
+++ b/src/context_regular_mode.h
@@ -1,0 +1,117 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "constants.h"
+#include "util.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace charls {
+
+/// <summary>
+/// JPEG-LS uses arrays of variables: A[0..366], B[0..364], C[0..364] and N[0..366]
+/// to maintain the statistic information for the context modeling.
+/// As the operations on these variables use the same index it is more efficient to combine A,B,C and N.
+/// </summary>
+class context_regular_mode final
+{
+public:
+    context_regular_mode() = default;
+
+    explicit context_regular_mode(const int32_t range) noexcept : a_{initialization_value_for_a(range)}
+    {
+    }
+
+    /// <summary>counter with prediction correction value</summary>
+    int32_t c() const noexcept
+    {
+        return c_;
+    }
+
+    FORCE_INLINE int32_t get_error_correction(const int32_t k) const noexcept
+    {
+        if (k != 0)
+            return 0;
+
+        return bit_wise_sign(2 * b_ + n_ - 1);
+    }
+
+    /// <summary>Code segment A.12 – Variables update. ISO 14495-1, page 22</summary>
+    FORCE_INLINE void update_variables_and_bias(const int32_t error_value, const int32_t near_lossless, const int32_t reset_threshold)
+    {
+        ASSERT(n_ != 0);
+
+        a_ += std::abs(error_value);
+        b_ += error_value * (2 * near_lossless + 1);
+
+        constexpr int limit{65536 * 256};
+        if (UNLIKELY(a_ >= limit || std::abs(b_) >= limit))
+            impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+
+        if (n_ == reset_threshold)
+        {
+            a_ >>= 1;
+            b_ >>= 1;
+            n_ >>= 1;
+        }
+
+        ++n_;
+        ASSERT(n_ != 0);
+
+        // This part is from: Code segment A.13 – Update of bias-related variables B[Q] and C[Q]
+        constexpr int32_t max_c{127};  // Minimum allowed value of c_[0..364]. ISO 14495-1, section 3.3
+        constexpr int32_t min_c{-128}; // Minimum allowed value of c_[0..364]. ISO 14495-1, section 3.3
+        if (b_ + n_ <= 0)
+        {
+            b_ += n_;
+            if (b_ <= -n_)
+            {
+                b_ = -n_ + 1;
+            }
+            if (c_ > min_c)
+            {
+                --c_;
+            }
+        }
+        else if (b_ > 0)
+        {
+            b_ -= n_;
+            if (b_ > 0)
+            {
+                b_ = 0;
+            }
+            if (c_ < max_c)
+            {
+                ++c_;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Computes the Golomb coding parameter using the algorithm as defined in ISO 14495-1, code segment A.10
+    /// </summary>
+    FORCE_INLINE int32_t get_golomb_coding_parameter() const
+    {
+        int32_t k{};
+        for (; n_ << k < a_ && k < max_k_value; ++k)
+        {
+        }
+
+        if (UNLIKELY(k == max_k_value))
+            impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+
+        return k;
+    }
+
+private:
+    // Initialize with the default values as defined in ISO 14495-1, A.8, step 1.d.
+    int32_t a_{};
+    int32_t b_{};
+    int32_t c_{};
+    int32_t n_{1};
+};
+
+} // namespace charls

--- a/src/context_run_mode.h
+++ b/src/context_run_mode.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "constants.h"
 #include "util.h"
 
 #include <cassert>
@@ -10,17 +11,18 @@
 
 namespace charls {
 
-// Implements statistical modeling for the run mode context.
-// Computes model dependent parameters like the Golomb code lengths
+/// <summary>
+/// JPEG-LS uses arrays of variables: A[0..366], B[0..364], C[0..364] and N[0..366]
+/// to maintain the statistic information for the context modeling.
+/// Index 365 and 366 are used for run mode interruption contexts.
+/// </summary>
 class context_run_mode final
 {
 public:
     context_run_mode() = default;
 
-    context_run_mode(const int32_t run_interruption_type, const int32_t a) noexcept :
-        run_interruption_type_{run_interruption_type},
-        a_{a},
-        n_{1}
+    context_run_mode(const int32_t run_interruption_type, const int32_t range) noexcept :
+        run_interruption_type_{run_interruption_type}, a_{initialization_value_for_a(range)}
     {
     }
 
@@ -99,9 +101,10 @@ public:
     }
 
 private:
+    // Initialize with the default values as defined in ISO 14495-1, A.8, step 1.d and 1.f.
     int32_t run_interruption_type_{};
     int32_t a_{};
-    uint8_t n_{};
+    uint8_t n_{1};
     uint8_t nn_{};
 };
 

--- a/src/context_run_mode.h
+++ b/src/context_run_mode.h
@@ -17,10 +17,9 @@ class context_run_mode final
 public:
     context_run_mode() = default;
 
-    context_run_mode(const int32_t arg_run_interruption_type, const int32_t a, const int32_t reset_threshold) noexcept :
-        run_interruption_type_{arg_run_interruption_type},
+    context_run_mode(const int32_t run_interruption_type, const int32_t a) noexcept :
+        run_interruption_type_{run_interruption_type},
         a_{a},
-        reset_threshold_{static_cast<uint8_t>(reset_threshold)},
         n_{1}
     {
     }
@@ -43,20 +42,25 @@ public:
         return k;
     }
 
-    void update_variables(const int32_t error_value, const int32_t e_mapped_error_value) noexcept
+    /// <summary>Code segment A.23 – Update of variables for run interruption sample.</summary>
+    void update_variables(const int32_t error_value, const int32_t e_mapped_error_value,
+                          const uint8_t reset_threshold) noexcept
     {
         if (error_value < 0)
         {
-            nn_ = nn_ + 1U;
+            ++nn_;
         }
-        a_ = a_ + ((e_mapped_error_value + 1 - run_interruption_type_) >> 1);
-        if (n_ == reset_threshold_)
+
+        a_ += (e_mapped_error_value + 1 - run_interruption_type_) >> 1;
+
+        if (n_ == reset_threshold)
         {
-            a_ = a_ >> 1;
-            n_ = n_ >> 1;
-            nn_ = nn_ >> 1;
+            a_ >>= 1;
+            n_ >>= 1;
+            nn_ >>= 1;
         }
-        n_ = n_ + 1;
+
+        ++n_;
     }
 
     FORCE_INLINE int32_t compute_error_value(const int32_t temp, const int32_t k) const noexcept
@@ -74,6 +78,7 @@ public:
         return error_value_abs;
     }
 
+    /// <summary>Code segment A.21 – Computation of map for Errval mapping.</summary>
     bool compute_map(const int32_t error_value, const int32_t k) const noexcept
     {
         if (k == 0 && error_value > 0 && 2 * nn_ < n_)
@@ -96,7 +101,6 @@ public:
 private:
     int32_t run_interruption_type_{};
     int32_t a_{};
-    uint8_t reset_threshold_{};
     uint8_t n_{};
     uint8_t nn_{};
 };

--- a/src/scan.h
+++ b/src/scan.h
@@ -477,7 +477,7 @@ private:
         t1_ = t1;
         t2_ = t2;
         t3_ = t3;
-        reset_threshold_ = reset_threshold;
+        reset_threshold_ = static_cast<uint8_t>(reset_threshold);
 
         initialize_quantization_lut();
         reset_parameters();
@@ -491,8 +491,8 @@ private:
             context = context_initial_value;
         }
 
-        context_runmode_[0] = context_run_mode(0, std::max(2, (traits_.range + 32) / 64), reset_threshold_);
-        context_runmode_[1] = context_run_mode(1, std::max(2, (traits_.range + 32) / 64), reset_threshold_);
+        context_runmode_[0] = context_run_mode(0, std::max(2, (traits_.range + 32) / 64));
+        context_runmode_[1] = context_run_mode(1, std::max(2, (traits_.range + 32) / 64));
         run_index_ = 0;
     }
 
@@ -672,7 +672,7 @@ private:
         const int32_t e_mapped_error_value{
             decode_value(k, traits_.limit - J[run_index_] - 1, traits_.quantized_bits_per_pixel)};
         const int32_t error_value{context.compute_error_value(e_mapped_error_value + context.run_interruption_type(), k)};
-        context.update_variables(error_value, e_mapped_error_value);
+        context.update_variables(error_value, e_mapped_error_value, reset_threshold_);
         return error_value;
     }
 
@@ -774,7 +774,7 @@ private:
 
         ASSERT(error_value == context.compute_error_value(e_mapped_error_value + context.run_interruption_type(), k));
         encode_mapped_value(k, e_mapped_error_value, traits_.limit - J[run_index_] - 1);
-        context.update_variables(error_value, e_mapped_error_value);
+        context.update_variables(error_value, e_mapped_error_value, reset_threshold_);
     }
 
     sample_type encode_run_interruption_pixel(const int32_t x, const int32_t ra, const int32_t rb)
@@ -887,7 +887,7 @@ private:
     int32_t t1_{};
     int32_t t2_{};
     int32_t t3_{};
-    int32_t reset_threshold_{};
+    uint8_t reset_threshold_{};
     uint32_t restart_interval_{};
     uint32_t restart_interval_counter_{};
 

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="charls_jpegls_decoder_test.cpp" />
     <ClCompile Include="charls_jpegls_encoder_test.cpp" />
     <ClCompile Include="compliance_test.cpp" />
+    <ClCompile Include="context_run_mode_test.cpp" />
     <ClCompile Include="golomb_table_test.cpp" />
     <ClCompile Include="decoder_strategy_test.cpp" />
     <ClCompile Include="default_traits_test.cpp" />

--- a/unittest/CharLSUnitTest.vcxproj.filters
+++ b/unittest/CharLSUnitTest.vcxproj.filters
@@ -101,6 +101,9 @@
     <ClCompile Include="scan_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="context_run_mode_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="lena8b.pgm">

--- a/unittest/context_run_mode_test.cpp
+++ b/unittest/context_run_mode_test.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.h"
+
+#include "../src/context_run_mode.h"
+
+
+using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
+
+namespace charls { namespace test {
+
+TEST_CLASS(context_run_mode_test)
+{
+public:
+    TEST_METHOD(update_variable) // NOLINT
+    {
+        context_run_mode context;
+
+        context.update_variables(3, 27, 0);
+
+        Assert::AreEqual(3, context.get_golomb_code());
+    }
+};
+
+}} // namespace charls::test


### PR DESCRIPTION
- Use standard C++, the compiler will take of using the optimal registers.
- Use uint32_t instead of uint16_t (slightly faster)