### PR TITLE
Use explicit ofstream.close() and replace static_casts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,12 +2,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Build to a folder outside the source folders, making it easier to clean. -->
-    <OutDir>$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\</OutDir>
-    <OutDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)bin\x86\$(Configuration)\</OutDir>
+    <OutDir>$(MSBuildThisFileDirectory)build\bin\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)build\bin\x86\$(Configuration)\</OutDir>
 
     <!-- C++ temp files can be redirected. -->
-    <IntDir>$(MSBuildThisFileDirectory)intermediate\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <IntDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)intermediate\$(MSBuildProjectName)\x86\$(Configuration)\</IntDir>
+    <IntDir>$(MSBuildThisFileDirectory)build\intermediate\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Platform)'=='Win32'">$(MSBuildThisFileDirectory)build\intermediate\$(MSBuildProjectName)\x86\$(Configuration)\</IntDir>
 
     <!-- The C runtime is provided by the OS on the Windows platform (Universal C Runtime (CRT)) -->
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -215,7 +215,7 @@ int peek_zero_bits(uint64_t val_test) noexcept
 {
     for (int32_t count{}; count < 16; ++count)
     {
-        if ((val_test & (static_cast<uint64_t>(1) << (64 - 1))) != 0)
+        if ((val_test & (uint64_t{1} << (64 - 1))) != 0)
             return count;
 
         val_test <<= 1;

--- a/fuzztest/main.cpp
+++ b/fuzztest/main.cpp
@@ -101,7 +101,7 @@ int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-
 
     while (__AFL_LOOP(100))
     {
-        vector<uint8_t> source(static_cast<size_t>(1024) * 1024);
+        vector<uint8_t> source(size_t{1024} * 1024);
         const size_t input_length = _read(fd, source.data(), charls::conditional_static_cast<unsigned int>(source.size()));
         source.resize(input_length);
 

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -293,7 +293,7 @@ public:
              typename T2 = typename DestinationContainer::value_type>
     static std::pair<charls::frame_info, charls::interleave_mode>
     decode(const SourceContainer& source, DestinationContainer& destination,
-           const size_t maximum_size_in_bytes = static_cast<size_t>(7680) * 4320 * 3)
+           const size_t maximum_size_in_bytes = size_t{7680} * 4320 * 3)
     {
         jpegls_decoder decoder{source, true};
 

--- a/samples/convert.cpp/main.cpp
+++ b/samples/convert.cpp/main.cpp
@@ -122,6 +122,7 @@ void save_buffer_to_file(const void* buffer, const size_t buffer_size, const cha
     output.exceptions(std::ios::failbit | std::ios::badbit);
 
     output.write(static_cast<const char*>(buffer), static_cast<std::streamsize>(buffer_size));
+    output.close(); // close explict to get feedback on failures.
 }
 
 void log_failure(const char* message) noexcept

--- a/test/bitstreamdamage.cpp
+++ b/test/bitstreamdamage.cpp
@@ -22,7 +22,7 @@ namespace {
 void test_damaged_bit_stream1()
 {
     const vector<uint8_t> encoded_buffer = read_file("test/incorrect_images/InfiniteLoopFFMPEG.jls");
-    vector<uint8_t> destination(static_cast<size_t>(256) * 256 * 2);
+    vector<uint8_t> destination(size_t{256} * 256 * 2);
 
     error_code error;
     try
@@ -45,7 +45,7 @@ void test_damaged_bit_stream2()
     encoded_buffer.resize(900);
     encoded_buffer.resize(40000, 3);
 
-    vector<uint8_t> destination(static_cast<size_t>(512) * 512);
+    vector<uint8_t> destination(size_t{512} * 512);
 
     error_code error;
     try
@@ -68,7 +68,7 @@ void test_damaged_bit_stream3()
     encoded_buffer[300] = 0xFF;
     encoded_buffer[301] = 0xFF;
 
-    vector<uint8_t> destination(static_cast<size_t>(512) * 512);
+    vector<uint8_t> destination(size_t{512} * 512);
 
     error_code error;
     try
@@ -93,7 +93,7 @@ void test_file_with_random_header_damage(const char* filename)
     MSVC_WARNING_SUPPRESS_NEXT_LINE(26496) // cannot be marked as const as operator() is not always defined const.
     uniform_int_distribution<uint32_t> distribution(0, 255);
 
-    vector<uint8_t> destination(static_cast<size_t>(512) * 512);
+    vector<uint8_t> destination(size_t{512} * 512);
 
     for (size_t i{}; i != 40; ++i)
     {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -36,31 +36,20 @@ using std::ostream;
 using std::streamoff;
 using std::string;
 using std::stringstream;
-using std::system_error;
+using std::runtime_error;
 using std::uniform_int_distribution;
 using std::vector;
 using namespace charls;
 
 namespace {
 
-constexpr ios::openmode mode_input = ios::in | ios::binary;
-constexpr ios::openmode mode_output = ios::out | ios::binary;
+constexpr ios::openmode mode_input{ios::in | ios::binary};
 
 ifstream open_input_stream(const char* filename)
 {
     ifstream stream;
     stream.exceptions(ios::eofbit | ios::failbit | ios::badbit);
     stream.open(filename, mode_input);
-
-    return stream;
-}
-
-
-ofstream open_output_stream(const char* filename)
-{
-    ofstream stream;
-    stream.exceptions(ios::eofbit | ios::failbit | ios::badbit);
-    stream.open(filename, mode_output);
 
     return stream;
 }
@@ -344,7 +333,7 @@ void test_bgr()
 void test_too_small_output_buffer()
 {
     const vector<uint8_t> encoded{read_file("test/tulips-gray-8bit-512-512-hp-encoder.jls")};
-    vector<uint8_t> destination(static_cast<size_t>(512) * 511);
+    vector<uint8_t> destination(size_t{512} * 511);
 
     jpegls_decoder decoder;
     decoder.source(encoded).read_header();
@@ -541,15 +530,16 @@ try
         }
     }
 
-    const int magic_number = frame_info.component_count == 3 ? 6 : 5;
+    const int magic_number{frame_info.component_count == 3 ? 6 : 5};
 
     ofstream output{open_output_stream(filename_output)};
     output << 'P' << magic_number << "\n" << frame_info.width << ' ' << frame_info.height << "\n" << max_value << "\n";
     write(output, decoded_destination, decoded_destination.size());
+    output.close();
 
     return true;
 }
-catch (const system_error& error)
+catch (const runtime_error& error)
 {
     cout << "Failed to decode " << filename_input << " to " << filename_output << ", reason: " << error.what() << '\n';
     return false;
@@ -629,9 +619,11 @@ try
 
     ofstream jls_file_stream(open_output_stream(filename_output));
     write(jls_file_stream, destination, bytes_encoded);
+    jls_file_stream.close();
+
     return true;
 }
-catch (const system_error& error)
+catch (const runtime_error& error)
 {
     cout << "Failed to encode " << filename_input << " to " << filename_output << ", reason: " << error.what() << '\n';
     return false;
@@ -726,7 +718,7 @@ try
     write_file(filename_output, decoded_destination.data(), decoded_destination.size());
     return true;
 }
-catch (const system_error& error)
+catch (const runtime_error& error)
 {
     cout << "Failed to decode " << filename_encoded << " to " << filename_output << ", reason: " << error.what() << '\n';
     return false;

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -41,6 +41,18 @@ MSVC_WARNING_UNSUPPRESS()
 } // namespace
 
 
+ofstream open_output_stream(const char* filename)
+{
+    static constexpr ios::openmode mode_output{ios::out | ios::binary};
+
+    ofstream stream;
+    stream.exceptions(ios::eofbit | ios::failbit | ios::badbit);
+    stream.open(filename, mode_output);
+
+    return stream;
+}
+
+
 void fix_endian(vector<uint8_t>* buffer, const bool little_endian_data) noexcept
 {
     if (little_endian_data == is_machine_little_endian())
@@ -85,6 +97,7 @@ void write_file(const char* filename, const void* data, const size_t size)
     output.exceptions(ios::eofbit | ios::failbit | ios::badbit);
     output.open(filename, ios::out | ios::binary);
     output.write(static_cast<const char*>(data), static_cast<std::streamsize>(size));
+    output.close(); // close explict to get feedback on failures.
 }
 
 void test_round_trip(const char* name, const vector<uint8_t>& decoded_buffer, const rect_size size,

--- a/test/util.h
+++ b/test/util.h
@@ -20,6 +20,7 @@ struct rect_size final
 };
 
 
+std::ofstream open_output_stream(const char* filename);
 void fix_endian(std::vector<uint8_t>* buffer, bool little_endian_data) noexcept;
 std::vector<uint8_t> read_file(const char* filename, long offset = 0, size_t bytes = 0);
 void write_file(const char* filename, const void* data, size_t size);

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -62,8 +62,8 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>$(SolutionDir)intermediate\CharLS\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(SolutionDir)intermediate\CharLS\x86\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)build\intermediate\CharLS\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(SolutionDir)build\intermediate\CharLS\x86\$(Configuration)\</AdditionalLibraryDirectories>
       <AdditionalDependencies>jpegls.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;validate_spiff_header.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/unittest/encoder_strategy_test.cpp
+++ b/unittest/encoder_strategy_test.cpp
@@ -56,21 +56,21 @@ public:
         strategy.flush_forward();
 
         // Verify output.
-        Assert::AreEqual(static_cast<size_t>(13), strategy.get_length_forward());
-        Assert::AreEqual(static_cast<uint8_t>(0x00), destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(0x00), destination[1]);
-        Assert::AreEqual(static_cast<uint8_t>(0x00), destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0x7F), destination[4]); // extra 0 bit.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>(0x7F), destination[6]); // extra 0 bit.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>(0x60), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>(0x00), destination[9]);
-        Assert::AreEqual(static_cast<uint8_t>(0x00), destination[10]);
-        Assert::AreEqual(static_cast<uint8_t>(0x00), destination[11]);
-        Assert::AreEqual(static_cast<uint8_t>(0xC0), destination[12]);
-        Assert::AreEqual(static_cast<uint8_t>(0x77), destination[13]);
+        Assert::AreEqual(size_t{13}, strategy.get_length_forward());
+        Assert::AreEqual(uint8_t{}, destination[0]);
+        Assert::AreEqual(uint8_t{}, destination[1]);
+        Assert::AreEqual(uint8_t{}, destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[3]);
+        Assert::AreEqual(uint8_t{0x7F}, destination[4]); // extra 0 bit.
+        Assert::AreEqual(uint8_t{0xFF}, destination[5]);
+        Assert::AreEqual(uint8_t{0x7F}, destination[6]); // extra 0 bit.
+        Assert::AreEqual(uint8_t{0xFF}, destination[7]);
+        Assert::AreEqual(uint8_t{0x60}, destination[8]);
+        Assert::AreEqual(uint8_t{}, destination[9]);
+        Assert::AreEqual(uint8_t{}, destination[10]);
+        Assert::AreEqual(uint8_t{}, destination[11]);
+        Assert::AreEqual(uint8_t{0xC0}, destination[12]);
+        Assert::AreEqual(uint8_t{0x77}, destination[13]);
     }
 };
 

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -539,7 +539,7 @@ public:
 
         reader.read_header();
 
-        Assert::AreEqual(static_cast<size_t>(5), actual.size);
+        Assert::AreEqual(size_t{5}, actual.size);
         Assert::IsTrue(memcmp("hello", actual.data, actual.size) == 0);
     }
 
