### PR TITLE
Add documentation to charls_validate_spiff_header method

### DIFF
--- a/include/charls/validate_spiff_header.h
+++ b/include/charls/validate_spiff_header.h
@@ -9,6 +9,17 @@
 extern "C" {
 #endif
 
+/// <summary>
+/// Validates a SPIFF header. It is validated against the ISO/IEC 10918-3, Annex F and if the
+/// values match with the frame info argument.
+/// </summary>
+/// <remarks>
+/// ISO/IEC 10918-3 (SPIFF) and ISO/IEC 14495-1 (JPEG-LS) use different allowed ranges for
+/// bits per sample: (1, 2, 4, 8, 12, 16) vs [2..16]. The JPEG-LS range is used for validation.
+/// </remarks>
+/// <param name="spiff_header">Reference to a charls_spiff_header instance.</param>
+/// <param name="frame_info">Reference to a charls_frame_info instance.</param>
+/// <returns>charls_jpegls_errc::success when the SPIFF header is valid, otherwise charls_jpegls_errc::invalid_spiff_header.</returns>
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION charls_validate_spiff_header(
     CHARLS_IN const charls_spiff_header* spiff_header, CHARLS_IN const charls_frame_info* frame_info) CHARLS_NOEXCEPT
     CHARLS_ATTRIBUTE((nonnull));

--- a/unittest/validate_spiff_header_test.cpp
+++ b/unittest/validate_spiff_header_test.cpp
@@ -91,6 +91,21 @@ public:
         Assert::AreEqual(jpegls_errc::invalid_spiff_header, result);
     }
 
+    TEST_METHOD(all_jpegls_bits_per_sample_are_valid) // NOLINT
+    {
+        spiff_header spiff_header{create_valid_spiff_header()};
+        frame_info frame_info{create_valid_frame_info()};
+
+        for (int bits_per_sample{2}; bits_per_sample <= 16; ++bits_per_sample)
+        {
+            spiff_header.bits_per_sample = bits_per_sample;
+            frame_info.bits_per_sample = bits_per_sample;
+
+            const auto result = charls_validate_spiff_header(&spiff_header, &frame_info);
+            Assert::AreEqual(jpegls_errc::success, result);
+        }
+    }
+
     TEST_METHOD(invalid_bits_per_sample) // NOLINT
     {
         spiff_header spiff_header{create_valid_spiff_header()};


### PR DESCRIPTION
The original PR didn't add XML documentation.