### PR TITLE
Add unit test and benchmark for log2_ceil

### DIFF
--- a/benchmark/benchmark.vcxproj
+++ b/benchmark/benchmark.vcxproj
@@ -195,6 +195,7 @@
   <ItemGroup>
     <ClCompile Include="benchmark.cpp" />
     <ClCompile Include="context_regular_mode.cpp" />
+    <ClCompile Include="log2.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\CharLS.vcxproj">

--- a/benchmark/benchmark.vcxproj.filters
+++ b/benchmark/benchmark.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="context_regular_mode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="log2.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="context_regular_mode_v220.h">

--- a/benchmark/log2.cpp
+++ b/benchmark/log2.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <benchmark/benchmark.h>
+
+#include "../src/util.h"
+
+#include <cmath>
+#include <limits>
+
+
+uint32_t log2_floor(uint32_t n) noexcept
+{
+    return 31 - charls::countl_zero(n);
+}
+
+uint32_t max_value_to_bits_per_sample(uint32_t max_value) noexcept
+{
+    ASSERT(max_value > 0);
+    return log2_floor(max_value) + 1;
+}
+
+
+static void bm_log2_floor_floating_point(benchmark::State& state)
+{
+    for (const auto _ : state)
+    {
+        benchmark::DoNotOptimize(std::floor(std::log2(255)));
+        benchmark::DoNotOptimize(std::floor(std::log2(1023)));
+        benchmark::DoNotOptimize(std::floor(std::log2(std::numeric_limits<uint16_t>::max())));
+    }
+}
+BENCHMARK(bm_log2_floor_floating_point);
+
+
+static void bm_log2_floor_uint32(benchmark::State& state)
+{
+    for (const auto _ : state)
+    {
+        benchmark::DoNotOptimize(log2_floor(255));
+        benchmark::DoNotOptimize(log2_floor(1023));
+        benchmark::DoNotOptimize(log2_floor(std::numeric_limits<uint16_t>::max()));
+    }
+}
+BENCHMARK(bm_log2_floor_uint32);
+
+static void bm_log2_ceil_int32(benchmark::State& state)
+{
+    for (const auto _ : state)
+    {
+        benchmark::DoNotOptimize(charls::log2_ceil(256));
+        benchmark::DoNotOptimize(charls::log2_ceil(1024));
+        benchmark::DoNotOptimize(charls::log2_ceil(std::numeric_limits<uint16_t>::max()));
+    }
+}
+BENCHMARK(bm_log2_ceil_int32);
+
+static void bm_max_value_to_bits_per_sample(benchmark::State& state)
+{
+    for (const auto _ : state)
+    {
+        benchmark::DoNotOptimize(max_value_to_bits_per_sample(255));
+        benchmark::DoNotOptimize(max_value_to_bits_per_sample(1023));
+        benchmark::DoNotOptimize(max_value_to_bits_per_sample(std::numeric_limits<uint16_t>::max()));
+    }
+}
+BENCHMARK(bm_max_value_to_bits_per_sample);

--- a/src/default_traits.h
+++ b/src/default_traits.h
@@ -38,8 +38,8 @@ struct default_traits final
         maximum_sample_value{arg_maximum_sample_value},
         near_lossless{arg_near_lossless},
         range{compute_range_parameter(maximum_sample_value, near_lossless)},