@@ -571,7 +571,7 @@ public:
 
         reader.read_header();
 
-        Assert::AreEqual(static_cast<size_t>(0), actual.size);
+        Assert::AreEqual(size_t{}, actual.size);
         Assert::IsNull(actual.data);
     }
 
@@ -628,7 +628,7 @@ public:
         reader.read_header();
 
         Assert::AreEqual(8, actual.id);
-        Assert::AreEqual(static_cast<size_t>(5), actual.size);
+        Assert::AreEqual(size_t{5}, actual.size);
         Assert::IsTrue(memcmp("hello", actual.data, actual.size) == 0);
     }
 
@@ -664,7 +664,7 @@ public:
         reader.read_header();
 
         Assert::AreEqual(15, actual.id);
-        Assert::AreEqual(static_cast<size_t>(0), actual.size);
+        Assert::AreEqual(size_t{}, actual.size);
         Assert::IsNull(actual.data);
     }
 

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -22,7 +22,7 @@ public:
     TEST_METHOD(remaining_destination_will_be_zero_after_create_with_default) // NOLINT
     {
         const jpeg_stream_writer writer;
-        Assert::AreEqual(static_cast<size_t>(0), writer.remaining_destination().size);
+        Assert::AreEqual(size_t{}, writer.remaining_destination().size);
         Assert::IsNull(writer.remaining_destination().data);
     }
 
@@ -33,8 +33,8 @@ public:
 
         writer.write_start_of_image();
 
-        Assert::AreEqual(static_cast<size_t>(2), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(size_t{2}, writer.bytes_written());
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), buffer[1]);
     }
 
@@ -44,7 +44,7 @@ public:
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&writer] { writer.write_start_of_image(); });
-        Assert::AreEqual(static_cast<size_t>(0), writer.bytes_written());
+        Assert::AreEqual(size_t{}, writer.bytes_written());
     }
 
     TEST_METHOD(write_end_of_image) // NOLINT
@@ -54,8 +54,8 @@ public:
 
         writer.write_end_of_image(false);
 
-        Assert::AreEqual(static_cast<size_t>(2), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(size_t{2}, writer.bytes_written());
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[1]);
     }
 
@@ -66,8 +66,8 @@ public:
 
         writer.write_end_of_image(true);
 
-        Assert::AreEqual(static_cast<size_t>(2), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(size_t{2}, writer.bytes_written());
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[1]);
     }
 
@@ -81,14 +81,14 @@ public:
         writer.write_comment_segment({&comment, 1});
         writer.write_end_of_image(true);
 
-        Assert::AreEqual(static_cast<size_t>(8), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(size_t{8}, writer.bytes_written());
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), buffer[1]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);
-        Assert::AreEqual(static_cast<uint8_t>(3), buffer[3]);
-        Assert::AreEqual(static_cast<uint8_t>(99), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[6]);
+        Assert::AreEqual(uint8_t{}, buffer[2]);
+        Assert::AreEqual(uint8_t{3}, buffer[3]);
+        Assert::AreEqual(uint8_t{99}, buffer[4]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[5]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[6]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[7]);
     }
 
