### PR TITLE
Add a new encoder option to write APP8 marker

### DIFF
--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -87,7 +87,8 @@ enum charls_encoding_options
     CHARLS_ENCODING_OPTIONS_NONE = 0,
     CHARLS_ENCODING_OPTIONS_EVEN_DESTINATION_SIZE = 1,
     CHARLS_ENCODING_OPTIONS_INCLUDE_VERSION_NUMBER = 2,
-    CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI = 4
+    CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI = 4,
+    CHARLS_ENCODING_OPTIONS_INCLUDE_COLOR_TRANSFORM_SEGMENT = 8
 };
 
 enum charls_color_transformation
@@ -494,7 +495,13 @@ enum class encoding_options
     /// Most users of this codec are aware of this problem and have implemented a work-around.
     /// This option is default enabled. Will not be default enabled in the next major version upgrade.
     /// </summary>
-    include_pc_parameters_jai = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI
+    include_pc_parameters_jai = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI,
+
+    /// <summary>
+    /// Writes explicitly an APP8 marker (`mrfx`) even in case where no color
+    /// transformation is specified.
+    /// </summary>
+    include_color_transform_segment = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_COLOR_TRANSFORM_SEGMENT
 };
 
 constexpr encoding_options operator|(const encoding_options lhs, const encoding_options rhs) noexcept

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -67,7 +67,8 @@ struct charls_jpegls_encoder final
     {
         constexpr charls::encoding_options all_options = encoding_options::even_destination_size |
                                                          encoding_options::include_version_number |
-                                                         encoding_options::include_pc_parameters_jai;
+                                                         encoding_options::include_pc_parameters_jai |
+                                                         encoding_options::include_color_transform_segment;
         check_argument(encoding_options >= encoding_options::none && encoding_options <= all_options,
                        jpegls_errc::invalid_argument_encoding_options);
 
@@ -178,7 +179,7 @@ struct charls_jpegls_encoder final
             writer_.write_jpegls_preset_parameters_segment(frame_info_.height, frame_info_.width);
         }
 
-        if (color_transformation_ != charls::color_transformation::none)
+        if (color_transformation_ != charls::color_transformation::none || has_option(encoding_options::include_color_transform_segment))
         {
             if (UNLIKELY(!(frame_info_.bits_per_sample == 8 || frame_info_.bits_per_sample == 16)))
                 throw_jpegls_error(jpegls_errc::bit_depth_for_transform_not_supported);

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -1398,7 +1398,7 @@ public:
         jpegls_encoder encoder;
 
         assert_expect_exception(jpegls_errc::invalid_argument_encoding_options,
-                                [&encoder] { encoder.encoding_options(static_cast<encoding_options>(8)); });
+                                [&encoder] { encoder.encoding_options(static_cast<encoding_options>(16)); });
     }
 
     TEST_METHOD(large_image_contains_lse_for_oversize_image_dimension) // NOLINT


### PR DESCRIPTION
This new option will force writing of a color transformation segment
even in the case where no color transformation is specified.