### PR TITLE
Use GCC 10 on the CI server

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,10 +196,10 @@ jobs:
         CXX: g++-9
         Shared: 'OFF'
 
-      GCC-9 Release Shared:
+      GCC-10 Release Shared:
         buildType: Release
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
         Shared: 'ON'
 
       Clang-10 Debug:


### PR DESCRIPTION
The latest CI build agent also supports GCC 10. Update one of the build configurations to use GCC 10 to get beter compiler coverage.