@@ -102,13 +102,13 @@ public:
         writer.write_comment_segment({&comment, 1});
         writer.write_end_of_image(false);
 
-        Assert::AreEqual(static_cast<size_t>(7), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(size_t{7}, writer.bytes_written());
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), buffer[1]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);
-        Assert::AreEqual(static_cast<uint8_t>(3), buffer[3]);
-        Assert::AreEqual(static_cast<uint8_t>(99), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[5]);
+        Assert::AreEqual(uint8_t{}, buffer[2]);
+        Assert::AreEqual(uint8_t{3}, buffer[3]);
+        Assert::AreEqual(uint8_t{99}, buffer[4]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[5]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[6]);
     }
 
@@ -118,7 +118,7 @@ public:
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&writer] { writer.write_end_of_image(false); });
-        Assert::AreEqual(static_cast<size_t>(0), writer.bytes_written());
+        Assert::AreEqual(size_t{}, writer.bytes_written());
     }
 
     TEST_METHOD(write_spiff_segment) // NOLINT
@@ -139,40 +139,40 @@ public:
 
         writer.write_spiff_header_segment(header);
 
-        Assert::AreEqual(static_cast<size_t>(34), writer.bytes_written());
+        Assert::AreEqual(size_t{34}, writer.bytes_written());
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), buffer[1]);
 
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);
-        Assert::AreEqual(static_cast<uint8_t>(32), buffer[3]);
+        Assert::AreEqual(uint8_t{}, buffer[2]);
+        Assert::AreEqual(uint8_t{32}, buffer[3]);
 
         // Verify SPIFF identifier string.
-        Assert::AreEqual(static_cast<uint8_t>('S'), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>('P'), buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>('I'), buffer[6]);
-        Assert::AreEqual(static_cast<uint8_t>('F'), buffer[7]);
-        Assert::AreEqual(static_cast<uint8_t>('F'), buffer[8]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[9]);
+        Assert::AreEqual(uint8_t{'S'}, buffer[4]);
+        Assert::AreEqual(uint8_t{'P'}, buffer[5]);
+        Assert::AreEqual(uint8_t{'I'}, buffer[6]);
+        Assert::AreEqual(uint8_t{'F'}, buffer[7]);
+        Assert::AreEqual(uint8_t{'F'}, buffer[8]);
+        Assert::AreEqual(uint8_t{}, buffer[9]);
 
         // Verify version
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[10]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[11]);
+        Assert::AreEqual(uint8_t{2}, buffer[10]);
+        Assert::AreEqual(uint8_t{}, buffer[11]);
 
         Assert::AreEqual(static_cast<uint8_t>(header.profile_id), buffer[12]);
         Assert::AreEqual(static_cast<uint8_t>(header.component_count), buffer[13]);
 
         // Height
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[14]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[15]);
-        Assert::AreEqual(static_cast<uint8_t>(0x3), buffer[16]);
-        Assert::AreEqual(static_cast<uint8_t>(0x20), buffer[17]);
+        Assert::AreEqual(uint8_t{}, buffer[14]);
+        Assert::AreEqual(uint8_t{}, buffer[15]);
+        Assert::AreEqual(uint8_t{0x3}, buffer[16]);
+        Assert::AreEqual(uint8_t{0x20}, buffer[17]);
 
         // Width
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[18]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[19]);
-        Assert::AreEqual(static_cast<uint8_t>(0x2), buffer[20]);
-        Assert::AreEqual(static_cast<uint8_t>(0x58), buffer[21]);
+        Assert::AreEqual(uint8_t{}, buffer[18]);
+        Assert::AreEqual(uint8_t{}, buffer[19]);
+        Assert::AreEqual(uint8_t{0x2}, buffer[20]);
+        Assert::AreEqual(uint8_t{0x58}, buffer[21]);
 
         Assert::AreEqual(static_cast<uint8_t>(header.color_space), buffer[22]);
         Assert::AreEqual(static_cast<uint8_t>(header.bits_per_sample), buffer[23]);
@@ -180,16 +180,16 @@ public:
         Assert::AreEqual(static_cast<uint8_t>(header.resolution_units), buffer[25]);
 
         // vertical_resolution
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[26]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[27]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[28]);
-        Assert::AreEqual(static_cast<uint8_t>(96), buffer[29]);
+        Assert::AreEqual(uint8_t{}, buffer[26]);
+        Assert::AreEqual(uint8_t{}, buffer[27]);
+        Assert::AreEqual(uint8_t{}, buffer[28]);
+        Assert::AreEqual(uint8_t{96}, buffer[29]);
 
         // header.horizontal_resolution = 1024
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[30]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[31]);
-        Assert::AreEqual(static_cast<uint8_t>(4), buffer[32]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[33]);
+        Assert::AreEqual(uint8_t{}, buffer[30]);
+        Assert::AreEqual(uint8_t{}, buffer[31]);
+        Assert::AreEqual(uint8_t{4}, buffer[32]);
+        Assert::AreEqual(uint8_t{}, buffer[33]);
     }
 
     TEST_METHOD(write_spiff_segment_in_too_small_buffer) // NOLINT
@@ -210,7 +210,7 @@ public:
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small,
                                 [&writer, &header] { writer.write_spiff_header_segment(header); });
-        Assert::AreEqual(static_cast<size_t>(0), writer.bytes_written());
+        Assert::AreEqual(size_t{}, writer.bytes_written());
     }
 
     TEST_METHOD(write_spiff_end_of_directory_segment) // NOLINT
@@ -220,24 +220,24 @@ public:
 
         writer.write_spiff_end_of_directory_entry();
 
-        Assert::AreEqual(static_cast<size_t>(10), writer.bytes_written());
+        Assert::AreEqual(size_t{10}, writer.bytes_written());
 
         // Verify Entry Magic Number (EMN)
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), buffer[1]);
 
         // Verify EOD Entry Length (EOD = End Of Directory)
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);
-        Assert::AreEqual(static_cast<uint8_t>(8), buffer[3]);
+        Assert::AreEqual(uint8_t{}, buffer[2]);
+        Assert::AreEqual(uint8_t{8}, buffer[3]);
 
         // Verify EOD Tag
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[6]);
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[7]);
+        Assert::AreEqual({}, buffer[4]);
+        Assert::AreEqual(uint8_t{}, buffer[5]);
+        Assert::AreEqual(uint8_t{}, buffer[6]);
+        Assert::AreEqual(uint8_t{1}, buffer[7]);
 
         // Verify embedded SOI tag
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[8]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[8]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), buffer[9]);
     }
 
