### PR TITLE
Add support to write and read APPn markers

### DIFF
--- a/include/charls/annotations.h
+++ b/include/charls/annotations.h
@@ -61,6 +61,8 @@
 #define CHARLS_ATTRIBUTE(a)
 #endif
 
+// The GCC access attribute can be used to annotate memory access for a pointer.
+// Typical usage is: access (access-mode, ref-index, size-index)
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 10
 #define CHARLS_ATTRIBUTE_ACCESS(a) __attribute__(a)
 #else

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -622,7 +622,7 @@ public:
     /// The callback can throw an exception to abort the decoding process.
     /// This abort will be returned as a callback_failed error code.
     /// </remarks>
-    /// <param name="comment_handler">Function object to the comment handler.</param>
+    /// <param name="application_data_handler">Function object to the application data handler.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_decoder& at_application_data(
         std::function<void(int32_t application_data_id, const void* data, size_t size)> application_data_handler)
@@ -662,7 +662,7 @@ private:
         }
     }
 
-    static int32_t CHARLS_API_CALLING_CONVENTION at_application_data_callback(int32_t application_data_id, const void* data,
+    static int32_t CHARLS_API_CALLING_CONVENTION at_application_data_callback(const int32_t application_data_id, const void* data,
                                                                               const size_t size, void* user_context) noexcept
     {
         try

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -198,6 +198,23 @@ charls_jpegls_decoder_at_comment(CHARLS_IN charls_jpegls_decoder* decoder, charl
                                  void* user_context) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull(1)));
 
 
+/// <summary>
+/// Will install a function that will be called when an application data (APPn) segment is found.
+/// </summary>
+/// <remarks>
+/// Pass NULL or nullptr to uninstall the callback function.
+/// The callback should return 0 if there are no errors.
+/// It can return a non-zero value to abort decoding with a callback_failed error code.
+/// </remarks>
+/// <param name="decoder">Reference to the decoder instance.</param>
+/// <param name="handler">Function pointer to the callback function.</param>
+/// <param name="user_context">Free to use context data that will be provided to the callback function.</param>
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_jpegls_decoder_at_application_data(CHARLS_IN charls_jpegls_decoder* decoder,
+                                          charls_at_application_data_handler handler, void* user_context) CHARLS_NOEXCEPT
+    CHARLS_ATTRIBUTE((nonnull(1)));
+
+
 // Note: The 3 methods below are considered obsolete and will be removed in the next major update.
 
 /// <summary>
@@ -597,6 +614,25 @@ public:
         return *this;
     }
 
+    /// <summary>
+    /// Will install a function that will be called when an application data (APPn) segment is found.
+    /// </summary>
+    /// <remarks>
+    /// Pass a nullptr to uninstall the callback function.
+    /// The callback can throw an exception to abort the decoding process.
+    /// This abort will be returned as a callback_failed error code.
+    /// </remarks>
+    /// <param name="comment_handler">Function object to the comment handler.</param>
+    /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
+    jpegls_decoder& at_application_data(
+        std::function<void(int32_t application_data_id, const void* data, size_t size)> application_data_handler)
+    {
+        application_data_handler_ = std::move(application_data_handler);
+        check_jpegls_errc(charls_jpegls_decoder_at_application_data(
+            decoder_.get(), application_data_handler_ ? &at_application_data_callback : nullptr, this));
+        return *this;
+    }
+
 private:
     CHARLS_CHECK_RETURN static charls_jpegls_decoder* create_decoder()
     {
@@ -626,12 +662,27 @@ private:
         }
     }
 
+    static int32_t CHARLS_API_CALLING_CONVENTION at_application_data_callback(int32_t application_data_id, const void* data,
+                                                                              const size_t size, void* user_context) noexcept
+    {
+        try
+        {
+            static_cast<jpegls_decoder*>(user_context)->application_data_handler_(application_data_id, data, size);
+            return 0;
+        }
+        catch (...)
+        {
+            return 1; // will trigger jpegls_errc::callback_failed.
+        }
+    }
+
     std::unique_ptr<charls_jpegls_decoder, void (*)(const charls_jpegls_decoder*)> decoder_{create_decoder(),
                                                                                             &destroy_decoder};
     bool spiff_header_has_value_{};
     charls::spiff_header spiff_header_{};
     charls::frame_info frame_info_{};
     std::function<void(const void*, size_t)> comment_handler_{};
