### PR TITLE
Add overflow detection for estimated_destination_size in x86 build

### DIFF
--- a/cpp.hint
+++ b/cpp.hint
@@ -10,10 +10,10 @@
 
 #define CHARLS_API_IMPORT_EXPORT
 #define CHARLS_API_CALLING_CONVENTION
-#define CHARLS_NO_DISCARD [[nodiscard]]
-#define CHARLS_DEPRECATED [[deprecated]]
+#define CHARLS_NO_DISCARD
+#define CHARLS_DEPRECATED
 #define CHARLS_FINAL final
-#define CHARLS_NOEXCEPT noexcept
+#define CHARLS_NOEXCEPT
 #define CHARLS_NO_INLINE
 #define FORCE_INLINE
 #define MSVC_WARNING_SUPPRESS(x)

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -10,27 +10,6 @@
 
 using namespace charls;
 
-namespace {
-
-#if INTPTR_MAX == INT64_MAX
-// 64-bit
-constexpr size_t checked_mul(const size_t a, const size_t b) noexcept
-{
-    return a * b;
-}
-#elif INTPTR_MAX == INT32_MAX
-// 32-bit
-size_t checked_mul(const size_t a, const size_t b)
-{
-    const size_t result{a * b};
-    if (UNLIKELY(result < a || result < b)) // check for unsigned integer overflow.
-        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
-    return result;
-}
-#endif
-
-} // namespace
-
 struct charls_jpegls_decoder final
 {
     void source(const const_byte_span source)

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -92,8 +92,8 @@ struct charls_jpegls_encoder final
     size_t estimated_destination_size() const
     {
         check_operation(is_frame_info_configured());
-        return static_cast<size_t>(frame_info_.component_count) * frame_info_.width * frame_info_.height *
-                   bit_to_byte_count(frame_info_.bits_per_sample) +
+        return checked_mul(checked_mul(checked_mul(frame_info_.width, frame_info_.height), frame_info_.component_count), 
+                   bit_to_byte_count(frame_info_.bits_per_sample)) +
                1024 + spiff_header_size_in_bytes;
     }
 

--- a/src/jls_codec_factory.h
+++ b/src/jls_codec_factory.h
@@ -24,7 +24,9 @@ private:
     std::unique_ptr<Strategy> try_create_optimized_codec(const frame_info& frame, const coding_parameters& parameters);
 };
 
+#ifndef _MSC_VER // IntelliSense fails to parse next lines and __INTELLISENSE__ cannot exclude it. Not needed for MSVC build.
 extern template class jls_codec_factory<decoder_strategy>;
 extern template class jls_codec_factory<encoder_strategy>;
+#endif
 
 } // namespace charls

--- a/src/util.h
+++ b/src/util.h
@@ -491,4 +491,21 @@ auto countl_zero(T value) noexcept -> std::enable_if_t<is_uint_v<32, T>, int>
 
 #endif
 
+
+#if INTPTR_MAX == INT64_MAX
+constexpr size_t checked_mul(const size_t a, const size_t b) noexcept
+{
+    return a * b;
+}
+#elif INTPTR_MAX == INT32_MAX
+inline size_t checked_mul(const size_t a, const size_t b)
+{
+    const size_t result{a * b};
+    if (UNLIKELY(result < a || result < b)) // check for unsigned integer overflow.
+        impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
+    return result;
+}
+#endif
+
+
 } // namespace charls

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -21,7 +21,7 @@ TEST_CLASS(jpeg_stream_writer_test)
 public:
     TEST_METHOD(remaining_destination_will_be_zero_after_create_with_default) // NOLINT
     {
-        const jpeg_stream_writer writer;
+        constexpr jpeg_stream_writer writer;
         Assert::AreEqual(static_cast<size_t>(0), writer.remaining_destination().size);
         Assert::IsNull(writer.remaining_destination().data);
     }

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -204,6 +204,23 @@ public:
                                 [&encoder] { ignore = encoder.estimated_destination_size(); });
     }
 
+    TEST_METHOD(estimated_destination_size_thath_causes_overflow_throws) // NOLINT
+    {
+        jpegls_encoder encoder;
+
+        encoder.frame_info({numeric_limits<uint32_t>::max(), numeric_limits<uint32_t>::max(), 8, 1});
+
+        #if INTPTR_MAX == INT64_MAX
+        const auto size{encoder.estimated_destination_size()};
+        Assert::IsTrue(size != 0); // actual value already checked in other test functions.
+        #elif INTPTR_MAX == INT32_MAX
+        assert_expect_exception(jpegls_errc::parameter_value_not_supported,
+                                [&encoder] { ignore = encoder.estimated_destination_size(); });
+        #else
+        #error Unknown pointer size or missing size macros!
+        #endif
+    }
+
     TEST_METHOD(destination) // NOLINT
     {
         jpegls_encoder encoder;

--- a/unittest/util_test.cpp
+++ b/unittest/util_test.cpp
@@ -13,25 +13,25 @@ namespace charls { namespace test {
 
 namespace {
 
-uint32_t log2_floor(uint32_t n) noexcept
+uint32_t log2_floor(const uint32_t n) noexcept
 {
     ASSERT(n != 0 && "log2 is not defined for 0");
     return 31 - countl_zero(n);
 }
 
-uint32_t max_value_to_bits_per_sample(uint32_t max_value) noexcept
+uint32_t max_value_to_bits_per_sample(const uint32_t max_value) noexcept
 {
     ASSERT(max_value > 0);
     return log2_floor(max_value) + 1;
 }
 
-void call_and_compare_log2_ceil(int32_t arg)
+void call_and_compare_log2_ceil(const int32_t arg)
 {
     const int32_t expected{static_cast<int32_t>(ceil(std::log2(arg)))};
     Assert::AreEqual(expected, log2_ceil(arg));
 }
 
-void call_and_compare_log2_floor(uint32_t arg)
+void call_and_compare_log2_floor(const uint32_t arg)
 {
     MSVC_WARNING_SUPPRESS_NEXT_LINE(26467) // cast from double to uint32 is safe. values always positive.
     const uint32_t expected{static_cast<uint32_t>(floor(std::log2(arg)))};


### PR DESCRIPTION
As CharLS now supports oversized image dimensions, the x86 build should check that the calculated estimated destination buffer size doesn't overflow.