@@ -251,18 +251,18 @@ public:
         writer.write_spiff_directory_entry(2, data.data(), data.size());
 
         // Verify Entry Magic Number (EMN)
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), buffer[1]);
 
         // Verify Entry Length
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);
-        Assert::AreEqual(static_cast<uint8_t>(8), buffer[3]);
+        Assert::AreEqual(uint8_t{}, buffer[2]);
+        Assert::AreEqual(uint8_t{8}, buffer[3]);
 
         // Verify Entry Tag
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[6]);
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[7]);
+        Assert::AreEqual(uint8_t{}, buffer[4]);
+        Assert::AreEqual(uint8_t{}, buffer[5]);
+        Assert::AreEqual(uint8_t{}, buffer[6]);
+        Assert::AreEqual(uint8_t{2}, buffer[7]);
 
         // Verify embedded data
         Assert::AreEqual(data[0], buffer[8]);
@@ -281,30 +281,30 @@ public:
             writer.write_start_of_frame_segment({100, numeric_limits<uint16_t>::max(), bits_per_sample, component_count})};
 
         Assert::IsFalse(oversized_image);
-        Assert::AreEqual(static_cast<size_t>(19), writer.bytes_written());
+        Assert::AreEqual(size_t{19}, writer.bytes_written());
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(0xF7), buffer[1]); // JPEG_SOF_55
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);    // 6 + (3 * 3) + 2 (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(17), buffer[3]);   // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
+        Assert::AreEqual(uint8_t{0xF7}, buffer[1]);         // JPEG_SOF_55
+        Assert::AreEqual(uint8_t{}, buffer[2]);             // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(uint8_t{17}, buffer[3]);           // 6 + (3 * 3) + 2 (in big endian)
         Assert::AreEqual(static_cast<uint8_t>(bits_per_sample), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(255), buffer[5]); // height (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(255), buffer[6]); // height (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[7]);   // width (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(100), buffer[8]); // width (in big endian)
+        Assert::AreEqual(uint8_t{255}, buffer[5]);          // height (in big endian)
+        Assert::AreEqual(uint8_t{255}, buffer[6]);          // height (in big endian)
+        Assert::AreEqual(uint8_t{}, buffer[7]);             // width (in big endian)
+        Assert::AreEqual(uint8_t{100}, buffer[8]);          // width (in big endian)
         Assert::AreEqual(static_cast<uint8_t>(component_count), buffer[9]);
 
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[10]);
-        Assert::AreEqual(static_cast<uint8_t>(0x11), buffer[11]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[12]);
+        Assert::AreEqual(uint8_t{1}, buffer[10]);
+        Assert::AreEqual(uint8_t{0x11}, buffer[11]);
+        Assert::AreEqual(uint8_t{}, buffer[12]);
 
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[13]);
-        Assert::AreEqual(static_cast<uint8_t>(0x11), buffer[14]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[15]);
+        Assert::AreEqual(uint8_t{2}, buffer[13]);
+        Assert::AreEqual(uint8_t{0x11}, buffer[14]);
+        Assert::AreEqual(uint8_t{}, buffer[15]);
 
-        Assert::AreEqual(static_cast<uint8_t>(3), buffer[16]);
-        Assert::AreEqual(static_cast<uint8_t>(0x11), buffer[17]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[18]);
+        Assert::AreEqual(uint8_t{3}, buffer[16]);
+        Assert::AreEqual(uint8_t{0x11}, buffer[17]);
+        Assert::AreEqual(uint8_t{}, buffer[18]);
     }
 
     TEST_METHOD(write_start_of_frame_segment_large_image) // NOLINT
@@ -319,32 +319,31 @@ public:
             {100, numeric_limits<uint16_t>::max() + 1U, bits_per_sample, component_count})};
 
         Assert::IsTrue(oversized_image);
-        Assert::AreEqual(static_cast<size_t>(19), writer.bytes_written());
+        Assert::AreEqual(size_t{19}, writer.bytes_written());
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(0xF7), buffer[1]); // JPEG_SOF_55
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[2]);    // 6 + (3 * 3) + 2 (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(17), buffer[3]);   // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
+        Assert::AreEqual(uint8_t{0xF7}, buffer[1]);         // JPEG_SOF_55
+        Assert::AreEqual(uint8_t{}, buffer[2]);             // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(uint8_t{17}, buffer[3]);      // 6 + (3 * 3) + 2 (in big endian)
         Assert::AreEqual(static_cast<uint8_t>(bits_per_sample), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[5]); // height (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[6]); // height (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[7]); // width (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[8]); // width (in big endian)
+        Assert::AreEqual(uint8_t{}, buffer[5]);         // height (in big endian)
+        Assert::AreEqual(uint8_t{}, buffer[6]);         // height (in big endian)
+        Assert::AreEqual(uint8_t{}, buffer[7]);   // width (in big endian)
+        Assert::AreEqual(uint8_t{}, buffer[8]);   // width (in big endian)
         Assert::AreEqual(static_cast<uint8_t>(component_count), buffer[9]);
 
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[10]);
-        Assert::AreEqual(static_cast<uint8_t>(0x11), buffer[11]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[12]);
+        Assert::AreEqual(uint8_t{1}, buffer[10]);
+        Assert::AreEqual(uint8_t{0x11}, buffer[11]);
+        Assert::AreEqual(uint8_t{}, buffer[12]);
 
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[13]);
-        Assert::AreEqual(static_cast<uint8_t>(0x11), buffer[14]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[15]);
+        Assert::AreEqual(uint8_t{2}, buffer[13]);
+        Assert::AreEqual(uint8_t{0x11}, buffer[14]);
+        Assert::AreEqual(uint8_t{}, buffer[15]);
 
-        Assert::AreEqual(static_cast<uint8_t>(3), buffer[16]);
-        Assert::AreEqual(static_cast<uint8_t>(0x11), buffer[17]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[18]);
+        Assert::AreEqual(uint8_t{3}, buffer[16]);
+        Assert::AreEqual(uint8_t{0x11}, buffer[17]);
+        Assert::AreEqual(uint8_t{}, buffer[18]);
     }
-
 
     TEST_METHOD(write_start_of_frame_marker_segment_with_low_boundary_values) // NOLINT
     {
@@ -370,7 +369,7 @@ public:
             {numeric_limits<uint16_t>::max(), numeric_limits<uint16_t>::max(), 16, numeric_limits<uint8_t>::max()});
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(16), buffer[4]);
+        Assert::AreEqual(uint8_t{16}, buffer[4]);
         Assert::AreEqual(numeric_limits<uint8_t>::max(), buffer[9]);
 
         Assert::AreEqual(numeric_limits<uint8_t>::max(), buffer[buffer.size() - 3]); // Last component index.
@@ -387,10 +386,10 @@ public:
         Assert::AreEqual(buffer.size(), writer.bytes_written());
 
         // Verify mrfx identifier string.
-        Assert::AreEqual(static_cast<uint8_t>('m'), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>('r'), buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>('f'), buffer[6]);
-        Assert::AreEqual(static_cast<uint8_t>('x'), buffer[7]);
+        Assert::AreEqual(uint8_t{'m'}, buffer[4]);
+        Assert::AreEqual(uint8_t{'r'}, buffer[5]);
+        Assert::AreEqual(uint8_t{'f'}, buffer[6]);
+        Assert::AreEqual(uint8_t{'x'}, buffer[7]);
 
         Assert::AreEqual(static_cast<uint8_t>(transformation), buffer[8]);
     }
@@ -406,27 +405,27 @@ public:
         Assert::AreEqual(buffer.size(), writer.bytes_written());
 
         // Parameter ID.
