### PR TITLE
Restore Visual Studio 2015 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ if(MSVC)
   add_compile_options("/utf-8")
 
   # Zc:__cplusplus: Will configure the MSVC compiler to use the correct value for the __cplusplus macro
-  # (introduced with Visual Studio 2017 version 15.7)
+  # This option is introduced with Visual Studio 2017 version 15.7
   if(MSVC_VERSION GREATER_EQUAL 1914)
     add_compile_options("/Zc:__cplusplus")
   endif()
@@ -164,7 +164,10 @@ if(MSVC)
   add_compile_options("/Zc:throwingNew")
 
   # /permissive-: Will configure the MSVC compiler to accept only standards conformance C++
-  add_compile_options("/permissive-")
+  # This option is introduced with Visual Studio 2017.
+  if(MSVC_VERSION GREATER_EQUAL 1910)
+    add_compile_options("/permissive-")
+  endif()
 
   # /ZH:SHA_256: Wiill use SHA 256 for checksums between source code and debug symbols (more secure)
   add_compile_options("/ZH:SHA_256")

--- a/fuzztest/main.cpp
+++ b/fuzztest/main.cpp
@@ -39,10 +39,20 @@
 
 namespace {
 
-auto generate_once()
+std::vector<uint8_t> generate_once()
 {
     const std::vector<uint8_t> source(3);
-    return charls::jpegls_encoder::encode(source, {1, 1, 8, 3});
+
+    charls::jpegls_encoder encoder;
+    encoder.frame_info({1, 1, 8, 3});
+
+    std::vector<uint8_t> destination(encoder.estimated_destination_size());
+    encoder.destination(destination);
+
+    const size_t bytes_written{encoder.encode(source)};
+    destination.resize(bytes_written);
+
+    return destination;
 }
 
 } // namespace

--- a/src/jpegls_preset_coding_parameters.h
+++ b/src/jpegls_preset_coding_parameters.h
@@ -15,10 +15,7 @@ namespace charls {
 /// <summary>Clamping function as defined by ISO/IEC 14495-1, Figure C.3</summary>
 constexpr int32_t clamp(const int32_t i, const int32_t j, const int32_t maximum_sample_value) noexcept
 {
-    if (i > maximum_sample_value || i < j)
-        return j;
-
-    return i;
+    return i > maximum_sample_value || i < j ? j : i;
 }
 
 /// <summary>Default coding threshold values as defined by ISO/IEC 14495-1, C.2.4.1.1.1</summary>


### PR DESCRIPTION
- /permissive- is supported since Visual Studio 2017.
- VS 2015 cannot handle all constexpr functions with mutiple return statements.
- VS 2015 template deduction is limited.