+    std::function<void(int32_t, const void*, size_t)> application_data_handler_{};
 };
 
 } // namespace charls

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -188,7 +188,7 @@ charls_jpegls_encoder_write_spiff_entry(CHARLS_IN charls_jpegls_encoder* encoder
 /// Writes a comment (COM) segment to the destination.
 /// </summary>
 /// <remarks>
-/// Function should be called before decoding the image.
+/// Function should be called before encoding the image data.
 /// </remarks>
 /// <param name="encoder">Reference to the encoder instance.</param>
 /// <param name="comment">The 'comment' bytes. Application specific, usually human readable string.</param>
@@ -199,6 +199,24 @@ CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLI
 charls_jpegls_encoder_write_comment(CHARLS_IN charls_jpegls_encoder* encoder,
                                     CHARLS_IN_READS_BYTES(comment_size_bytes) const void* comment,
                                     size_t comment_size_bytes) CHARLS_NOEXCEPT;
+
+/// <summary>
+/// Writes an application data (APPn) segment to the destination.
+/// </summary>
+/// <remarks>
+/// Function should be called before encoding the image data.
+/// </remarks>
+/// <param name="encoder">Reference to the encoder instance.</param>
+/// <param name="application_data_id">The ID of the application data segment in the range [0..15].</param>
+/// <param name="application_data">The 'application data' bytes. Application specific.</param>
+/// <param name="application_data_size_bytes">The size in bytes of the comment [0-65533].</param>
+/// <returns>The result of the operation: success or a failure code.</returns>
+CHARLS_ATTRIBUTE_ACCESS((access(read_only, 3, 4)))
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_jpegls_encoder_write_application_data(CHARLS_IN charls_jpegls_encoder* encoder,
+                                             int32_t application_data_id,
+                                             CHARLS_IN_READS_BYTES(application_data_size_bytes) const void* application_data,
+                                             size_t application_data_size_bytes) CHARLS_NOEXCEPT;
 
 /// <summary>
 /// Encodes the passed buffer with the source image data to the destination.
@@ -488,6 +506,21 @@ public:
     jpegls_encoder& write_comment(CHARLS_IN_READS_BYTES(size) const void* comment, const size_t size)
     {
         check_jpegls_errc(charls_jpegls_encoder_write_comment(encoder_.get(), comment, size));
+        return *this;
+    }
+
+    /// <summary>
+    /// Writes a JPEG application data segment to the JPEG-LS bit stream.
+    /// </summary>
+    /// <param name="application_data_id">The ID of the application data segment.</param>
+    /// <param name="application_data">The bytes of the application data: application specific.</param>
+    /// <param name="size">The size of the comment in bytes.</param>
+    CHARLS_ATTRIBUTE_ACCESS((access(read_only, 2, 3)))
+    jpegls_encoder& write_application_data(const int32_t application_data_id,
+                                           CHARLS_IN_READS_BYTES(size) const void* application_data, const size_t size)
+    {
+        check_jpegls_errc(
+            charls_jpegls_encoder_write_application_data(encoder_.get(), application_data_id, application_data, size));
         return *this;
     }
 

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -388,7 +388,8 @@ enum class CHARLS_NO_DISCARD jpegls_errc
     invalid_parameter_height = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_HEIGHT,
 
     /// <summary>
-    /// This error is returned when the stream contains a component count parameter outside the range [1,255] for SOF or [1,4] for SOS.
+    /// This error is returned when the stream contains a component count parameter outside the range [1,255] for SOF or
+    /// [1,4] for SOS.
     /// </summary>
     invalid_parameter_component_count = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COMPONENT_COUNT,
 
@@ -1121,12 +1122,27 @@ struct JlsParameters
 /// handler.</param>
 using charls_at_comment_handler = int32_t(CHARLS_API_CALLING_CONVENTION*)(const void* data, size_t size, void* user_context);
 
+/// <summary>
+/// Function definition for a callback handler that will be called when an application data (APPn) segment is found.
+/// </summary>
+/// <remarks>
+/// </remarks>
+/// <param name="application_data_id">Id of the APPn segment [0 .. 15].</param>
+/// <param name="data">Reference to the data of the APPn segment.</param>
+/// <param name="size">Size in bytes of the data of the APPn segment.</param>
+/// <param name="user_context">Free to use context information that can be set during the installation of the
+/// handler.</param>
+using charls_at_application_data_handler = int32_t(CHARLS_API_CALLING_CONVENTION*)(int32_t application_data_id,
+                                                                                   const void* data, size_t size,
+                                                                                   void* user_context);
+
 namespace charls {
 
 using spiff_header = charls_spiff_header;
 using frame_info = charls_frame_info;
 using jpegls_pc_parameters = charls_jpegls_pc_parameters;
 using at_comment_handler = charls_at_comment_handler;
+using at_application_data_handler = charls_at_application_data_handler;
 
 static_assert(sizeof(spiff_header) == 40, "size of struct is incorrect, check padding settings");
 static_assert(sizeof(frame_info) == 16, "size of struct is incorrect, check padding settings");
@@ -1136,7 +1152,10 @@ static_assert(sizeof(jpegls_pc_parameters) == 20, "size of struct is incorrect, 
 
 #else
 
-typedef void(CHARLS_API_CALLING_CONVENTION* charls_at_comment_handler)(const void* data, size_t size, void* user_context);
+typedef int32_t(CHARLS_API_CALLING_CONVENTION* charls_at_comment_handler)(const void* data, size_t size, void* user_context);
+typedef int32_t(CHARLS_API_CALLING_CONVENTION* charls_at_application_data_handler)(int32_t application_data_id,
+                                                                                   const void* data, size_t size,
+                                                                                   void* user_context);
 
 typedef struct charls_spiff_header charls_spiff_header;
 typedef struct charls_frame_info charls_frame_info;

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -86,7 +86,7 @@ struct charls_jpegls_decoder final
         if (stride == 0)
         {
             return checked_mul(checked_mul(checked_mul(info.component_count, info.height), info.width),
-                                    bit_to_byte_count(info.bits_per_sample));
+                               bit_to_byte_count(info.bits_per_sample));
         }
 
         switch (interleave_mode())
@@ -103,9 +103,14 @@ struct charls_jpegls_decoder final
         return 0;
     }
 
-    void at_comment(const at_comment_handler handler, void* user_context) noexcept
+    void at_comment(const callback_function<at_comment_handler> at_comment_callback) noexcept
     {
-        reader_.at_comment(handler, user_context);
+        reader_.at_comment(at_comment_callback);
+    }
+
+    void at_application_data(const callback_function<at_application_data_handler> at_application_data_callback) noexcept
+    {
+        reader_.at_application_data(at_application_data_callback);
     }
 
     void decode(const byte_span destination, const size_t stride)
@@ -298,7 +303,20 @@ USE_DECL_ANNOTATIONS jpegls_errc CHARLS_API_CALLING_CONVENTION charls_jpegls_dec
     charls_jpegls_decoder* decoder, const at_comment_handler handler, void* user_context) noexcept
 try
 {
-    check_pointer(decoder)->at_comment(handler, user_context);
+    check_pointer(decoder)->at_comment({handler, user_context});
+    return jpegls_errc::success;
+}
+catch (...)
+{
+    return to_jpegls_errc();
+}
+
+
+USE_DECL_ANNOTATIONS jpegls_errc CHARLS_API_CALLING_CONVENTION charls_jpegls_decoder_at_application_data(
+    charls_jpegls_decoder* decoder, const charls_at_application_data_handler handler, void* user_context) noexcept
+try
+{
+    check_pointer(decoder)->at_application_data({handler, user_context});
     return jpegls_errc::success;
 }
 catch (...)