-        Assert::AreEqual(static_cast<uint8_t>(0x1), buffer[4]);
+        Assert::AreEqual(uint8_t{0x1}, buffer[4]);
 
         // MaximumSampleValue
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[6]);
+        Assert::AreEqual(uint8_t{}, buffer[5]);
+        Assert::AreEqual(uint8_t{2}, buffer[6]);
 
         // Threshold1
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[7]);
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[8]);
+        Assert::AreEqual(uint8_t{}, buffer[7]);
+        Assert::AreEqual(uint8_t{1}, buffer[8]);
 
         // Threshold2
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[9]);
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[10]);
+        Assert::AreEqual(uint8_t{}, buffer[9]);
+        Assert::AreEqual(uint8_t{2}, buffer[10]);
 
         // Threshold3
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[11]);
-        Assert::AreEqual(static_cast<uint8_t>(3), buffer[12]);
+        Assert::AreEqual(uint8_t{}, buffer[11]);
+        Assert::AreEqual(uint8_t{3}, buffer[12]);
 
         // ResetValue
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[13]);
-        Assert::AreEqual(static_cast<uint8_t>(7), buffer[14]);
+        Assert::AreEqual(uint8_t{}, buffer[13]);
+        Assert::AreEqual(uint8_t{7}, buffer[14]);
     }
 
     TEST_METHOD(write_jpegls_preset_parameters_segment_for_oversized_image_dimensions) // NOLINT
@@ -438,22 +437,22 @@ public:
         Assert::AreEqual(buffer.size(), writer.bytes_written());
 
         // Parameter ID.
-        Assert::AreEqual(static_cast<uint8_t>(0x4), buffer[4]);
+        Assert::AreEqual(uint8_t{0x4}, buffer[4]);
 
         // Wxy
-        Assert::AreEqual(static_cast<uint8_t>(4), buffer[5]);
+        Assert::AreEqual(uint8_t{4}, buffer[5]);
 
         // Height (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[6]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[7]);
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[8]);
-        Assert::AreEqual(static_cast<uint8_t>(100), buffer[9]);
+        Assert::AreEqual(uint8_t{}, buffer[6]);
+        Assert::AreEqual(uint8_t{}, buffer[7]);
+        Assert::AreEqual(uint8_t{}, buffer[8]);
+        Assert::AreEqual(uint8_t{100}, buffer[9]);
 
         // Width (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(255), buffer[10]);
-        Assert::AreEqual(static_cast<uint8_t>(255), buffer[11]);
-        Assert::AreEqual(static_cast<uint8_t>(255), buffer[12]);
-        Assert::AreEqual(static_cast<uint8_t>(255), buffer[13]);
+        Assert::AreEqual(uint8_t{255}, buffer[10]);
+        Assert::AreEqual(uint8_t{255}, buffer[11]);
+        Assert::AreEqual(uint8_t{255}, buffer[12]);
+        Assert::AreEqual(uint8_t{255}, buffer[13]);
     }
 
     TEST_METHOD(write_start_of_scan_marker) // NOLINT
@@ -464,12 +463,12 @@ public:
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[4]); // component count.
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[5]); // component index.
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[6]); // table ID.
-        Assert::AreEqual(static_cast<uint8_t>(2), buffer[7]); // NEAR parameter.
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[8]); // ILV parameter.
-        Assert::AreEqual(static_cast<uint8_t>(0), buffer[9]); // transformation.
+        Assert::AreEqual(uint8_t{1}, buffer[4]); // component count.
+        Assert::AreEqual(uint8_t{1}, buffer[5]); // component index.
+        Assert::AreEqual(uint8_t{}, buffer[6]);  // table ID.
+        Assert::AreEqual(uint8_t{2}, buffer[7]); // NEAR parameter.
+        Assert::AreEqual(uint8_t{}, buffer[8]);  // ILV parameter.
+        Assert::AreEqual(uint8_t{}, buffer[9]);  // transformation.
     }
 
     TEST_METHOD(rewind) // NOLINT
@@ -483,7 +482,7 @@ public:
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(1), buffer[4]); // component count.
+        Assert::AreEqual(uint8_t{1}, buffer[4]); // component count.
     }
 };
 

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -154,7 +154,7 @@ public:
 
         const jpegls_decoder decoder{source, true};
 
-        constexpr size_t expected_destination_size{static_cast<size_t>(256) * 256 * 3};
+        constexpr size_t expected_destination_size{size_t{256} * 256 * 3};
         Assert::AreEqual(expected_destination_size, decoder.destination_size());
     }
 
@@ -598,7 +598,7 @@ public:
 
         decoder.read_header();
 
-        Assert::AreEqual(static_cast<size_t>(5), actual_size);
+        Assert::AreEqual(size_t{5}, actual_size);
         Assert::IsTrue(memcmp("hello", actual_data, actual_size) == 0);
     }
 
@@ -662,7 +662,7 @@ public:
         decoder.read_header();
 
         Assert::AreEqual(0, actual_application_data_id);
-        Assert::AreEqual(static_cast<size_t>(5), actual_size);
+        Assert::AreEqual(size_t{5}, actual_size);
         Assert::IsTrue(memcmp("hello", actual_data, actual_size) == 0);
     }
 
@@ -876,15 +876,15 @@ private:
     {
         vector<uint8_t> segment;
 
-        segment.push_back(static_cast<uint8_t>(0xFF));
+        segment.push_back(uint8_t{0xFF});
         segment.push_back(static_cast<uint8_t>(jpeg_marker_code::jpegls_preset_parameters));
         push_back(segment, static_cast<uint16_t>(11 + sizeof(uint16_t)));
         segment.push_back(static_cast<uint8_t>(jpegls_preset_parameters_type::preset_coding_parameters));
-        push_back(segment, static_cast<uint16_t>(0));
-        push_back(segment, static_cast<uint16_t>(0));
-        push_back(segment, static_cast<uint16_t>(0));
-        push_back(segment, static_cast<uint16_t>(0));
-        push_back(segment, static_cast<uint16_t>(0));
+        push_back(segment, uint16_t{0});
+        push_back(segment, uint16_t{0});
+        push_back(segment, uint16_t{0});
+        push_back(segment, uint16_t{0});
+        push_back(segment, uint16_t{0});
 
         return segment;
     }

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -166,7 +166,7 @@ public:
 
         encoder.frame_info({100, 100, 16, 1}); // minimum.
         const auto size{encoder.estimated_destination_size()};
-        Assert::IsTrue(size >= static_cast<size_t>(100) * 100 * 2);
+        Assert::IsTrue(size >= size_t{100} * 100 * 2);
     }
 
     TEST_METHOD(estimated_destination_size_color_8_bit) // NOLINT
@@ -175,7 +175,7 @@ public:
 
         encoder.frame_info({2000, 2000, 8, 3});
         const auto size{encoder.estimated_destination_size()};
-        Assert::IsTrue(size >= static_cast<size_t>(2000) * 2000 * 3);
+        Assert::IsTrue(size >= size_t{2000} * 2000 * 3);
     }
 
     TEST_METHOD(estimated_destination_size_very_wide) // NOLINT
@@ -210,15 +210,15 @@ public:
 
         encoder.frame_info({numeric_limits<uint32_t>::max(), numeric_limits<uint32_t>::max(), 8, 1});
 
