### PR TITLE
Setup VISIBILITY_INLINES_HIDDEN cmake property on charls target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ foreach(header HEADERS)
 endforeach()
 
 set_target_properties(charls PROPERTIES CXX_VISIBILITY_PRESET hidden)
+set_target_properties(charls PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
 set_property(TARGET charls PROPERTY PUBLIC_HEADER ${HEADERS})
 
 target_sources(charls


### PR DESCRIPTION
Set VISIBILITY_INLINES_HIDDEN to 1 so that -fvisibility-inlines-hidden
is also passed on the gcc command line (-fvisibility=hidden is passed
thanks to CXX_VISIBILITY_PRESET).

At least on Debian system this allow hidding of c++ symbol:

  % c++filt _ZnwmPv
  operator new(unsigned long, void*)