### PR TITLE
Enable -Wcast-align=strict and use void+static_cast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         -Wduplicated-cond
       )
   endif()
+  if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+      set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}
+        -Wcast-align=strict
+      )
+  endif()
 
   set(WARNINGS_AS_ERRORS_FLAG_COMPILER -Werror)
   set(WARNINGS_AS_ERRORS_FLAG_LINKER LINKER:--fatal-warnings)
@@ -91,7 +96,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       -Wextra # (-W is synonym)
       -Wnon-gcc
       -Wpedantic
-      -Walloca
       -Wcast-qual
       -Wformat=2
       -Wvla
@@ -125,6 +129,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0.2)
     set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}
       -Wno-undefined-func-template            # Ignore, linker will complain if final template code is not available.
+    )
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+    set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}
+      -Walloca
     )
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}
       -Wno-undefined-func-template            # Ignore, linker will complain if final template code is not available.
     )
+  endif()
   if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
     set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}
       -Walloca

--- a/src/color_transform.h
+++ b/src/color_transform.h
@@ -49,7 +49,7 @@ struct transform_hp1 final
 
         FORCE_INLINE triplet<T> operator()(const int v1, const int v2, const int v3) const noexcept
         {
-            return triplet<T>(v1 + v2 - Range / 2, v2, v3 + v2 - Range / 2);
+            return triplet<T>(v1 + v2 - range_ / 2, v2, v3 + v2 - range_ / 2);
         }
     };
 
@@ -57,13 +57,13 @@ struct transform_hp1 final
     {
         triplet<T> hp1;
         hp1.v2 = static_cast<T>(green);
-        hp1.v1 = static_cast<T>(red - green + Range / 2);
-        hp1.v3 = static_cast<T>(blue - green + Range / 2);
+        hp1.v1 = static_cast<T>(red - green + range_ / 2);
+        hp1.v3 = static_cast<T>(blue - green + range_ / 2);
         return hp1;
     }
 
 private:
-    static constexpr size_t Range = 1 << (sizeof(T) * 8);
+    static constexpr size_t range_{1 << (sizeof(T) * 8)};
 };
 
 
@@ -83,20 +83,20 @@ struct transform_hp2 final
         FORCE_INLINE triplet<T> operator()(const int v1, const int v2, const int v3) const noexcept
         {
             triplet<T> rgb;
-            rgb.R = static_cast<T>(v1 + v2 - Range / 2);                     // new R
+            rgb.R = static_cast<T>(v1 + v2 - range_ / 2);                     // new R
             rgb.G = static_cast<T>(v2);                                      // new G
-            rgb.B = static_cast<T>(v3 + ((rgb.R + rgb.G) >> 1) - Range / 2); // new B
+            rgb.B = static_cast<T>(v3 + ((rgb.R + rgb.G) >> 1) - range_ / 2); // new B
             return rgb;
         }
     };
 
     FORCE_INLINE triplet<T> operator()(const int red, const int green, const int blue) const noexcept
     {
-        return triplet<T>(red - green + Range / 2, green, blue - ((red + green) >> 1) - Range / 2);
+        return triplet<T>(red - green + range_ / 2, green, blue - ((red + green) >> 1) - range_ / 2);
     }
 
 private:
-    static constexpr size_t Range = 1 << (sizeof(T) * 8);
+    static constexpr size_t range_{1 << (sizeof(T) * 8)};
 };
 
 
@@ -115,11 +115,11 @@ struct transform_hp3 final
 
         FORCE_INLINE triplet<T> operator()(const int v1, const int v2, const int v3) const noexcept
         {
-            const int g = v1 - ((v3 + v2) >> 2) + Range / 4;
+            const int g = v1 - ((v3 + v2) >> 2) + range_ / 4;
             triplet<T> rgb;
-            rgb.R = static_cast<T>(v3 + g - Range / 2); // new R
+            rgb.R = static_cast<T>(v3 + g - range_ / 2); // new R
             rgb.G = static_cast<T>(g);                  // new G
-            rgb.B = static_cast<T>(v2 + g - Range / 2); // new B
+            rgb.B = static_cast<T>(v2 + g - range_ / 2); // new B
             return rgb;
         }
     };
@@ -127,14 +127,14 @@ struct transform_hp3 final
     FORCE_INLINE triplet<T> operator()(const int red, const int green, const int blue) const noexcept
     {
         triplet<T> hp3;
-        hp3.v2 = static_cast<T>(blue - green + Range / 2);
-        hp3.v3 = static_cast<T>(red - green + Range / 2);
-        hp3.v1 = static_cast<T>(green + ((hp3.v2 + hp3.v3) >> 2)) - Range / 4;
+        hp3.v2 = static_cast<T>(blue - green + range_ / 2);
+        hp3.v3 = static_cast<T>(red - green + range_ / 2);
+        hp3.v1 = static_cast<T>(green + ((hp3.v2 + hp3.v3) >> 2)) - range_ / 4;
         return hp3;
     }
 
 private:
-    static constexpr size_t Range = 1 << (sizeof(T) * 8);
+    static constexpr size_t range_{1 << (sizeof(T) * 8)};
 };
 
 } // namespace charls

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -31,7 +31,9 @@ void test_file16_bit_as12(const char* filename, const int offset, const rect_siz
     vector<uint8_t> uncompressed_data{read_file(filename, offset)};
     fix_endian(&uncompressed_data, little_endian_file);
 
-    auto* const p{reinterpret_cast<uint16_t*>(uncompressed_data.data())};
+    // Dynamic allocated memory is properly aligned: safe to use void*
+    void* const data{uncompressed_data.data()};
+    auto* const p{static_cast<uint16_t*>(data)};
     for (size_t i{}; i != uncompressed_data.size() / 2; ++i)
     {
         p[i] = p[i] >> 4;

--- a/unittest/util.cpp
+++ b/unittest/util.cpp
@@ -272,8 +272,10 @@ void test_compliance(const vector<uint8_t>& encoded_source, const vector<uint8_t
         }
         else
         {
-            const auto* source16 = reinterpret_cast<const uint16_t*>(uncompressed_source.data());
-            const auto* destination16 = reinterpret_cast<const uint16_t*>(destination.data());
+            const void* data{uncompressed_source.data()};
+            const auto* source16{static_cast<const uint16_t*>(data)};
+            data = destination.data();
+            const auto* destination16{static_cast<const uint16_t*>(data)};
 
             for (size_t i{}; i != uncompressed_source.size() / 2; ++i)
             {


### PR DESCRIPTION
CharLS is cross-platform. -Wcast-align=strict will always warn for alignement issues, even when current platform can handle it (for example x86)
Use void*+static_cast to increase alignement of dynamic allocated memory.