### PR TITLE
Fix off-by-one function attribute declaration

### DIFF
--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -515,7 +515,7 @@ public:
     /// <param name="application_data_id">The ID of the application data segment.</param>
     /// <param name="application_data">The bytes of the application data: application specific.</param>
     /// <param name="size">The size of the comment in bytes.</param>
-    CHARLS_ATTRIBUTE_ACCESS((access(read_only, 2, 3)))
+    CHARLS_ATTRIBUTE_ACCESS((access(read_only, 3, 4)))
     jpegls_encoder& write_application_data(const int32_t application_data_id,
                                            CHARLS_IN_READS_BYTES(size) const void* application_data, const size_t size)
     {


### PR DESCRIPTION
This should fix the following compilation error on gcc-10:

In file included from charls/src/charls_jpegls_encoder.cpp:4:
charls/include/charls/charls_jpegls_encoder.h:520:119: error: attribute ‘access(read_only, 2, 3)’ positional argument 1 references non-pointer argument type ‘int32_t’ {aka ‘int’}
  520 |                                            CHARLS_IN_READS_BYTES(size) const void* application_data, const size_t size)
      |