### PR TITLE
Add _throws to unit tests that verify failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Team CharLS.
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.13...3.22)
+cmake_minimum_required(VERSION 3.13...3.24)
 
 # Extract the version info from version.h
 file(READ "include/charls/version.h" version)

--- a/src/jls_codec_factory.h
+++ b/src/jls_codec_factory.h
@@ -24,9 +24,7 @@ private:
     std::unique_ptr<Strategy> try_create_optimized_codec(const frame_info& frame, const coding_parameters& parameters);
 };
 
-#ifndef _MSC_VER // IntelliSense fails to parse next lines and __INTELLISENSE__ cannot exclude it. Not needed for MSVC build.
 extern template class jls_codec_factory<decoder_strategy>;
 extern template class jls_codec_factory<encoder_strategy>;
-#endif
 
 } // namespace charls

--- a/unittest/color_transform_test.cpp
+++ b/unittest/color_transform_test.cpp
@@ -100,7 +100,7 @@ public:
         }
     }
 
-    TEST_METHOD(decode_non_8_or_16_bit_is_not_supported) // NOLINT
+    TEST_METHOD(decode_non_8_or_16_bit_that_is_not_supported_throws) // NOLINT
     {
         const vector<uint8_t> jpegls_data{read_file("land10-10bit-rgb-hp3-invalid.jls")};
 
@@ -112,7 +112,7 @@ public:
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
-    TEST_METHOD(encode_non_8_or_16_bit_is_not_supported) // NOLINT
+    TEST_METHOD(encode_non_8_or_16_bit_that_is_not_supported_throws) // NOLINT
     {
         constexpr frame_info frame_info{2, 1, 10, 3};
         jpegls_encoder encoder;

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -23,7 +23,7 @@ namespace charls { namespace test {
 TEST_CLASS(jpeg_stream_reader_test)
 {
 public:
-    TEST_METHOD(read_header_from_to_small_input_buffer) // NOLINT
+    TEST_METHOD(read_header_from_to_small_input_buffer_throws) // NOLINT
     {
         array<uint8_t, 1> buffer{};
         jpeg_stream_reader reader;
@@ -52,7 +52,7 @@ public:
         reader.read_header(); // if it doesn't throw test is passed.
     }
 
-    TEST_METHOD(read_header_from_buffer_not_starting_with_ff_should_throw) // NOLINT
+    TEST_METHOD(read_header_from_buffer_not_starting_with_ff_throws) // NOLINT
     {
         array<uint8_t, 6> buffer{0x0F, 0xFF, 0xD8, 0xFF, 0xFF, 0xDA}; // 0xDA = SOS: Marks the start of scan.
 
@@ -70,7 +70,7 @@ public:
         }
     }
 
-    TEST_METHOD(read_header_with_jpegls_extended_frame_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_jpegls_extended_frame_throws) // NOLINT
     {
         array<uint8_t, 6> buffer{
             0xFF, 0xD8, 0xFF, 0xF9}; // 0xF9 = SOF_57: Marks the start of a JPEG-LS extended (ISO/IEC 14495-2) encoded frame.
@@ -105,7 +105,7 @@ public:
         Assert::AreEqual(presets.threshold3, actual.threshold3);
     }
 
-    TEST_METHOD(read_header_with_too_small_jpegls_preset_parameter_segment_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_jpegls_preset_parameter_segment_throws) // NOLINT
     {
         array<uint8_t, 7> buffer{0xFF, 0xD8, 0xFF,
                                  0xF8, // LSE: Marks the start of a JPEG-LS preset parameters segment.
@@ -117,7 +117,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_small_jpegls_preset_parameter_segment_with_coding_parameters_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_jpegls_preset_parameter_segment_with_coding_parameters_throws) // NOLINT
     {
         array<uint8_t, 7> buffer{0xFF, 0xD8, 0xFF,
                                  0xF8, // LSE: Marks the start of a JPEG-LS preset parameters segment.
@@ -129,7 +129,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_large_jpegls_preset_parameter_segment_with_coding_parameters_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_large_jpegls_preset_parameter_segment_with_coding_parameters_throws) // NOLINT
     {
         array<uint8_t, 7> buffer{0xFF, 0xD8, 0xFF,
                                  0xF8, // LSE: Marks the start of a JPEG-LS preset parameters segment.
@@ -141,17 +141,17 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_jpegls_preset_parameter_with_extended_id_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_jpegls_preset_parameter_with_extended_id_throws) // NOLINT
     {
         constexpr array<uint8_t, 8> ids{0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xC, 0xD};
 
         for (const auto id : ids)
         {
-            read_header_with_jpeg_ls_preset_parameter_with_extended_id_should_throw(id);
+            read_header_with_jpeg_ls_preset_parameter_with_extended_id_throws(id);
         }
     }
 
-    TEST_METHOD(read_header_with_too_small_segment_size_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_segment_size_throws) // NOLINT
     {
         array<uint8_t, 8> buffer{0xFF, 0xD8, 0xFF,
                                  0xF7,                    // SOF_55: Marks the start of JPEG-LS extended scan.
@@ -163,7 +163,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_small_start_of_frame_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_start_of_frame_throws) // NOLINT
     {
         array<uint8_t, 6> buffer{0xFF, 0xD8, 0xFF,
                                  0xF7, // SOF_55: Marks the start of JPEG-LS extended scan.
@@ -175,7 +175,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_small_start_of_frame_in_component_info_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_start_of_frame_in_component_info_throws) // NOLINT
     {
         array<uint8_t, 6> buffer{0xFF, 0xD8, 0xFF,
                                  0xF7, // SOF_55: Marks the start of JPEG-LS extended scan.
@@ -187,7 +187,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_large_start_of_frame_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_large_start_of_frame_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -201,7 +201,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_sos_before_sof_should_throw) // NOLINT
+    TEST_METHOD(read_header_sos_before_sof_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -213,7 +213,7 @@ public:
         assert_expect_exception(jpegls_errc::unexpected_marker_found, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_extra_sof_should_throw) // NOLINT
+    TEST_METHOD(read_header_extra_sof_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -226,7 +226,7 @@ public:
         assert_expect_exception(jpegls_errc::duplicate_start_of_frame_marker, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_too_large_near_lossless_in_sos_should_throw) // NOLINT
+    TEST_METHOD(read_header_too_large_near_lossless_in_sos_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -239,7 +239,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_parameter_near_lossless, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_too_large_near_lossless_in_sos_should_throw2) // NOLINT
+    TEST_METHOD(read_header_too_large_near_lossless_in_sos_throws2) // NOLINT
     {
         constexpr jpegls_pc_parameters preset_coding_parameters{200, 0, 0, 0, 0};
 
@@ -257,17 +257,17 @@ public:
         assert_expect_exception(jpegls_errc::invalid_parameter_near_lossless, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_line_interleave_in_sos_for_single_component_should_throw) // NOLINT
+    TEST_METHOD(read_header_line_interleave_in_sos_for_single_component_throws) // NOLINT
     {
-        read_header_incorrect_interleave_in_sos_for_single_component_should_throw(interleave_mode::line);
+        read_header_incorrect_interleave_in_sos_for_single_component_throws(interleave_mode::line);
     }
 
-    TEST_METHOD(read_header_sample_interleave_in_sos_for_single_component_should_throw) // NOLINT
+    TEST_METHOD(read_header_sample_interleave_in_sos_for_single_component_throws) // NOLINT
     {
-        read_header_incorrect_interleave_in_sos_for_single_component_should_throw(interleave_mode::sample);
+        read_header_incorrect_interleave_in_sos_for_single_component_throws(interleave_mode::sample);
     }
 
-    TEST_METHOD(read_header_with_duplicate_component_id_in_start_of_frame_segment_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_duplicate_component_id_in_start_of_frame_segment_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.componentIdOverride = 7;
@@ -280,7 +280,7 @@ public:
         assert_expect_exception(jpegls_errc::duplicate_component_id_in_sof_segment, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_to_many_components_in_start_of_frame_segment_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_to_many_components_in_start_of_frame_segment_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -293,7 +293,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_parameter_component_count, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_no_components_in_start_of_frame_segment_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_no_components_in_start_of_frame_segment_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -306,7 +306,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_parameter_component_count, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_more_then_max_components_in_start_of_frame_segment_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_more_then_max_components_in_start_of_frame_segment_throws) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -319,7 +319,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_parameter_component_count, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_small_start_of_scan_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_start_of_scan_throws) // NOLINT
     {
         array<uint8_t, 16> buffer{0xFF, 0xD8, 0xFF,
                                   0xF7, // SOF_55: Marks the start of JPEG-LS extended scan.
@@ -341,7 +341,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_too_small_start_of_scan_component_count_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_too_small_start_of_scan_component_count_throws) // NOLINT
     {
         array<uint8_t, 17> buffer{0xFF, 0xD8, 0xFF,
                                   0xF7, // SOF_55: Marks the start of JPEG-LS extended scan.
@@ -363,7 +363,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_directly_end_of_image_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_directly_end_of_image_throws) // NOLINT
     {
         array<uint8_t, 4> buffer{0xFF, 0xD8, 0xFF, 0xD9}; // 0xD9 = EOI
 
@@ -373,7 +373,7 @@ public:
         assert_expect_exception(jpegls_errc::unexpected_end_of_image_marker, [&reader] { reader.read_header(); });
     }
 
-    TEST_METHOD(read_header_with_duplicate_start_of_image_should_throw) // NOLINT
+    TEST_METHOD(read_header_with_duplicate_start_of_image_throws) // NOLINT
     {
         array<uint8_t, 4> buffer{0xFF, 0xD8, 0xFF, 0xD8}; // 0xD8 = SOI.
 
@@ -735,7 +735,7 @@ private:
         reader.read_header(); // if it doesn't throw test is passed.
     }
 
-    static void read_header_incorrect_interleave_in_sos_for_single_component_should_throw(const interleave_mode mode)
+    static void read_header_incorrect_interleave_in_sos_for_single_component_throws(const interleave_mode mode)
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -748,7 +748,7 @@ private:
         assert_expect_exception(jpegls_errc::invalid_parameter_interleave_mode, [&reader] { reader.read_header(); });
     }
 
-    static void read_header_with_jpeg_ls_preset_parameter_with_extended_id_should_throw(const uint8_t id)
+    static void read_header_with_jpeg_ls_preset_parameter_with_extended_id_throws(const uint8_t id)
     {
         array<uint8_t, 7> buffer{0xFF, 0xD8, 0xFF,
                                  0xF8, // LSE: Marks the start of a JPEG-LS preset parameters segment.

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -38,7 +38,7 @@ public:
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), buffer[1]);
     }
 
-    TEST_METHOD(write_start_of_image_in_too_small_buffer) // NOLINT
+    TEST_METHOD(write_start_of_image_in_too_small_buffer_throws) // NOLINT
     {
         array<uint8_t, 1> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
@@ -112,7 +112,7 @@ public:
         Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[6]);
     }
 
-    TEST_METHOD(write_end_of_image_in_too_small_buffer) // NOLINT
+    TEST_METHOD(write_end_of_image_in_too_small_buffer_throws) // NOLINT
     {
         array<uint8_t, 1> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
@@ -192,7 +192,7 @@ public:
         Assert::AreEqual(uint8_t{}, buffer[33]);
     }
 
-    TEST_METHOD(write_spiff_segment_in_too_small_buffer) // NOLINT
+    TEST_METHOD(write_spiff_segment_in_too_small_buffer_throws) // NOLINT
     {
         array<uint8_t, 33> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -122,7 +122,7 @@ public:
         Assert::AreEqual(256U, info.width);
     }
 
-    TEST_METHOD(interleave_mode_without_read_header) // NOLINT
+    TEST_METHOD(interleave_mode_without_read_header_throws) // NOLINT
     {
         const vector<uint8_t> source(2000);
         const jpegls_decoder decoder{source, false};
@@ -130,7 +130,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder] { ignore = decoder.interleave_mode(); });
     }
 
-    TEST_METHOD(near_lossless_without_read_header) // NOLINT
+    TEST_METHOD(near_lossless_without_read_header_throws) // NOLINT
     {
         const vector<uint8_t> source(2000);
         const jpegls_decoder decoder{source, false};
@@ -138,7 +138,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder] { ignore = decoder.near_lossless(); });
     }
 
-    TEST_METHOD(preset_coding_parameters_without_read_header) // NOLINT
+    TEST_METHOD(preset_coding_parameters_without_read_header_throws) // NOLINT
     {
         jpegls_decoder decoder;
 
@@ -533,7 +533,7 @@ public:
         Assert::AreEqual(expected_size, decoded_destination.size() * sizeof(uint16_t));
     }
 
-    TEST_METHOD(decode_file_with_ff_in_entropy_data) // NOLINT
+    TEST_METHOD(decode_file_with_ff_in_entropy_data_throws) // NOLINT
     {
         const vector<uint8_t> source{read_file("ff_in_entropy_data.jls")};
 
@@ -589,7 +589,7 @@ public:
         }
     }
 
-    TEST_METHOD(decode_file_with_golomb_large_then_k_max) // NOLINT
+    TEST_METHOD(decode_file_with_golomb_large_then_k_max_throws) // NOLINT
     {
         const vector<uint8_t> source{read_file("fuzzy_input_golomb_16.jls")};
 
@@ -607,7 +607,7 @@ public:
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
-    TEST_METHOD(decode_file_with_missing_restart_marker) // NOLINT
+    TEST_METHOD(decode_file_with_missing_restart_marker_throws) // NOLINT
     {
         vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
 
@@ -624,7 +624,7 @@ public:
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
-    TEST_METHOD(decode_file_with_incorrect_restart_marker) // NOLINT
+    TEST_METHOD(decode_file_with_incorrect_restart_marker_throws) // NOLINT
     {
         vector<uint8_t> source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
 
@@ -720,7 +720,7 @@ public:
         Assert::IsFalse(callback_called);
     }
 
-    TEST_METHOD(at_comment_that_throws_return_callback_error) // NOLINT
+    TEST_METHOD(at_comment_that_throws_returns_callback_error) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
@@ -785,7 +785,7 @@ public:
         Assert::IsFalse(callback_called);
     }
 
-    TEST_METHOD(at_application_data_that_throws_return_callback_error) // NOLINT
+    TEST_METHOD(at_application_data_that_throws_returns_callback_error) // NOLINT
     {
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -54,21 +54,21 @@ public:
         encoder.frame_info({std::numeric_limits<uint32_t>::max(), numeric_limits<uint32_t>::max(), 16, 255}); // maximum.
     }
 
-    TEST_METHOD(frame_info_bad_width) // NOLINT
+    TEST_METHOD(frame_info_bad_width_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
         assert_expect_exception(jpegls_errc::invalid_argument_width, [&encoder] { encoder.frame_info({0, 1, 2, 1}); });
     }
 
-    TEST_METHOD(frame_info_bad_height) // NOLINT
+    TEST_METHOD(frame_info_bad_height_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
         assert_expect_exception(jpegls_errc::invalid_argument_height, [&encoder] { encoder.frame_info({1, 0, 2, 1}); });
     }
 
-    TEST_METHOD(frame_info_bad_bits_per_sample) // NOLINT
+    TEST_METHOD(frame_info_bad_bits_per_sample_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -80,7 +80,7 @@ public:
         });
     }
 
-    TEST_METHOD(frame_info_bad_component_count) // NOLINT
+    TEST_METHOD(frame_info_bad_component_count_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -101,7 +101,7 @@ public:
         encoder.interleave_mode(interleave_mode::sample);
     }
 
-    TEST_METHOD(interleave_mode_bad) // NOLINT
+    TEST_METHOD(interleave_mode_bad_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -111,7 +111,7 @@ public:
                                 [&encoder] { encoder.interleave_mode(static_cast<charls::interleave_mode>(3)); });
     }
 
-    TEST_METHOD(interleave_mode_does_not_match_component_count) // NOLINT
+    TEST_METHOD(interleave_mode_does_not_match_component_count_throws) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
         vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
@@ -132,7 +132,7 @@ public:
         encoder.near_lossless(255); // set highest value.
     }
 
-    TEST_METHOD(near_lossless_bad) // NOLINT
+    TEST_METHOD(near_lossless_bad_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -196,7 +196,7 @@ public:
         Assert::IsTrue(size >= static_cast<size_t>(numeric_limits<uint16_t>::max()) + 1024U);
     }
 
-    TEST_METHOD(estimated_destination_size_too_soon) // NOLINT
+    TEST_METHOD(estimated_destination_size_too_soon_throws) // NOLINT
     {
         const jpegls_encoder encoder;
 
@@ -229,7 +229,7 @@ public:
         encoder.destination(destination);
     }
 
-    TEST_METHOD(destination_can_only_be_set_once) // NOLINT
+    TEST_METHOD(destination_can_only_be_set_once_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -270,7 +270,7 @@ public:
         Assert::AreEqual(uint8_t{}, destination[11]);
     }
 
-    TEST_METHOD(write_standard_spiff_header_without_destination) // NOLINT
+    TEST_METHOD(write_standard_spiff_header_without_destination_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -280,7 +280,7 @@ public:
                                 [&encoder] { encoder.write_standard_spiff_header(spiff_color_space::cmyk); });
     }
 
-    TEST_METHOD(write_standard_spiff_header_without_frame_info) // NOLINT
+    TEST_METHOD(write_standard_spiff_header_without_frame_info_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -291,7 +291,7 @@ public:
                                 [&encoder] { encoder.write_standard_spiff_header(spiff_color_space::cmyk); });
     }
 
-    TEST_METHOD(write_standard_spiff_header_twice) // NOLINT
+    TEST_METHOD(write_standard_spiff_header_twice_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -338,7 +338,7 @@ public:
         Assert::AreEqual(uint8_t{}, destination[11]);
     }
 
-    TEST_METHOD(write_spiff_header_invalid_height) // NOLINT
+    TEST_METHOD(write_spiff_header_invalid_height_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -355,7 +355,7 @@ public:
         Assert::AreEqual(size_t{}, encoder.bytes_written());
     }
 
-    TEST_METHOD(write_spiff_header_invalid_width) // NOLINT
+    TEST_METHOD(write_spiff_header_invalid_width_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -418,7 +418,7 @@ public:
         Assert::AreEqual(size_t{44}, encoder.bytes_written());
     }
 
-    TEST_METHOD(write_spiff_entry_with_invalid_tag) // NOLINT
+    TEST_METHOD(write_spiff_entry_with_invalid_tag_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -431,7 +431,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] { encoder.write_spiff_entry(1, "test", 4); });
     }
 