-        quantized_bits_per_pixel{log_2(range)},
-        bits_per_pixel{log_2(maximum_sample_value)},
+        quantized_bits_per_pixel{log2_ceil(range)},
+        bits_per_pixel{log2_ceil(maximum_sample_value)},
         limit{compute_limit_parameter(bits_per_pixel)},
         reset_threshold{reset}
     {

--- a/src/util.h
+++ b/src/util.h
@@ -149,8 +149,14 @@ inline jpegls_errc set_error_message(const jpegls_errc error,
 }
 
 
-CONSTEXPR int32_t log_2(const int32_t n) noexcept
+/// <Remarks>
+/// Bits per sample can be computed if range is passed as argument.
+/// </Remarks>
+CONSTEXPR int32_t log2_ceil(const int32_t n) noexcept
 {
+    ASSERT(n >= 0);
+    ASSERT(static_cast<uint32_t>(n) <= std::numeric_limits<uint32_t>::max() >> 2); // otherwise 1 << x becomes negative.
+
     int32_t x{};
     while (n > (1 << x))
     {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -67,6 +67,20 @@ ofstream open_output_stream(const char* filename)
 }
 
 
+uint32_t log2_floor(uint32_t n) noexcept
+{
+    ASSERT(n != 0 && "log2 is not defined for 0");
+    return 31 - countl_zero(n);
+}
+
+
+uint32_t max_value_to_bits_per_sample(uint32_t max_value) noexcept
+{
+    ASSERT(max_value > 0);
+    return log2_floor(max_value) + 1;
+}
+
+
 template<typename Container>
 void read(istream& input, Container& destination_container)
 {
@@ -495,7 +509,8 @@ try
         vector<uint8_t> pixels(decoded_destination.size());
         if (frame_info.bits_per_sample > 8)
         {
-            convert_planar_to_pixel<uint16_t>(frame_info.width, frame_info.height, decoded_destination.data(), pixels.data());
+            convert_planar_to_pixel<uint16_t>(frame_info.width, frame_info.height, decoded_destination.data(),
+                                              pixels.data());
         }
         else
         {
@@ -576,7 +591,8 @@ try
         return false;
 
     const frame_info frame_info{static_cast<uint32_t>(read_values[1]), static_cast<uint32_t>(read_values[2]),
-                                log_2(read_values[3] + 1), read_values[0] == 6 ? 3 : 1};
+                                static_cast<int32_t>(max_value_to_bits_per_sample(read_values[3])),
+                                read_values[0] == 6 ? 3 : 1};
 
     const auto bytes_per_sample = static_cast<int32_t>(::bit_to_byte_count(frame_info.bits_per_sample));
     vector<uint8_t> input_buffer(static_cast<size_t>(frame_info.width) * frame_info.height * bytes_per_sample *

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="jpeg_stream_writer_test.cpp" />
     <ClCompile Include="scan_test.cpp" />
     <ClCompile Include="util.cpp" />
+    <ClCompile Include="util_test.cpp" />
     <ClCompile Include="version_test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/unittest/CharLSUnitTest.vcxproj.filters
+++ b/unittest/CharLSUnitTest.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="context_run_mode_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="util_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="lena8b.pgm">

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -287,7 +287,7 @@ public:
 
     TEST_METHOD(read_spiff_header) // NOLINT
     {
-        const vector<uint8_t> source = create_test_spiff_header();
+        const vector<uint8_t> source{create_test_spiff_header()};
         const jpegls_decoder decoder{source, true};
 
         Assert::IsTrue(decoder.spiff_header_has_value());

--- a/unittest/pch.h
+++ b/unittest/pch.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <limits>
 
 #ifdef _MSC_VER
 #define MSVC_WARNING_SUPPRESS(x) \

--- a/unittest/util_test.cpp
+++ b/unittest/util_test.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.h"
+
+#include "../src/util.h"
+
+using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
+using std::array;
+using std::numeric_limits;
+
+namespace charls { namespace test {
+
+namespace {
+
+uint32_t log2_floor(uint32_t n) noexcept
+{
+    ASSERT(n != 0 && "log2 is not defined for 0");
+    return 31 - countl_zero(n);
+}
+
+uint32_t max_value_to_bits_per_sample(uint32_t max_value) noexcept
+{
+    ASSERT(max_value > 0);
+    return log2_floor(max_value) + 1;
+}
+
+void call_and_compare_log2_ceil(int32_t arg)
+{
+    const int32_t expected{static_cast<int32_t>(ceil(std::log2(arg)))};
+    Assert::AreEqual(expected, log2_ceil(arg));
+}
+
+void call_and_compare_log2_floor(uint32_t arg)
+{
+    MSVC_WARNING_SUPPRESS_NEXT_LINE(26467) // cast from double to uint32 is safe. values always positive.
+    const uint32_t expected{static_cast<uint32_t>(floor(std::log2(arg)))};
+    Assert::AreEqual(expected, log2_floor(arg));
+}
+
+}
+
+TEST_CLASS(util_test)
+{
+public:
+    TEST_METHOD(log2_ceil) // NOLINT
+    {
+        call_and_compare_log2_ceil(1);
+        call_and_compare_log2_ceil(2);
+        call_and_compare_log2_ceil(32);
+        call_and_compare_log2_ceil(33);
+        call_and_compare_log2_ceil(33);
+        call_and_compare_log2_ceil(numeric_limits<uint16_t>::max());
+        call_and_compare_log2_ceil(numeric_limits<uint16_t>::max() + 1);
+        call_and_compare_log2_ceil(numeric_limits<uint32_t>::max() >> 2);
+    }
+
+    TEST_METHOD(log2_floor) // NOLINT
+    {
+        call_and_compare_log2_floor(1);
+        call_and_compare_log2_floor(2);
+        call_and_compare_log2_floor(32);
+        call_and_compare_log2_floor(33);
+        call_and_compare_log2_floor(33);
+        call_and_compare_log2_floor(numeric_limits<uint16_t>::max());
+        call_and_compare_log2_floor(numeric_limits<uint16_t>::max() + 1);
+        call_and_compare_log2_floor(numeric_limits<uint32_t>::max() >> 2);
+    }
+
+    TEST_METHOD(max_value_to_bits_per_sample_test) // NOLINT
+    {
+        Assert::AreEqual(1U, max_value_to_bits_per_sample(1));
+        Assert::AreEqual(2U, max_value_to_bits_per_sample(2));
+        Assert::AreEqual(5U, max_value_to_bits_per_sample(31));
+        Assert::AreEqual(6U, max_value_to_bits_per_sample(32));
+        Assert::AreEqual(6U, max_value_to_bits_per_sample(33));
+        Assert::AreEqual(8U, max_value_to_bits_per_sample(255));
+        Assert::AreEqual(10U, max_value_to_bits_per_sample(1023));
+        Assert::AreEqual(16U, max_value_to_bits_per_sample(numeric_limits<uint16_t>::max()));
+    }
+};
+
+}} // namespace charls::test


### PR DESCRIPTION
- Rename the log_2 function into log2_ceil as that is what the function performs.
- Add unit test and benchmark test to get insight if using it in more places has benefits.