### PR TITLE
Add method to validate SPIFF header

### DIFF
--- a/include/charls/annotations.h
+++ b/include/charls/annotations.h
@@ -5,10 +5,9 @@
 
 #ifdef _MSC_VER
 
+// Use the Microsoft Source Code Annotation Language when compiling with the MSVC compiler.
 #include <sal.h>
 
-// Note: these macro's are not prefixed with CHARLS_, as these macro's are used for function parameters.
-//       and long macro's would make the code harder to read.
 #define CHARLS_IN _In_
 #define CHARLS_IN_OPT _In_opt_
 #define CHARLS_IN_Z _In_z_
@@ -30,6 +29,7 @@
 
 #else
 
+// For other compilers use empty macros.
 #define CHARLS_IN
 #define CHARLS_IN_OPT
 #define CHARLS_IN_Z

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -55,6 +55,7 @@ enum charls_jpegls_errc
     CHARLS_JPEGLS_ERRC_RESTART_MARKER_NOT_FOUND = 26,
     CHARLS_JPEGLS_ERRC_CALLBACK_FAILED = 27,
     CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND = 28,
+    CHARLS_JPEGLS_ERRC_INVALID_SPIFF_HEADER = 29,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_WIDTH = 100,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_HEIGHT = 101,
     CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COMPONENT_COUNT = 102,
@@ -322,6 +323,11 @@ enum class CHARLS_NO_DISCARD jpegls_errc
     end_of_image_marker_not_found = impl::CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND,
 
     /// <summary>
+    /// This error is returned when the SPIFF header is invalid.
+    /// </summary>
+    invalid_spiff_header = impl::CHARLS_JPEGLS_ERRC_INVALID_SPIFF_HEADER,
+
+    /// <summary>
     /// The argument for the width parameter is outside the range [1, 65535].
     /// </summary>
     invalid_argument_width = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_WIDTH,
@@ -562,6 +568,7 @@ enum class spiff_profile_id : int32_t
 {
     /// <summary>
     /// No profile identified.
+    /// This is the only valid option for JPEG-LS encoded images.
     /// </summary>
     none = impl::CHARLS_SPIFF_PROFILE_ID_NONE,
 
@@ -593,6 +600,7 @@ enum class spiff_color_space : int32_t
 {
     /// <summary>
     /// Bi-level image. Each image sample is one bit: 0 = white and 1 = black.
+    /// This option is not valid for JPEG-LS encoded images.
     /// </summary>
     bi_level_black = impl::CHARLS_SPIFF_COLOR_SPACE_BI_LEVEL_BLACK,
 
@@ -654,6 +662,7 @@ enum class spiff_color_space : int32_t
 
     /// <summary>
     /// Bi-level image. Each image sample is one bit: 1 = white and 0 = black.
+    /// This option is not valid for JPEG-LS encoded images.
     /// </summary>
     bi_level_white = impl::CHARLS_SPIFF_COLOR_SPACE_BI_LEVEL_WHITE
 };
@@ -694,7 +703,8 @@ enum class spiff_compression_type : int32_t
     jpeg = impl::CHARLS_SPIFF_COMPRESSION_TYPE_JPEG,
 
     /// <summary>
-    /// ISO/IEC 14495-1 or ISO/IEC 14495-2, commonly known as JPEG-LS. (extension defined in ISO/IEC 14495-1)
+    /// ISO/IEC 14495-1 or ISO/IEC 14495-2, commonly known as JPEG-LS. (extension defined in ISO/IEC 14495-1).
+    /// This is the only valid option for JPEG-LS encoded images.
     /// </summary>
     jpeg_ls = impl::CHARLS_SPIFF_COMPRESSION_TYPE_JPEG_LS
 };