-        #if INTPTR_MAX == INT64_MAX
+#if INTPTR_MAX == INT64_MAX
         const auto size{encoder.estimated_destination_size()};
         Assert::IsTrue(size != 0); // actual value already checked in other test functions.
-        #elif INTPTR_MAX == INT32_MAX
+#elif INTPTR_MAX == INT32_MAX
         assert_expect_exception(jpegls_errc::parameter_value_not_supported,
                                 [&encoder] { ignore = encoder.estimated_destination_size(); });
-        #else
-        #error Unknown pointer size or missing size macros!
-        #endif
+#else
+#error Unknown pointer size or missing size macros!
+#endif
     }
 
     TEST_METHOD(destination) // NOLINT
@@ -254,20 +254,20 @@ public:
         Assert::AreEqual(serialized_spiff_header_size + 2, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APP8 with SPIFF has been written (details already verified by jpeg_stream_writer_test).
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(32), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>('S'), destination[6]);
-        Assert::AreEqual(static_cast<uint8_t>('P'), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>('I'), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>('F'), destination[9]);
-        Assert::AreEqual(static_cast<uint8_t>('F'), destination[10]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[11]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{32}, destination[5]);
+        Assert::AreEqual(uint8_t{'S'}, destination[6]);
+        Assert::AreEqual(uint8_t{'P'}, destination[7]);
+        Assert::AreEqual(uint8_t{'I'}, destination[8]);
+        Assert::AreEqual(uint8_t{'F'}, destination[9]);
+        Assert::AreEqual(uint8_t{'F'}, destination[10]);
+        Assert::AreEqual(uint8_t{}, destination[11]);
     }
 
     TEST_METHOD(write_standard_spiff_header_without_destination) // NOLINT
@@ -322,20 +322,20 @@ public:
         Assert::AreEqual(serialized_spiff_header_size + 2, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APP8 with SPIFF has been written (details already verified by jpeg_stream_writer_test).
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(32), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>('S'), destination[6]);
-        Assert::AreEqual(static_cast<uint8_t>('P'), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>('I'), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>('F'), destination[9]);
-        Assert::AreEqual(static_cast<uint8_t>('F'), destination[10]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[11]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{32}, destination[5]);
+        Assert::AreEqual(uint8_t{'S'}, destination[6]);
+        Assert::AreEqual(uint8_t{'P'}, destination[7]);
+        Assert::AreEqual(uint8_t{'I'}, destination[8]);
+        Assert::AreEqual(uint8_t{'F'}, destination[9]);
+        Assert::AreEqual(uint8_t{'F'}, destination[10]);
+        Assert::AreEqual(uint8_t{}, destination[11]);
     }
 
     TEST_METHOD(write_spiff_header_invalid_height) // NOLINT
@@ -352,7 +352,7 @@ public:
 
         assert_expect_exception(jpegls_errc::invalid_argument_height,
                                 [&encoder, &spiff_header] { encoder.write_spiff_header(spiff_header); });
-        Assert::AreEqual(static_cast<size_t>(0), encoder.bytes_written());
+        Assert::AreEqual(size_t{}, encoder.bytes_written());
     }
 
     TEST_METHOD(write_spiff_header_invalid_width) // NOLINT
@@ -369,7 +369,7 @@ public:
 
         assert_expect_exception(jpegls_errc::invalid_argument_width,
                                 [&encoder, &spiff_header] { encoder.write_spiff_header(spiff_header); });
-        Assert::AreEqual(static_cast<size_t>(0), encoder.bytes_written());
+        Assert::AreEqual(size_t{}, encoder.bytes_written());
     }
 
     TEST_METHOD(write_spiff_entry) // NOLINT
@@ -384,7 +384,7 @@ public:
 
         encoder.write_spiff_entry(spiff_entry_tag::image_title, "test", 4);
 
-        Assert::AreEqual(static_cast<size_t>(48), encoder.bytes_written());
+        Assert::AreEqual(size_t{48}, encoder.bytes_written());
     }
 
     TEST_METHOD(write_spiff_entry_twice) // NOLINT
@@ -400,7 +400,7 @@ public:
         encoder.write_spiff_entry(spiff_entry_tag::image_title, "test", 4);
         encoder.write_spiff_entry(spiff_entry_tag::image_title, "test", 4);
 
-        Assert::AreEqual(static_cast<size_t>(60), encoder.bytes_written());
+        Assert::AreEqual(size_t{60}, encoder.bytes_written());
     }
 
     TEST_METHOD(write_empty_spiff_entry) // NOLINT
@@ -415,7 +415,7 @@ public:
 
         encoder.write_spiff_entry(spiff_entry_tag::image_title, nullptr, 0);
 
-        Assert::AreEqual(static_cast<size_t>(44), encoder.bytes_written());
+        Assert::AreEqual(size_t{44}, encoder.bytes_written());
     }
 
     TEST_METHOD(write_spiff_entry_with_invalid_tag) // NOLINT
@@ -474,8 +474,8 @@ public:
         encoder.write_standard_spiff_header(spiff_color_space::none);
         encoder.write_spiff_end_of_directory_entry();
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[44]);
-        Assert::AreEqual(static_cast<uint8_t>(0xD8), destination[45]); // 0xD8 = SOI: Marks the start of an image.
+        Assert::AreEqual(uint8_t{0xFF}, destination[44]);
+        Assert::AreEqual(uint8_t{0xD8}, destination[45]); // 0xD8 = SOI: Marks the start of an image.
     }
 
     TEST_METHOD(write_spiff_end_of_directory_entry_before_header_throws) // NOLINT
@@ -485,9 +485,8 @@ public:
         vector<uint8_t> destination(300);
         encoder.destination(destination);
 
-        assert_expect_exception(jpegls_errc::invalid_operation, [&encoder] {
-            encoder.write_spiff_end_of_directory_entry();
-        });
+        assert_expect_exception(jpegls_errc::invalid_operation,
+                                [&encoder] { encoder.write_spiff_end_of_directory_entry(); });
     }
 
     TEST_METHOD(write_spiff_end_of_directory_entry_twice_throws) // NOLINT
@@ -515,21 +514,21 @@ public:
 
         encoder.write_comment("123");
 
-        Assert::AreEqual(static_cast<size_t>(10), encoder.bytes_written());
+        Assert::AreEqual(size_t{10}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2 + 4), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>('1'), destination[6]);
-        Assert::AreEqual(static_cast<uint8_t>('2'), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>('3'), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[9]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
+        Assert::AreEqual(uint8_t{'1'}, destination[6]);
+        Assert::AreEqual(uint8_t{'2'}, destination[7]);
+        Assert::AreEqual(uint8_t{'3'}, destination[8]);
+        Assert::AreEqual(uint8_t{}, destination[9]);
     }
 
     TEST_METHOD(write_empty_comment) // NOLINT
@@ -541,17 +540,17 @@ public:
 
         encoder.write_comment("");
 
-        Assert::AreEqual(static_cast<size_t>(6), encoder.bytes_written());
+        Assert::AreEqual(size_t{6}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[5]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2}, destination[5]);
     }
 
     TEST_METHOD(write_empty_comment_buffer) // NOLINT
