### PR TITLE
Write full coding parameters when not default

### DIFF
--- a/CharLS.sln.DotSettings
+++ b/CharLS.sln.DotSettings
@@ -45,6 +45,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=banny/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bgra/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bugprone/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=byteswap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CHARLS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=charlstest/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmove/@EntryIndexedValue">True</s:Boolean>

--- a/src/jpegls.cpp
+++ b/src/jpegls.cpp
@@ -48,7 +48,7 @@ int8_t quantize_gradient_org(const jpegls_pc_parameters& preset, const int32_t d
 
 vector<int8_t> create_quantize_lut_lossless(const int32_t bit_count)
 {
-    const jpegls_pc_parameters preset{compute_default((1 << static_cast<uint32_t>(bit_count)) - 1, 0)};
+    const jpegls_pc_parameters preset{compute_default(calculate_maximum_sample_value(bit_count), 0)};
     const int32_t range{preset.maximum_sample_value + 1};
 
     vector<int8_t> lut(static_cast<size_t>(range) * 2);

--- a/src/jpegls_preset_coding_parameters.h
+++ b/src/jpegls_preset_coding_parameters.h
@@ -13,7 +13,7 @@
 namespace charls {
 
 /// <summary>Clamping function as defined by ISO/IEC 14495-1, Figure C.3</summary>
-inline int32_t clamp(const int32_t i, const int32_t j, const int32_t maximum_sample_value) noexcept
+constexpr int32_t clamp(const int32_t i, const int32_t j, const int32_t maximum_sample_value) noexcept
 {
     if (i > maximum_sample_value || i < j)
         return j;
@@ -52,21 +52,26 @@ inline jpegls_pc_parameters compute_default(const int32_t maximum_sample_value, 
 }
 
 
-inline bool is_default(const jpegls_pc_parameters& preset_coding_parameters) noexcept
+inline bool is_default(const jpegls_pc_parameters& preset_coding_parameters, const jpegls_pc_parameters& defaults) noexcept
 {
-    if (preset_coding_parameters.maximum_sample_value != 0)
+    if (preset_coding_parameters.maximum_sample_value == 0 && preset_coding_parameters.threshold1 == 0 &&
+        preset_coding_parameters.threshold2 == 0 && preset_coding_parameters.threshold3 == 0 &&
+        preset_coding_parameters.reset_value == 0)
+        return true;
+
+    if (preset_coding_parameters.maximum_sample_value != defaults.maximum_sample_value)
         return false;
 
-    if (preset_coding_parameters.threshold1 != 0)
+    if (preset_coding_parameters.threshold1 != defaults.threshold1)
         return false;
 
-    if (preset_coding_parameters.threshold2 != 0)
+    if (preset_coding_parameters.threshold2 != defaults.threshold2)
         return false;
 
-    if (preset_coding_parameters.threshold3 != 0)
+    if (preset_coding_parameters.threshold3 != defaults.threshold3)
         return false;
 
-    if (preset_coding_parameters.reset_value != 0)
+    if (preset_coding_parameters.reset_value != defaults.reset_value)
         return false;
 
     return true;

--- a/src/util.h
+++ b/src/util.h
@@ -265,7 +265,7 @@ CHARLS_CHECK_RETURN T byte_swap(T /*value*/) noexcept
 }
 
 template<>
-CHARLS_CHECK_RETURN inline uint16_t byte_swap<uint16_t>(const uint16_t value) noexcept
+CHARLS_CHECK_RETURN inline uint16_t byte_swap(const uint16_t value) noexcept
 {
 #ifdef _MSC_VER
     return _byteswap_ushort(value);
@@ -276,7 +276,7 @@ CHARLS_CHECK_RETURN inline uint16_t byte_swap<uint16_t>(const uint16_t value) no
 }
 
 template<>
-CHARLS_CHECK_RETURN inline uint32_t byte_swap<uint32_t>(const uint32_t value) noexcept
+CHARLS_CHECK_RETURN inline uint32_t byte_swap(const uint32_t value) noexcept
 {
 #ifdef _MSC_VER
     return _byteswap_ulong(value);

--- a/unittest/jpegls_preset_coding_parameters_test.cpp
+++ b/unittest/jpegls_preset_coding_parameters_test.cpp
@@ -118,6 +118,34 @@ public:
 
         Assert::IsTrue(is_valid(pc_parameters, maximum_component_value, 0));
     }
+
+    TEST_METHOD(is_default_nothing_set) // NOLINT
+    {
+        const auto default_parameters{compute_default(255, 0)};
+
+        constexpr jpegls_pc_parameters pc_parameters{};
+
+        Assert::IsTrue(is_default(pc_parameters, default_parameters));
+    }
+
+    TEST_METHOD(is_default_same_as_default) // NOLINT
+    {
+        const auto default_parameters{compute_default(255, 0)};
+
+        const jpegls_pc_parameters pc_parameters{compute_default(255, 0)};
+
+        Assert::IsTrue(is_default(pc_parameters, default_parameters));
+    }
+
+    TEST_METHOD(is_default_same_as_default_except_reset) // NOLINT
+    {
+        const auto default_parameters{compute_default(255, 0)};
+
+        jpegls_pc_parameters pc_parameters{compute_default(255, 0)};
+        ++pc_parameters.reset_value;
+
+        Assert::IsFalse(is_default(pc_parameters, default_parameters));
+    }
 };
 
 }} // namespace charls::test


### PR DESCRIPTION
The JPEG-LS standard allow it to write 0 values in the LSE segment to indicate that the default value should be used. By writing always the actual values (if not default) the decoding always use the same values as the encoding.