--- a/src/constants.h
+++ b/src/constants.h
@@ -22,6 +22,8 @@ constexpr int maximum_component_count{255};
 constexpr int minimum_bits_per_sample{2};
 constexpr int maximum_bits_per_sample{16};
 constexpr int maximum_near_lossless{255};
+constexpr int32_t minimum_application_data_id{0};
+constexpr int32_t maximum_application_data_id{15};
 
 constexpr int max_k_value{16}; // This is an implementation limit (theoretical limit is 32)
 

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -811,7 +811,7 @@ void jpeg_stream_reader::frame_info_width(const uint32_t width)
 }
 
 
-void jpeg_stream_reader::call_application_data_callback(const jpeg_marker_code marker_code)
+void jpeg_stream_reader::call_application_data_callback(const jpeg_marker_code marker_code) const
 {
     if (at_application_data_callback_.handler &&
         UNLIKELY(static_cast<bool>(at_application_data_callback_.handler(

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -32,6 +32,11 @@ constexpr bool is_restart_marker_code(const jpeg_marker_code marker_code) noexce
            static_cast<uint8_t>(marker_code) < jpeg_restart_marker_base + jpeg_restart_marker_range;
 }
 
+constexpr int32_t to_application_data_id(const jpeg_marker_code marker_code) noexcept
+{
+    return static_cast<int32_t>(marker_code) - static_cast<int32_t>(jpeg_marker_code::application_data0);
+}
+
 } // namespace
 
 
@@ -312,7 +317,7 @@ void jpeg_stream_reader::read_marker_segment(const jpeg_marker_code marker_code,
     case jpeg_marker_code::application_data13:
     case jpeg_marker_code::application_data14:
     case jpeg_marker_code::application_data15:
-        read_application_data_segment();
+        read_application_data_segment(marker_code);
         break;
 
     // Other tags not supported (among which DNL)
@@ -377,17 +382,18 @@ void jpeg_stream_reader::read_start_of_frame_segment()
 
 void jpeg_stream_reader::read_comment_segment()
 {
-    if (comment_handler_ &&
-        UNLIKELY(static_cast<bool>(comment_handler_(segment_data_.empty() ? nullptr : position_, segment_data_.size(),
-                                                    comment_handler_user_context_))))
+    if (at_comment_callback_.handler &&
+        UNLIKELY(static_cast<bool>(at_comment_callback_.handler(segment_data_.empty() ? nullptr : position_,
+                                                                segment_data_.size(), at_comment_callback_.user_context))))
         throw_jpegls_error(jpegls_errc::callback_failed);
 
     skip_remaining_segment_data();
 }
 
 
-void jpeg_stream_reader::read_application_data_segment() noexcept
+void jpeg_stream_reader::read_application_data_segment(const jpeg_marker_code marker_code)
 {
+    call_application_data_callback(marker_code);
     skip_remaining_segment_data();
 }
 
@@ -636,6 +642,8 @@ void jpeg_stream_reader::check_segment_size(const size_t expected_size) const
 
 void jpeg_stream_reader::try_read_application_data8_segment(spiff_header* header, bool* spiff_header_found)
 {
+    call_application_data_callback(jpeg_marker_code::application_data8);
+
     if (spiff_header_found)
     {
         ASSERT(header);
@@ -800,6 +808,16 @@ void jpeg_stream_reader::frame_info_width(const uint32_t width)
         throw_jpegls_error(jpegls_errc::invalid_parameter_width);
 
     frame_info_.width = width;
+}
+
+
+void jpeg_stream_reader::call_application_data_callback(const jpeg_marker_code marker_code)
+{
+    if (at_application_data_callback_.handler &&
+        UNLIKELY(static_cast<bool>(at_application_data_callback_.handler(
+            to_application_data_id(marker_code), segment_data_.empty() ? nullptr : position_, segment_data_.size(),
+            at_application_data_callback_.user_context))))
+        throw_jpegls_error(jpegls_errc::callback_failed);
 }
 
 } // namespace charls

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -120,7 +120,7 @@ private:
     void check_frame_info() const;
     void frame_info_height(uint32_t height);
     void frame_info_width(uint32_t width);
-    void call_application_data_callback(const jpeg_marker_code marker_code);
+    void call_application_data_callback(jpeg_marker_code marker_code) const;
 
     enum class state
     {

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -55,10 +55,14 @@ public:
         rect_ = rect;
     }
 
-    void at_comment(const at_comment_handler handler, void* user_context) noexcept
+    void at_comment(const callback_function<at_comment_handler> at_comment_callback) noexcept
     {
-        comment_handler_ = handler;
-        comment_handler_user_context_ = user_context;
+        at_comment_callback_ = at_comment_callback;
+    }
+
+    void at_application_data(const callback_function<at_application_data_handler> at_application_data_callback) noexcept
+    {
+        at_application_data_callback_ = at_application_data_callback;
     }
 
     void read_header(spiff_header* header = nullptr, bool* spiff_header_found = nullptr);
@@ -100,7 +104,7 @@ private:
     void read_start_of_frame_segment();
     void read_start_of_scan_segment();
     void read_comment_segment();
-    void read_application_data_segment() noexcept;
+    void read_application_data_segment(jpeg_marker_code marker_code);
     void read_preset_parameters_segment();
     void read_preset_coding_parameters();
     void oversize_image_dimension();
@@ -116,6 +120,7 @@ private:
     void check_frame_info() const;
     void frame_info_height(uint32_t height);
     void frame_info_width(uint32_t width);
+    void call_application_data_callback(const jpeg_marker_code marker_code);
 
     enum class state
     {
@@ -138,8 +143,8 @@ private:
     JlsRect rect_{};
     std::vector<uint8_t> component_ids_;
     state state_{};
-    at_comment_handler comment_handler_{};
-    void* comment_handler_user_context_{};
+    callback_function<at_comment_handler> at_comment_callback_{};
+    callback_function<at_application_data_handler> at_application_data_callback_{};
 };
 
 } // namespace charls

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -131,7 +131,18 @@ void jpeg_stream_writer::write_color_transform_segment(const color_transformatio
 void jpeg_stream_writer::write_comment_segment(const const_byte_span comment)
 {
     write_segment_header(jpeg_marker_code::comment, comment.size());
-    write_bytes(comment.data(), comment.size());
+    write_bytes(comment);
+}
+
+
+void jpeg_stream_writer::write_application_data_segment(const int32_t application_data_id, const const_byte_span application_data)
+{
+    ASSERT(application_data_id >= minimum_application_data_id && application_data_id <= maximum_application_data_id);
+
+    write_segment_header(
+        static_cast<jpeg_marker_code>(static_cast<int32_t>(jpeg_marker_code::application_data0) + application_data_id),
+        application_data.size());
+    write_bytes(application_data);
 }
 
 

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -56,6 +56,13 @@ public:
     void write_comment_segment(const_byte_span comment);
 
     /// <summary>
+    /// Writes an application data (APPn) segment.
+    /// </summary>
+    /// <param name="application_data_id">The ID of the application data segment.</param>
+    /// <param name="application_data">The bytes of the application data.</param>
+    void write_application_data_segment(int32_t application_data_id, const_byte_span application_data);
+
+    /// <summary>
     /// Writes a JPEG-LS preset parameters (LSE) segment.
     /// </summary>
     /// <param name="preset_coding_parameters">Parameters to write into the JPEG-LS preset segment.</param>
@@ -169,6 +176,11 @@ private:
         const UnsignedIntType big_endian_value{value};
 #endif
         write_bytes(&big_endian_value, sizeof big_endian_value);
+    }
+
+    void write_bytes(const const_byte_span data) noexcept
+    {
+        write_bytes(data.data(), data.size());
     }
 
     void write_bytes(CHARLS_IN_READS_BYTES(size) const void* data, const size_t size) noexcept

--- a/src/util.h
+++ b/src/util.h
@@ -274,6 +274,14 @@ struct quad final : triplet<SampleType>
 };
 
 
+template<typename Callback>
+struct callback_function final
+{
+    Callback handler;
+    void* user_context;
+};
+
+
 // C++23 comes with std::byteswap. Use our own byte_swap implementation for now.
 
 // A simple overload with uint64_t\uint32_t doesn't work for macOS. size_t is not the same type as uint64_t.

--- a/unittest/charls_jpegls_decoder_test.cpp
+++ b/unittest/charls_jpegls_decoder_test.cpp
@@ -182,6 +182,12 @@ public:
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
 
+    TEST_METHOD(at_application_data_nullptr) // NOLINT
+    {
+        const auto error{charls_jpegls_decoder_at_application_data(nullptr, nullptr, nullptr)};
+        Assert::AreEqual(jpegls_errc::invalid_argument, error);
+    }
+
 private:
     static charls_jpegls_decoder* get_initialized_decoder()
     {

--- a/unittest/charls_jpegls_encoder_test.cpp
+++ b/unittest/charls_jpegls_encoder_test.cpp
@@ -165,6 +165,13 @@ public:
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
 
+    TEST_METHOD(write_application_data_nullptr) // NOLINT
+    {
+        constexpr array<uint8_t, 10> buffer{};
+        const auto error{charls_jpegls_encoder_write_application_data(nullptr, 0, buffer.data(), buffer.size())};
+        Assert::AreEqual(jpegls_errc::invalid_argument, error);
+    }
+
     TEST_METHOD(rewind_nullptr) // NOLINT
     {
         const auto error{charls_jpegls_encoder_rewind(nullptr)};


### PR DESCRIPTION
APPn markers are application specific markers. They can be used to store additional information in the JPEG-LS byte stream. Until know it was not possible to add these kind of markers from "user" code or get a notification when such a marker was present in the JPEG-LS stream.