--- a/include/charls/validate_spiff_header.h
+++ b/include/charls/validate_spiff_header.h
@@ -1,0 +1,18 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "public_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION charls_validate_spiff_header(
+    CHARLS_IN const charls_spiff_header* spiff_header, CHARLS_IN const charls_frame_info* frame_info) CHARLS_NOEXCEPT
+    CHARLS_ATTRIBUTE((nonnull));
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ set(HEADERS
     "include/charls/charls_jpegls_encoder.h"
     "include/charls/jpegls_error.h"
     "include/charls/public_types.h"
+    "include/charls/validate_spiff_header.h"
     "include/charls/version.h"
 )
 foreach(header HEADERS)
@@ -106,6 +107,7 @@ target_sources(charls
     "${CMAKE_CURRENT_LIST_DIR}/process_line.h"
     "${CMAKE_CURRENT_LIST_DIR}/scan.h"
     "${CMAKE_CURRENT_LIST_DIR}/util.h"
+    "${CMAKE_CURRENT_LIST_DIR}/validate_spiff_header.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/version.cpp"
 )
 

--- a/src/CharLS.vcxproj
+++ b/src/CharLS.vcxproj
@@ -163,6 +163,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="validate_spiff_header.cpp" />
     <ClCompile Include="version.cpp" />
     <ClCompile Include="charls_jpegls_decoder.cpp" />
     <ClCompile Include="jpegls.cpp" />
@@ -179,6 +180,7 @@
     <ClInclude Include="..\include\charls\charls_jpegls_encoder.h" />
     <ClInclude Include="..\include\charls\jpegls_error.h" />
     <ClInclude Include="..\include\charls\public_types.h" />
+    <ClInclude Include="..\include\charls\validate_spiff_header.h" />
     <ClInclude Include="..\include\charls\version.h" />
     <ClInclude Include="coding_parameters.h" />
     <ClInclude Include="color_transform.h" />

--- a/src/CharLS.vcxproj.filters
+++ b/src/CharLS.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="version.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="validate_spiff_header.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="context_regular_mode.h">
@@ -109,6 +112,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="conditional_static_cast.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\charls\validate_spiff_header.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -78,50 +78,53 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
         return "The encoding options argument has an invalid value";
 
     case jpegls_errc::start_of_image_marker_not_found:
-        return "Invalid JPEG-LS stream, first JPEG marker is not a Start Of Image (SOI) marker";
+        return "Invalid JPEG-LS stream: first JPEG marker is not a Start Of Image (SOI) marker";
 
     case jpegls_errc::unexpected_marker_found:
-        return "Invalid JPEG-LS stream, unexpected marker found";
+        return "Invalid JPEG-LS stream: unexpected marker found";
 
     case jpegls_errc::invalid_marker_segment_size:
-        return "Invalid JPEG-LS stream, segment size of a marker segment is invalid";
+        return "Invalid JPEG-LS stream: segment size of a marker segment is invalid";
 
     case jpegls_errc::duplicate_start_of_image_marker:
-        return "Invalid JPEG-LS stream, more then one Start Of Image (SOI) marker";
+        return "Invalid JPEG-LS stream: more then one Start Of Image (SOI) marker";
 
     case jpegls_errc::duplicate_start_of_frame_marker:
-        return "Invalid JPEG-LS stream, more then one Start Of Frame (SOF) marker";
+        return "Invalid JPEG-LS stream: more then one Start Of Frame (SOF) marker";
 
     case jpegls_errc::duplicate_component_id_in_sof_segment:
-        return "Invalid JPEG-LS stream, duplicate component identifier in the (SOF) segment";
+        return "Invalid JPEG-LS stream: duplicate component identifier in the (SOF) segment";
 
     case jpegls_errc::unexpected_end_of_image_marker:
-        return "Invalid JPEG-LS stream, unexpected End Of Image (EOI) marker";
+        return "Invalid JPEG-LS stream: unexpected End Of Image (EOI) marker";
 
     case jpegls_errc::invalid_jpegls_preset_parameter_type:
-        return "Invalid JPEG-LS stream, JPEG-LS preset parameters segment contains an invalid type";
+        return "Invalid JPEG-LS stream: JPEG-LS preset parameters segment contains an invalid type";
 
     case jpegls_errc::jpegls_preset_extended_parameter_type_not_supported:
-        return "Unsupported JPEG-LS stream, JPEG-LS preset parameters segment contains an JPEG-LS Extended (ISO/IEC "
+        return "Unsupported JPEG-LS stream: JPEG-LS preset parameters segment contains an JPEG-LS Extended (ISO/IEC "
                "14495-2) type";
 
     case jpegls_errc::missing_end_of_spiff_directory:
-        return "Invalid JPEG-LS stream, SPIFF header without End Of Directory (EOD) entry";
+        return "Invalid JPEG-LS stream: SPIFF header without End Of Directory (EOD) entry";
 
     case jpegls_errc::unexpected_restart_marker:
-        return "Invalid JPEG-LS stream, restart (RTSm) marker found outside encoded entropy data";
+        return "Invalid JPEG-LS stream: restart (RTSm) marker found outside encoded entropy data";
 
     case jpegls_errc::restart_marker_not_found:
-        return "Invalid JPEG-LS stream, missing expected restart (RTSm) marker";
+        return "Invalid JPEG-LS stream: missing expected restart (RTSm) marker";
 
     case jpegls_errc::callback_failed:
         return "Callback function returned a failure";
 
     case jpegls_errc::end_of_image_marker_not_found:
-        return "Invalid JPEG-LS stream, missing End Of Image (EOI) marker";
+        return "Invalid JPEG-LS stream: missing End Of Image (EOI) marker";
+
+    case jpegls_errc::invalid_spiff_header:
+        return "Invalid JPEG-LS stream: invalid SPIFF header";
 
     case jpegls_errc::invalid_parameter_bits_per_sample:
-        return "Invalid JPEG-LS stream, The bit per sample (sample precision) parameter is not in the range [2, 16]";
+        return "Invalid JPEG-LS stream: the bit per sample (sample precision) parameter is not in the range [2, 16]";
 
     case jpegls_errc::parameter_value_not_supported:
         return "The JPEG-LS stream is encoded with a parameter value that is not supported by the CharLS decoder";
@@ -148,13 +151,13 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
         return "The color transform is not supported";
 
     case jpegls_errc::encoding_not_supported:
-        return "Invalid JPEG-LS stream, the JPEG stream is not encoded with the JPEG-LS algorithm";
+        return "Invalid JPEG-LS stream: the JPEG stream is not encoded with the JPEG-LS algorithm";
 
     case jpegls_errc::unknown_jpeg_marker_found:
-        return "Invalid JPEG-LS stream, an unknown JPEG marker code was found";
+        return "Invalid JPEG-LS stream: an unknown JPEG marker code was found";
 
     case jpegls_errc::jpeg_marker_start_byte_not_found:
-        return "Invalid JPEG-LS stream, the leading start byte (0xFF) for a JPEG marker was not found";
+        return "Invalid JPEG-LS stream: the leading start byte (0xFF) for a JPEG marker was not found";
 
     case jpegls_errc::not_enough_memory:
         return "No memory could be allocated for an internal buffer";
@@ -163,22 +166,22 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
         return "An unexpected internal failure occurred";
 
     case jpegls_errc::invalid_parameter_width:
-        return "Invalid JPEG-LS stream, the width (Number of samples per line) is already defined";
+        return "Invalid JPEG-LS stream: the width (Number of samples per line) is already defined";
 
     case jpegls_errc::invalid_parameter_height:
-        return "Invalid JPEG-LS stream, the height (Number of lines) is already defined";
+        return "Invalid JPEG-LS stream: the height (Number of lines) is already defined";
 
     case jpegls_errc::invalid_parameter_component_count:
-        return "Invalid JPEG-LS stream, component count in the SOF segment is outside the range [1, 255]";
+        return "Invalid JPEG-LS stream: component count in the SOF segment is outside the range [1, 255]";
 
     case jpegls_errc::invalid_parameter_interleave_mode:
-        return "Invalid JPEG-LS stream, interleave mode is outside the range [0, 2] or conflicts with component count";
+        return "Invalid JPEG-LS stream: interleave mode is outside the range [0, 2] or conflicts with component count";
 
     case jpegls_errc::invalid_parameter_near_lossless:
-        return "Invalid JPEG-LS stream, near-lossless is outside the range [0, min(255, MAXVAL/2)]";
+        return "Invalid JPEG-LS stream: near-lossless is outside the range [0, min(255, MAXVAL/2)]";
 
     case jpegls_errc::invalid_parameter_jpegls_preset_parameters:
-        return "Invalid JPEG-LS stream, JPEG-LS preset parameters segment contains invalid values";
+        return "Invalid JPEG-LS stream: JPEG-LS preset parameters segment contains invalid values";
     }
 
     return "Unknown";

--- a/src/validate_spiff_header.cpp
+++ b/src/validate_spiff_header.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "charls/validate_spiff_header.h"
+#include "util.h"
+
+using namespace charls;
+
+namespace {
+
+bool is_valid_color_space(const spiff_color_space color_space, const int32_t component_count) noexcept
+{
+    switch (color_space)
+    {
+    case spiff_color_space::none:
+        return true;
+
+    case spiff_color_space::bi_level_black:
+    case spiff_color_space::bi_level_white:
+        return false; // not supported for JPEG-LS.
+
+    case spiff_color_space::grayscale:
+        return component_count == 1;
+
+    case spiff_color_space::ycbcr_itu_bt_709_video:
+    case spiff_color_space::ycbcr_itu_bt_601_1_rgb:
+    case spiff_color_space::ycbcr_itu_bt_601_1_video:
+    case spiff_color_space::rgb:
+    case spiff_color_space::cmy:
+    case spiff_color_space::photo_ycc:
+    case spiff_color_space::cie_lab:
+        return component_count == 3;
+
+    case spiff_color_space::cmyk:
+    case spiff_color_space::ycck:
+        return component_count == 4;
+    }
+
+    return false;
+}
+
+bool is_valid_resolution_units(const spiff_resolution_units resolution_units) noexcept
+{
+    switch (resolution_units)
+    {
+    case spiff_resolution_units::aspect_ratio:
+    case spiff_resolution_units::dots_per_centimeter:
+    case spiff_resolution_units::dots_per_inch:
+        return true;
+    }
+
+    return false;
+}
+
+bool is_valid_spiff_header(const spiff_header& header, const charls::frame_info& frame_info) noexcept
+{
+    if (header.compression_type != spiff_compression_type::jpeg_ls)
+        return false;
+
+    if (header.profile_id != spiff_profile_id::none)
+        return false;
+
+    if (!is_valid_resolution_units(header.resolution_units))
+        return false;
+
+    if (header.horizontal_resolution == 0 || header.vertical_resolution == 0)
+        return false;
+
+    if (header.component_count != frame_info.component_count)
+        return false;
+
+    if (!is_valid_color_space(header.color_space, header.component_count))
+        return false;
+
+    if (header.bits_per_sample != frame_info.bits_per_sample)
+        return false;
+
+    if (header.height != frame_info.height)
+        return false;
+
+    if (header.width != frame_info.width)
+        return false;
+
+    return true;
+}
+
+} // namespace
+
+
+extern "C" {
+
+USE_DECL_ANNOTATIONS charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_validate_spiff_header(const charls_spiff_header* spiff_header, const charls_frame_info* frame_info) noexcept
+try
+{
+    return is_valid_spiff_header(*check_pointer(spiff_header), *check_pointer(frame_info))
+               ? jpegls_errc::success
+               : jpegls_errc::invalid_spiff_header;
+}
+catch (...)
+{
+    return to_jpegls_errc();
+}
+}

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Checked|Win32">
@@ -64,7 +64,7 @@
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(SolutionDir)intermediate\CharLS\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(SolutionDir)intermediate\CharLS\x86\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>jpegls.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>jpegls.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;validate_spiff_header.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -100,6 +100,7 @@
     <ClCompile Include="scan_test.cpp" />
     <ClCompile Include="util.cpp" />
     <ClCompile Include="util_test.cpp" />