-    TEST_METHOD(write_spiff_entry_with_invalid_size) // NOLINT
+    TEST_METHOD(write_spiff_entry_with_invalid_size_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -447,7 +447,7 @@ public:
         });
     }
 
-    TEST_METHOD(write_spiff_entry_without_spiff_header) // NOLINT
+    TEST_METHOD(write_spiff_entry_without_spiff_header_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -631,7 +631,7 @@ public:
         Assert::AreEqual(uint8_t{2}, destination[13]);
     }
 
-    TEST_METHOD(write_too_large_comment) // NOLINT
+    TEST_METHOD(write_too_large_comment_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -645,7 +645,7 @@ public:
                                 [&encoder, &data] { ignore = encoder.write_comment(data.data(), data.size()); });
     }
 
-    TEST_METHOD(write_comment_null_pointer_with_size) // NOLINT
+    TEST_METHOD(write_comment_null_pointer_with_size_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -658,7 +658,7 @@ public:
         });
     }
 
-    TEST_METHOD(write_comment_after_encode) // NOLINT
+    TEST_METHOD(write_comment_after_encode_throws) // NOLINT
     {
         const vector<uint8_t> source{0, 1, 2, 3, 4, 5};
 
@@ -882,7 +882,7 @@ public:
         Assert::IsTrue(true);
     }
 
