### PR TITLE
Add method write_spiff_end_of_directory_entry

### DIFF
--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -185,6 +185,19 @@ charls_jpegls_encoder_write_spiff_entry(CHARLS_IN charls_jpegls_encoder* encoder
                                         size_t entry_data_size_bytes) CHARLS_NOEXCEPT;
 
 /// <summary>
+/// Writes a SPIFF end of directory entry to the destination.
+/// The encoder will normally does this automatically. It is made available
+/// for the scenario to create SPIFF headers in front of existing JPEG-LS streams.
+/// </summary>
+/// <remarks>
+/// The end of directory also includes a SOI marker. This marker should be skipped from the JPEG-LS stream.
+/// </remarks>
+/// <param name="encoder">Reference to the encoder instance.</param>
+/// <returns>The result of the operation: success or a failure code.</returns>
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_jpegls_encoder_write_spiff_end_of_directory_entry(CHARLS_IN charls_jpegls_encoder* encoder) CHARLS_NOEXCEPT;
+
+/// <summary>
 /// Writes a comment (COM) segment to the destination.
 /// </summary>
 /// <remarks>
@@ -480,6 +493,20 @@ public:
     {
         check_jpegls_errc(charls_jpegls_encoder_write_spiff_entry(encoder_.get(), static_cast<uint32_t>(entry_tag),
                                                                   entry_data, entry_data_size_bytes));
+        return *this;
+    }
+
+    /// <summary>
+    /// Writes a SPIFF end of directory entry to the destination.
+    /// The encoder will normally does this automatically. It is made available
+    /// for the scenario to create SPIFF headers in front of existing JPEG-LS streams.
+    /// </summary>
+    /// <remarks>
+    /// The end of directory also includes a SOI marker. This marker should be skipped from the JPEG-LS stream.
+    /// </remarks>
+    jpegls_encoder& write_spiff_end_of_directory_entry()
+    {
+        check_jpegls_errc(charls_jpegls_encoder_write_spiff_end_of_directory_entry(encoder_.get()));
         return *this;
     }
 

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -128,6 +128,12 @@ struct charls_jpegls_encoder final
         writer_.write_spiff_directory_entry(entry_tag, entry_data, entry_data_size_bytes);
     }
 
+    void write_spiff_end_of_directory_entry()
+    {
+        check_operation(state_ == state::spiff_header);
+        transition_to_tables_and_miscellaneous_state();
+    }
+
     void write_comment(const const_byte_span comment)
     {
         check_argument(comment.data() || comment.empty());
@@ -513,6 +519,19 @@ charls_jpegls_encoder_write_spiff_entry(charls_jpegls_encoder* encoder, const ui
 try
 {
     check_pointer(encoder)->write_spiff_entry(entry_tag, entry_data, entry_data_size_bytes);
+    return jpegls_errc::success;
+}
+catch (...)
+{
+    return to_jpegls_errc();
+}
+
+
+USE_DECL_ANNOTATIONS jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_jpegls_encoder_write_spiff_end_of_directory_entry(charls_jpegls_encoder* encoder) noexcept
+try
+{
+    check_pointer(encoder)->write_spiff_end_of_directory_entry();
     return jpegls_errc::success;
 }
 catch (...)

--- a/unittest/charls_jpegls_encoder_test.cpp
+++ b/unittest/charls_jpegls_encoder_test.cpp
@@ -158,6 +158,12 @@ public:
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
 
+    TEST_METHOD(write_spiff_end_of_directory_entry_before_header_throws) // NOLINT
+    {
+        const auto error = charls_jpegls_encoder_write_spiff_end_of_directory_entry(nullptr);
+        Assert::AreEqual(jpegls_errc::invalid_argument, error);
+    }
+
     TEST_METHOD(write_comment_nullptr) // NOLINT
     {
         constexpr array<uint8_t, 10> buffer{};

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -462,6 +462,50 @@ public:
         });
     }
 
+    TEST_METHOD(write_spiff_end_of_directory_entry) // NOLINT
+    {
+        jpegls_encoder encoder;
+
+        encoder.frame_info({1, 1, 2, 1});
+
+        vector<uint8_t> destination(300);
+        encoder.destination(destination);
+
+        encoder.write_standard_spiff_header(spiff_color_space::none);
+        encoder.write_spiff_end_of_directory_entry();
+
+        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[44]);
+        Assert::AreEqual(static_cast<uint8_t>(0xD8), destination[45]); // 0xD8 = SOI: Marks the start of an image.
+    }
+
+    TEST_METHOD(write_spiff_end_of_directory_entry_before_header_throws) // NOLINT
+    {
+        jpegls_encoder encoder;
+
+        vector<uint8_t> destination(300);
+        encoder.destination(destination);
+
+        assert_expect_exception(jpegls_errc::invalid_operation, [&encoder] {
+            encoder.write_spiff_end_of_directory_entry();
+        });
+    }
+
+    TEST_METHOD(write_spiff_end_of_directory_entry_twice_throws) // NOLINT
+    {
+        jpegls_encoder encoder;
+
+        encoder.frame_info({1, 1, 2, 1});
+
+        vector<uint8_t> destination(300);
+        encoder.destination(destination);
+
+        encoder.write_standard_spiff_header(spiff_color_space::none);
+        encoder.write_spiff_end_of_directory_entry();
+
+        assert_expect_exception(jpegls_errc::invalid_operation,
+                                [&encoder] { encoder.write_spiff_end_of_directory_entry(); });
+    }
+
     TEST_METHOD(write_comment) // NOLINT
     {
         jpegls_encoder encoder;


### PR DESCRIPTION
This helper function can be used to add SPIFF headers to existing JPEG-LS streams.