### PR TITLE
Fix the incorrect computation for bytes_per_plane if custom stride is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.0] -
+
+### Fixed
+
+- Fixed [#167](https://github.com/team-charls/charls/issues/196), Multi component image with interleave mode none is not correctly decoded when a custom stride argument is used.
+
 ## [2.3.4] - 2021-2-12
 
 ### Changed
 
-- Replaced legacy test images
+- Replaced legacy test images.
 
 ## [2.3.3] - 2021-2-5
 
 ### Fixed
 
-- Fixed [#167](https://github.com/team-charls/charls/issues/167), Decoding\Encoding fails on IBM s390x CPU (Big Endian architecture)
+- Fixed [#167](https://github.com/team-charls/charls/issues/167), Decoding\Encoding fails on IBM s390x CPU (Big Endian architecture).
 
 ### Changed
 
@@ -24,8 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- Fixed [#160](https://github.com/team-charls/charls/issues/160), warning: cast from ‘unsigned char*’ to ‘uint16_t*’ increases required alignment of target type
-- Fixed [#161](https://github.com/team-charls/charls/issues/161), warning: useless cast to type ‘size_t’ {aka ‘unsigned int’} [-Wuseless-cast]
+- Fixed [#160](https://github.com/team-charls/charls/issues/160), warning: cast from ‘unsigned char*’ to ‘uint16_t*’ increases required alignment of target type.
+- Fixed [#161](https://github.com/team-charls/charls/issues/161), warning: useless cast to type ‘size_t’ {aka ‘unsigned int’} [-Wuseless-cast].
 
 ### Changed
 

--- a/unittest/interface_test.cpp
+++ b/unittest/interface_test.cpp
@@ -151,7 +151,7 @@ public:
         Assert::IsTrue(strlen(error_message.data()) > 0);
     }
 
-    TEST_METHOD(JpegLsDecodeRect_lena) // NOLINT
+    TEST_METHOD(JpegLsDecodeRect_tulips) // NOLINT
     {
         JlsParameters params{};
         const vector<uint8_t> encoded_source = read_file("DataFiles/tulips-gray-8bit-512-512-hp-encoder.jls");
@@ -164,16 +164,26 @@ public:
                              encoded_source.size(), &params, nullptr);
         Assert::IsFalse(static_cast<bool>(error));
 
-        constexpr JlsRect rect{128, 128, 256, 1};
-        vector<uint8_t> decoded_rect(static_cast<size_t>(rect.Width) * rect.Height);
-        decoded_rect.push_back(0x1f);
+        constexpr size_t width{256};
+        constexpr JlsRect rect{128, 128, width, 1};
+        vector<uint8_t> decoded_rect(width * rect.Height);
+
+        // Update the stride to match the width of the rectangle.
+        params.stride = width;
+
+        // Add a marker byte to detect the case of a buffer overrun.
+        constexpr uint8_t buffer_overrun_detection_marker{0x1f};
+        decoded_rect.push_back(buffer_overrun_detection_marker);
+
         error = JpegLsDecodeRect(decoded_rect.data(), decoded_rect.size(), encoded_source.data(), encoded_source.size(),
                                  rect, &params, nullptr);
         Assert::IsFalse(static_cast<bool>(error));
 
         Assert::IsTrue(memcmp(&decoded_destination[rect.X + static_cast<size_t>(rect.Y) * 512], decoded_rect.data(),
-                              static_cast<size_t>(rect.Width) * rect.Height) == 0);
-        Assert::IsTrue(decoded_rect[static_cast<size_t>(rect.Width) * rect.Height] == 0x1f);
+                              width * rect.Height) == 0);
+
+        // Check that the marker is not overwritten.
+        Assert::IsTrue(decoded_rect[width * rect.Height] == buffer_overrun_detection_marker);
     }
 
     TEST_METHOD(JpegLsDecodeRect_nullptr) // NOLINT

--- a/unittest/util.h
+++ b/unittest/util.h
@@ -53,8 +53,11 @@ std::vector<uint8_t> create_test_spiff_header(uint8_t high_version = 2, uint8_t 
 std::vector<uint8_t> create_noise_image_16_bit(size_t pixel_count, int bit_count, uint32_t seed);
 void test_round_trip_legacy(const std::vector<uint8_t>& source, const JlsParameters& params);
 bool verify_encoded_bytes(const std::vector<uint8_t>& uncompressed_source, const std::vector<uint8_t>& encoded_source);
+void verify_decoded_bytes(interleave_mode interleave_mode, const frame_info& frame_info,
+                          const std::vector<uint8_t>& uncompressed_data, size_t destination_stride,
+                          const char* reference_filename);
 void test_compliance(const std::vector<uint8_t>& encoded_source, const std::vector<uint8_t>& uncompressed_source,
-                     bool check_encode);
+                 bool check_encode);
 
 
 /// <summary>


### PR DESCRIPTION
The bytes_per_plane value was using the default stride and not the passed custom stride. For multi component images with interleave mode none this caused the second plane to overwrite part of the first decoded plane, etc.

Also added a check to verify the passed stride argument, it should minimal be the default stride.