@@ -563,17 +562,17 @@ public:
 
         encoder.write_comment(nullptr, 0);
 
-        Assert::AreEqual(static_cast<size_t>(6), encoder.bytes_written());
+        Assert::AreEqual(size_t{6}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[5]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2}, destination[5]);
     }
 
     TEST_METHOD(write_max_comment) // NOLINT
@@ -590,14 +589,14 @@ public:
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(255), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(255), destination[5]);
+        Assert::AreEqual(uint8_t{255}, destination[4]);
+        Assert::AreEqual(uint8_t{255}, destination[5]);
     }
 
     TEST_METHOD(write_two_comment) // NOLINT
@@ -613,23 +612,23 @@ public:
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that the COM segments have been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2 + 4), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>('1'), destination[6]);
-        Assert::AreEqual(static_cast<uint8_t>('2'), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>('3'), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[9]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
+        Assert::AreEqual(uint8_t{'1'}, destination[6]);
+        Assert::AreEqual(uint8_t{'2'}, destination[7]);
+        Assert::AreEqual(uint8_t{'3'}, destination[8]);
+        Assert::AreEqual(uint8_t{}, destination[9]);
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[10]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[10]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[11]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[12]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[13]);
+        Assert::AreEqual(uint8_t{}, destination[12]);
+        Assert::AreEqual(uint8_t{2}, destination[13]);
     }
 
     TEST_METHOD(write_too_large_comment) // NOLINT
@@ -654,7 +653,7 @@ public:
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] {
-            MSVC_WARNING_SUPPRESS_NEXT_LINE(6387)
+            MSVC_WARNING_SUPPRESS_NEXT_LINE(6387) // argument> may be null.
             ignore = encoder.write_comment(nullptr, 1);
         });
     }
@@ -700,21 +699,21 @@ public:
         const array<uint8_t, 4> application_data{1, 2, 3, 4};
         encoder.write_application_data(1, application_data.data(), application_data.size());
 
-        Assert::AreEqual(static_cast<size_t>(10), encoder.bytes_written());
+        Assert::AreEqual(size_t{10}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APPn segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data1), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2 + 4), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>(1), destination[6]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>(3), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>(4), destination[9]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
+        Assert::AreEqual(uint8_t{1}, destination[6]);
+        Assert::AreEqual(uint8_t{2}, destination[7]);
+        Assert::AreEqual(uint8_t{3}, destination[8]);
+        Assert::AreEqual(uint8_t{4}, destination[9]);
     }
 
     TEST_METHOD(write_empty_application_data) // NOLINT
@@ -726,17 +725,17 @@ public:
 
         encoder.write_application_data(2, nullptr, 0);
 
-        Assert::AreEqual(static_cast<size_t>(6), encoder.bytes_written());
+        Assert::AreEqual(size_t{6}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APPn segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data2), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[5]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2}, destination[5]);
     }
 
     TEST_METHOD(write_max_application_data) // NOLINT
@@ -753,14 +752,14 @@ public:
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APPn segment has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data15), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(255), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(255), destination[5]);
+        Assert::AreEqual(uint8_t{255}, destination[4]);
+        Assert::AreEqual(uint8_t{255}, destination[5]);
     }
 
     TEST_METHOD(write_two_application_data) // NOLINT
@@ -777,23 +776,23 @@ public:
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[0]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that the COM segments have been written.
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[2]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data0), destination[3]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[4]);
-        Assert::AreEqual(static_cast<uint8_t>(2 + 4), destination[5]);
-        Assert::AreEqual(static_cast<uint8_t>(1), destination[6]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[7]);
-        Assert::AreEqual(static_cast<uint8_t>(3), destination[8]);
-        Assert::AreEqual(static_cast<uint8_t>(4), destination[9]);
+        Assert::AreEqual(uint8_t{}, destination[4]);
+        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
+        Assert::AreEqual(uint8_t{1}, destination[6]);
+        Assert::AreEqual(uint8_t{2}, destination[7]);
+        Assert::AreEqual(uint8_t{3}, destination[8]);
+        Assert::AreEqual(uint8_t{4}, destination[9]);
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[10]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[10]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), destination[11]);
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[12]);
-        Assert::AreEqual(static_cast<uint8_t>(2), destination[13]);
+        Assert::AreEqual(uint8_t{}, destination[12]);
+        Assert::AreEqual(uint8_t{2}, destination[13]);
     }
 
     TEST_METHOD(write_too_large_application_data_throws) // NOLINT
@@ -1102,7 +1101,7 @@ public:
 
     TEST_METHOD(encode_1_component_4_bit_with_high_bits_set) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512, 0xFF);
         constexpr frame_info frame_info{512, 512, 4, 1};
 
         jpegls_encoder encoder;
@@ -1114,13 +1113,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(static_cast<size_t>(512) * 512, 15);
+        const vector<uint8_t> expected(size_t{512} * 512, 15);
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::none);
     }
 
     TEST_METHOD(encode_1_component_12_bit_with_high_bits_set) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 2, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 2, 0xFF);
         constexpr frame_info frame_info{512, 512, 12, 1};
 
         jpegls_encoder encoder;
@@ -1132,14 +1131,14 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint16_t> expected(static_cast<size_t>(512) * 512, 4095);
+        const vector<uint16_t> expected(size_t{512} * 512, 4095);
         test_by_decoding(destination, frame_info, expected.data(), expected.size() * sizeof(uint16_t),
                          interleave_mode::none);
     }
 
     TEST_METHOD(encode_3_components_6_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 3, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 3, 0xFF);
         constexpr frame_info frame_info{512, 512, 6, 3};
 
         jpegls_encoder encoder;
@@ -1151,13 +1150,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(static_cast<size_t>(512) * 512 * 3, 63);
+        const vector<uint8_t> expected(size_t{512} * 512 * 3, 63);
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::sample);
     }
 
     TEST_METHOD(encode_3_components_6_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 3, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 3, 0xFF);
         constexpr frame_info frame_info{512, 512, 6, 3};
 
         jpegls_encoder encoder;
@@ -1169,13 +1168,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(static_cast<size_t>(512) * 512 * 3, 63);
+        const vector<uint8_t> expected(size_t{512} * 512 * 3, 63);
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::line);
     }
 
     TEST_METHOD(encode_3_components_10_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 2 * 3, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 2 * 3, 0xFF);
         constexpr frame_info frame_info{512, 512, 10, 3};
 
         jpegls_encoder encoder;
@@ -1187,13 +1186,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint16_t> expected(static_cast<size_t>(512) * 512 * 3, 1023);
+        const vector<uint16_t> expected(size_t{512} * 512 * 3, 1023);
         test_by_decoding(destination, frame_info, expected.data(), expected.size() * 2, interleave_mode::sample);
     }
 
     TEST_METHOD(encode_3_components_10_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 2 * 3, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 2 * 3, 0xFF);
         constexpr frame_info frame_info{512, 512, 10, 3};
 
         jpegls_encoder encoder;