-    TEST_METHOD(set_preset_coding_parameters_bad_values) // NOLINT
+    TEST_METHOD(set_preset_coding_parameters_bad_values_throws) // NOLINT
     {
         const array<uint8_t, 5> source{0, 1, 1, 1, 0};
         constexpr frame_info frame_info{5, 1, 8, 1};
@@ -909,7 +909,7 @@ public:
         encode_with_custom_preset_coding_parameters({0, 0, 0, 0, 63});
     }
 
-    TEST_METHOD(set_color_transformation_bad_value) // NOLINT
+    TEST_METHOD(set_color_transformation_bad_value_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -917,7 +917,7 @@ public:
                                 [&encoder] { encoder.color_transformation(static_cast<color_transformation>(100)); });
     }
 
-    TEST_METHOD(encode_without_destination) // NOLINT
+    TEST_METHOD(encode_without_destination_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -926,7 +926,7 @@ public:
         assert_expect_exception(jpegls_errc::invalid_operation, [&encoder, &source] { ignore = encoder.encode(source); });
     }
 
-    TEST_METHOD(encode_without_frame_info) // NOLINT
+    TEST_METHOD(encode_without_frame_info_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -1070,7 +1070,7 @@ public:
                          interleave_mode::sample);
     }
 
-    TEST_METHOD(encode_with_bad_stride_interleave_none) // NOLINT
+    TEST_METHOD(encode_with_bad_stride_interleave_none_throws) // NOLINT
     {
         const array<uint8_t, 29> source{100, 100, 100, 0, 0, 0, 0, 0, 0,   0,   150, 150,
                                         150, 0,   0,   0, 0, 0, 0, 0, 200, 200, 200};
@@ -1085,7 +1085,7 @@ public:
                                 [&encoder, &source] { ignore = encoder.encode(source, 10); });
     }
 
-    TEST_METHOD(encode_with_bad_stride_interleave_sample) // NOLINT
+    TEST_METHOD(encode_with_bad_stride_interleave_sample_throws) // NOLINT
     {
         const array<uint8_t, 9> source{100, 150, 200, 100, 150, 200, 100, 150, 200};
         constexpr frame_info frame_info{3, 1, 8, 3};


### PR DESCRIPTION
CharLS is designed to throw when a method fails. End all unit test that verify this behaviour with _throws at the end.