### PR TITLE
Do not enforce exactly c++14 standard when building charls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,7 @@ option(BUILD_SHARED_LIBS "Will control if charls lib is build as shared lib/DLL 
 option(CHARLS_PEDANTIC_WARNINGS "Enable extra warnings and static analysis." OFF)
 option(CHARLS_TREAT_WARNING_AS_ERROR "Treat a warning as an error." OFF)
 
-# CharLS requires C++14 or newer.
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# CharLS is written in portable c++:
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Configure the supported C++ compilers: gcc, clang and MSVC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,8 @@ set_target_properties(charls PROPERTIES
                       SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_compile_definitions(charls PRIVATE CHARLS_LIBRARY_BUILD)
+# CharLS requires C++14 or newer.
+target_compile_features(charls PUBLIC cxx_std_14)
 
 set(HEADERS
     "include/charls/api_abi.h"


### PR DESCRIPTION
Per cmake documentation:

* https://cmake.org/cmake/help/git-stage/manual/cmake-compile-features.7.html#requiring-language-standards

For example, if C++ 11 features are used extensively in a project's
header files, then clients must use a compiler mode that is no less than
C++ 11. This can be requested with the code:

  target_compile_features(mylib PUBLIC cxx_std_11)

In this example, CMake will ensure the compiler is invoked in a mode of
at-least C++ 11 (or C++ 14, C++ 17, ...), adding flags such as
-std=gnu++11 if necessary. This applies to sources within mylib as well
as any dependents (that may include headers from mylib).