@@ -1205,13 +1204,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint16_t> expected(static_cast<size_t>(512) * 512 * 3, 1023);
+        const vector<uint16_t> expected(size_t{512} * 512 * 3, 1023);
         test_by_decoding(destination, frame_info, expected.data(), expected.size() * 2, interleave_mode::line);
     }
 
     TEST_METHOD(encode_4_components_6_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 4, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 4, 0xFF);
         constexpr frame_info frame_info{512, 512, 6, 4};
 
         jpegls_encoder encoder;
@@ -1223,13 +1222,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(static_cast<size_t>(512) * 512 * 4, 63);
+        const vector<uint8_t> expected(size_t{512} * 512 * 4, 63);
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::sample);
     }
 
     TEST_METHOD(encode_4_components_6_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 4, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 4, 0xFF);
         constexpr frame_info frame_info{512, 512, 6, 4};
 
         jpegls_encoder encoder;
@@ -1241,13 +1240,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(static_cast<size_t>(512) * 512 * 4, 63);
+        const vector<uint8_t> expected(size_t{512} * 512 * 4, 63);
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::line);
     }
 
     TEST_METHOD(encode_4_components_10_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 2 * 4, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 2 * 4, 0xFF);
         constexpr frame_info frame_info{512, 512, 10, 4};
 
         jpegls_encoder encoder;
@@ -1259,13 +1258,13 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint16_t> expected(static_cast<size_t>(512) * 512 * 4, 1023);
+        const vector<uint16_t> expected(size_t{512} * 512 * 4, 1023);
         test_by_decoding(destination, frame_info, expected.data(), expected.size() * 2, interleave_mode::sample);
     }
 
     TEST_METHOD(encode_4_components_10_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(static_cast<size_t>(512) * 512 * 2 * 4, 0xFF);
+        const vector<uint8_t> source(size_t{512} * 512 * 2 * 4, 0xFF);
         constexpr frame_info frame_info{512, 512, 10, 4};
 
         jpegls_encoder encoder;
@@ -1277,7 +1276,7 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint16_t> expected(static_cast<size_t>(512) * 512 * 4, 1023);
+        const vector<uint16_t> expected(size_t{512} * 512 * 4, 1023);
         test_by_decoding(destination, frame_info, expected.data(), expected.size() * 2, interleave_mode::line);
     }
 
@@ -1331,7 +1330,7 @@ public:
 
         const auto destination{jpegls_encoder::encode(source, frame_info)};
 
-        Assert::AreEqual(static_cast<size_t>(99), destination.size());
+        Assert::AreEqual(size_t{99}, destination.size());
         test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
     }
 
@@ -1343,7 +1342,7 @@ public:
         const auto destination{
             jpegls_encoder::encode(source, frame_info, interleave_mode::none, encoding_options::even_destination_size)};
 
-        Assert::AreEqual(static_cast<size_t>(100), destination.size());
+        Assert::AreEqual(size_t{100}, destination.size());
         test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
     }
 
@@ -1388,35 +1387,35 @@ public:
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        Assert::AreEqual(static_cast<size_t>(43), bytes_written);
+        Assert::AreEqual(size_t{43}, bytes_written);
 
-        Assert::AreEqual(static_cast<uint8_t>(0xFF), destination[15]);
+        Assert::AreEqual(uint8_t{0xFF}, destination[15]);
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::jpegls_preset_parameters), destination[16]);
 
         // Segment size.
-        Assert::AreEqual(static_cast<uint8_t>(0), destination[17]);
-        Assert::AreEqual(static_cast<uint8_t>(13), destination[18]);
+        Assert::AreEqual(uint8_t{}, destination[17]);
+        Assert::AreEqual(uint8_t{13}, destination[18]);
 
         // Parameter ID.
-        Assert::AreEqual(static_cast<uint8_t>(0x1), destination[19]);
+        Assert::AreEqual(uint8_t{0x1}, destination[19]);
 
         // MaximumSampleValue
-        Assert::AreEqual(static_cast<uint8_t>(255), destination[20]);
-        Assert::AreEqual(static_cast<uint8_t>(255), destination[21]);
+        Assert::AreEqual(uint8_t{255}, destination[20]);
+        Assert::AreEqual(uint8_t{255}, destination[21]);
 
         constexpr thresholds expected{
             compute_defaults_using_reference_implementation(std::numeric_limits<uint16_t>::max(), 0)};
 
-        const int32_t threshold1 = destination[22] << 8 | destination[23];
+        const int32_t threshold1{destination[22] << 8 | destination[23]};
         Assert::AreEqual(expected.t1, threshold1);
 
-        const int32_t threshold2 = destination[24] << 8 | destination[25];
+        const int32_t threshold2{destination[24] << 8 | destination[25]};
         Assert::AreEqual(expected.t2, threshold2);
 
-        const int32_t threshold3 = destination[26] << 8 | destination[27];
+        const int32_t threshold3{destination[26] << 8 | destination[27]};
         Assert::AreEqual(expected.t3, threshold3);
 
-        const int32_t reset = destination[28] << 8 | destination[29];
+        const int32_t reset{destination[28] << 8 | destination[29]};
         Assert::AreEqual(expected.reset, reset);
     }
 
@@ -1434,7 +1433,7 @@ public:
 
         const size_t bytes_written{encoder.encode(source)};
 
-        Assert::AreEqual(static_cast<size_t>(28), bytes_written);
+        Assert::AreEqual(size_t{28}, bytes_written);
     }
 
     TEST_METHOD(set_invalid_encode_options_throws) // NOLINT
@@ -1457,7 +1456,7 @@ public:
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
-        Assert::AreEqual(static_cast<size_t>(61), bytes_written);
+        Assert::AreEqual(size_t{61}, bytes_written);
 
         destination.resize(bytes_written);
         const auto it{find_first_lse_segment(destination.cbegin(), destination.cend())};
@@ -1486,7 +1485,7 @@ public:
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
-        Assert::AreEqual(static_cast<size_t>(99), bytes_written);
+        Assert::AreEqual(size_t{99}, bytes_written);
 
         destination.resize(bytes_written);
         const auto it{find_first_lse_segment(destination.cbegin(), destination.cend())};
@@ -1505,7 +1504,7 @@ public:
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
-        Assert::AreEqual(static_cast<size_t>(99), bytes_written);
+        Assert::AreEqual(size_t{99}, bytes_written);
 
         destination.resize(bytes_written);
         const auto it{find_first_lse_segment(destination.cbegin(), destination.cend())};
@@ -1524,7 +1523,7 @@ public:
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
-        Assert::AreEqual(static_cast<size_t>(114), bytes_written);
+        Assert::AreEqual(size_t{114}, bytes_written);
 
         destination.resize(bytes_written);
         const auto it{find_first_lse_segment(destination.cbegin(), destination.cend())};
@@ -1543,7 +1542,7 @@ public:
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
-        Assert::AreEqual(static_cast<size_t>(114), bytes_written);
+        Assert::AreEqual(size_t{114}, bytes_written);
 
         destination.resize(bytes_written);
         const auto it{find_first_lse_segment(destination.cbegin(), destination.cend())};


### PR DESCRIPTION
The destructor of std::ofstream will close the stream, but not report any failures (by design). Call close to trigger an exception when the close fails.

static_cast for constant values can be replaced with uniform initialization, this allows to reduce the number of static_casts.

Change the bin+intermediate to be sub-directories of build for MSBuild builds. This makes it easier to clean.