+    <ClCompile Include="validate_spiff_header_test.cpp" />
     <ClCompile Include="version_test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/unittest/CharLSUnitTest.vcxproj.filters
+++ b/unittest/CharLSUnitTest.vcxproj.filters
@@ -107,6 +107,9 @@
     <ClCompile Include="util_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="validate_spiff_header_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="tulips-gray-8bit-512-512.pgm">

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -352,6 +352,28 @@ public:
         Assert::AreEqual(256U, frame_info.width);
     }
 
+    TEST_METHOD(read_invalid_spiff_header_with_read_header) // NOLINT
+    {
+        const vector<uint8_t> source{create_test_spiff_header(2, 0, true, 1)};
+        jpegls_decoder decoder{source, false};
+
+        decoder.read_spiff_header();
+        std::error_code ec;
+        decoder.read_header(ec);
+
+        Assert::AreEqual(static_cast<int>(jpegls_errc::invalid_spiff_header), ec.value());
+    }
+
+    TEST_METHOD(read_invalid_spiff_header_throws) // NOLINT
+    {
+        const vector<uint8_t> source{create_test_spiff_header(2, 0, true, 1)};
+
+        assert_expect_exception(jpegls_errc::invalid_spiff_header, [&source] {
+            // ReSharper disable once CppLocalVariableWithNonTrivialDtorIsNeverUsed
+            jpegls_decoder decoder{source, true};
+        });
+    }
+
     TEST_METHOD(read_header_twice_throws) // NOLINT
     {
         const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};

--- a/unittest/util.cpp
+++ b/unittest/util.cpp
@@ -82,7 +82,8 @@ portable_anymap_file read_anymap_reference_file(const char* filename, const inte
     return reference_file;
 }
 
-vector<uint8_t> create_test_spiff_header(const uint8_t high_version, const uint8_t low_version, const bool end_of_directory)
+vector<uint8_t> create_test_spiff_header(const uint8_t high_version, const uint8_t low_version, const bool end_of_directory,
+                                         const uint8_t component_count)
 {
     vector<uint8_t> buffer;
     buffer.push_back(0xFF);
@@ -105,7 +106,7 @@ vector<uint8_t> create_test_spiff_header(const uint8_t high_version, const uint8
     buffer.push_back(low_version);
 
     buffer.push_back(0); // profile id
-    buffer.push_back(3); // component count
+    buffer.push_back(component_count);
 
     // Height
     buffer.push_back(0);
@@ -146,7 +147,7 @@ vector<uint8_t> create_test_spiff_header(const uint8_t high_version, const uint8
         writer.write_spiff_end_of_directory_entry();
     }
 
-    writer.write_start_of_frame_segment({100, 100, 8, 1});
+    writer.write_start_of_frame_segment({600, 800, 8, 3});
     writer.write_start_of_scan_segment(1, 0, interleave_mode::none);
 
     return buffer;

--- a/unittest/util.h
+++ b/unittest/util.h
@@ -49,7 +49,7 @@ charls_test::portable_anymap_file read_anymap_reference_file(const char* filenam
                                                              const frame_info& frame_info);
 charls_test::portable_anymap_file read_anymap_reference_file(const char* filename, interleave_mode interleave_mode);
 std::vector<uint8_t> create_test_spiff_header(uint8_t high_version = 2, uint8_t low_version = 0,
-                                              bool end_of_directory = true);
+                                              bool end_of_directory = true, uint8_t component_count = 3);
 std::vector<uint8_t> create_noise_image_16_bit(size_t pixel_count, int bit_count, uint32_t seed);
 void test_round_trip_legacy(const std::vector<uint8_t>& source, const JlsParameters& params);
 bool verify_encoded_bytes(const std::vector<uint8_t>& uncompressed_source, const std::vector<uint8_t>& encoded_source);

--- a/unittest/validate_spiff_header_test.cpp
+++ b/unittest/validate_spiff_header_test.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.h"
+
+#include "util.h"
+
+#include <charls/validate_spiff_header.h>
+
+using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
+using Microsoft::VisualStudio::CppUnitTestFramework::TestClass;
+
+MSVC_WARNING_SUPPRESS(6387) // '_Param_(x)' could be '0': this does not adhere to the specification for the function.
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+#endif
+
+namespace charls { namespace test {
+
+namespace {
+
+constexpr spiff_header create_valid_spiff_header()
+{
+    return {
+        spiff_profile_id::none,
+        3,
+        200,
+        100,
+        spiff_color_space::rgb,
+        8,
+        spiff_compression_type::jpeg_ls,
+        spiff_resolution_units::aspect_ratio,
+        1,
+        1,
+    };
+}
+
+constexpr frame_info create_valid_frame_info()
+{
+    return {100, 200, 8, 3};
+}
+
+} // namespace
+
+TEST_CLASS(charls_validate_spiff_header_test)
+{
+public:
+    TEST_METHOD(valid) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+
+        auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::success, result);
+
+        spiff_header.color_space = spiff_color_space::none;
+        result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::success, result);
+    }
+
+    TEST_METHOD(invalid_compression_type) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.compression_type = spiff_compression_type::uncompressed;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_profile_id) // NOLINT
+    {
+        spiff_header spiff_header{};
+        constexpr frame_info frame_info{};
+        spiff_header.compression_type = spiff_compression_type::jpeg_ls;
+        spiff_header.profile_id = spiff_profile_id::continuous_tone_base;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_component_count) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.component_count = 7;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_bits_per_sample) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.bits_per_sample = 12;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_height) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.height = 333;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_width) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.width = 27;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_color_space) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.color_space = static_cast<spiff_color_space>(27);
+
+        auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::IsTrue(result == jpegls_errc::invalid_spiff_header);
+
+        spiff_header.color_space = spiff_color_space::bi_level_black;
+        result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_color_space_component_count) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.color_space = spiff_color_space::grayscale;
+
+        auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+
+        spiff_header.color_space = spiff_color_space::cmyk;
+        result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_resolution_units) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.resolution_units = static_cast<spiff_resolution_units>(99);
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_vertical_resolution) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.vertical_resolution = 0;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(invalid_horizontal_resolution) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        constexpr frame_info frame_info{create_valid_frame_info()};
+        spiff_header.horizontal_resolution = 0;
+
+        const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+        Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
+    }
+
+    TEST_METHOD(spiff_header_nullptr) // NOLINT
+    {
+        constexpr frame_info frame_info{create_valid_frame_info()};
+
+        const auto result{charls_validate_spiff_header(nullptr, &frame_info)};
+        Assert::AreEqual(jpegls_errc::invalid_argument, result);
+    }
+
+    TEST_METHOD(frame_info_nullptr) // NOLINT
+    {
+        constexpr spiff_header spiff_header{create_valid_spiff_header()};
+
+        const auto result{charls_validate_spiff_header(&spiff_header, nullptr)};
+        Assert::AreEqual(jpegls_errc::invalid_argument, result);
+    }
+};
+
+}} // namespace charls::test


### PR DESCRIPTION
To ensure that the SPIFF header (when present) is valid validate the properties of the header. This can only be done after the frame info is also available.