### PR TITLE
Improve the compatibility with VS static analyzers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@
 # -clang-diagnostic-pragma-once-outside-header => Rationale: Generates false warnings for usage in header files
 # -clang-diagnostic-unused-const-variable => Rationale: false warnings for constexpr in .h files
 # -clang-diagnostic-unused-command-line-argument => Rationale: false warning about option passed to MSVC
+# -clang-diagnostic-declaration-after-statement => Rationale: Target is C14 and higher
 # -clang-analyzer-core.NonNullParamChecker => Rationale: cannot be effective disabled, already checked by other checkers.
 # -misc-non-private-member-variables-in-classes => Rationale: design can be ok, manual review is better
 # -modernize-use-trailing-return-type => Rationale: A style recommendation, this style is selected for CharLS
@@ -70,6 +71,7 @@ Checks:          '*,
                   -clang-diagnostic-pragma-once-outside-header,
                   -clang-diagnostic-unused-const-variable,
                   -clang-diagnostic-unused-command-line-argument,
+                  -clang-diagnostic-declaration-after-statement,
                   -clang-analyzer-core.NonNullParamChecker,
                   -misc-non-private-member-variables-in-classes,
                   -modernize-use-trailing-return-type,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,8 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
 
-      <!-- Explicit set the 'external' warning level to W3 (Supported since Visual Studio 2019 16.10) -->
-      <ExternalWarningLevel>Level3</ExternalWarningLevel>
+      <!-- Explicit disable warnings from external files (Supported since Visual Studio 2019 16.10) -->
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
 
       <!-- For development purposes, All warnings can be used to discover useful compiler warnings.
            This requires also that some warnings need to be disabled from this all warning list. -->
@@ -44,7 +44,6 @@
         C4623 = derived class`' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted [Just informational]
         C4625 = derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted [Just informational]
         C4626 = derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted [Just informational]
-        C4668 = symbol' is not defined as a preprocessor macro, replacing with '0' for 'directives' [problem in std C runtime headers when compiling as C]
         C4710 = function '' function not inlined [Just informational]
         C4711 = function '' selected for automatic inline expansion [Just informational]
         C4738 = storing 32-bit float result in memory, possible loss of performance [Just informational]
@@ -52,8 +51,9 @@
         C5026 = 'type': move constructor was implicitly defined as deleted [Just informational]
         C5027 = 'type': move assignment operator was implicitly defined as deleted [Just informational]
         C5045 = Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified [Just informational]
+        C5258 = explicit capture of '' is not required for this use [VS 2019 requires capture of constexpr]
       -->
-      <DisableSpecificWarnings Condition="'$(CHARLS_ALL_WARNINGS)'!=''">4061;4365;4464;4514;4571;4623;4625;4626;4668;4710;4711;4738;4820;5026;5027;5045</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(CHARLS_ALL_WARNINGS)'!=''">4061;4365;4464;4514;4571;4623;4625;4626;4710;4711;4738;4820;5026;5027;5045;5258</DisableSpecificWarnings>
 
       <!--
         __cplusplus = Use the correct value for the __cplusplus macro

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Before any major breaking change in the API and/or ABI a branch will be created 
 
 ## Related Projects
 
-* [CharLS.Native .NET](https://github.com/team-charls/charls-native-dotnet) - a .NET 5.0 and .NET 6.0 adapter assembly for CharLS
+* [CharLS.Native .NET](https://github.com/team-charls/charls-native-dotnet) - a .NET 6.0 adapter assembly for CharLS
 * [JPEG-LS WIC codec](https://github.com/team-charls/jpegls-wic-codec) - Windows Imaging Component (WIC) codec for JPEG-LS .jls files
 * [charls-js](https://github.com/chafey/charls-js) - WebAssembly build of CharLS, [Demo](https://chafey.github.io/charls-js/test/browser/index.html)
 * [JPEG-LS plugin for Python Pillow](https://github.com/planetmarshall/pillow-jpls) - JPEG-LS plugin for Python Pillow, [Pip](https://pypi.org/project/pillow-jpls/1.0.0/)

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -468,7 +468,7 @@ public:
     /// Function can be called after read_spiff_header and spiff_header_has_value.
     /// </summary>
     /// <returns>The SPIFF header.</returns>
-    CHARLS_CHECK_RETURN charls::spiff_header spiff_header() const&& noexcept
+    charls::spiff_header spiff_header() const&& noexcept  // Note: CHARLS_CHECK_RETURN causes false C6031 warnings [Visual Studio 2019 v16.11.19]
     {
         return spiff_header_;
     }
@@ -488,7 +488,7 @@ public:
     /// Function can be called after read_header.
     /// </summary>
     /// <returns>The frame info that describes the image stored in the JPEG-LS byte stream.</returns>
-    CHARLS_CHECK_RETURN charls::frame_info frame_info() const&& noexcept
+    charls::frame_info frame_info() const&& noexcept // Note: CHARLS_CHECK_RETURN causes false C6031 warnings [Visual Studio 2019 v16.11.19]
     {
         return frame_info_;
     }

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -43,7 +43,7 @@ void jpeg_stream_writer::write_spiff_header_segment(const spiff_header& header)
     ASSERT(header.height > 0);
     ASSERT(header.width > 0);
 
-    static constexpr array<uint8_t, 6> spiff_magic_id{'S', 'P', 'I', 'F', 'F', '\0'};
+    static constexpr array<uint8_t, 6> spiff_magic_id{{'S', 'P', 'I', 'F', 'F', '\0'}};
 
     // Create a JPEG APP8 segment in Still Picture Interchange File Format (SPIFF), v2.0
     write_segment_header(jpeg_marker_code::application_data8, 30);
@@ -78,7 +78,7 @@ void jpeg_stream_writer::write_spiff_end_of_directory_entry()
     // but only 6 data bytes. This approach allows to wrap existing bit streams\encoders with a SPIFF header.
     // In this implementation the SOI marker is added as data bytes to simplify the design.
     static constexpr array<uint8_t, 6> spiff_end_of_directory{
-        0, 0, 0, spiff_end_of_directory_entry_type, 0xFF, to_underlying_type(charls::jpeg_marker_code::start_of_image)};
+        {0, 0, 0, spiff_end_of_directory_entry_type, 0xFF, to_underlying_type(charls::jpeg_marker_code::start_of_image)}};
 
     write_segment_header(jpeg_marker_code::application_data8, spiff_end_of_directory.size());
     write_bytes(spiff_end_of_directory.data(), spiff_end_of_directory.size());

--- a/src/scan.h
+++ b/src/scan.h
@@ -31,8 +31,8 @@ extern const std::vector<int8_t> quantization_lut_lossless_16;
 
 // Used to determine how large runs should be encoded at a time. Defined by the JPEG-LS standard, A.2.1., Initialization
 // step 3.
-constexpr std::array<int, 32> J{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2,  2,  3,  3,  3,  3,
-                                4, 4, 5, 5, 6, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+constexpr std::array<int, 32> J{
+    {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15}};
 
 constexpr int32_t apply_sign(const int32_t i, const int32_t sign) noexcept
 {

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -143,7 +143,7 @@ public:
 
     TEST_METHOD(read_header_with_jpegls_preset_parameter_with_extended_id_throws) // NOLINT
     {
-        constexpr array<uint8_t, 8> ids{0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xC, 0xD};
+        constexpr array<uint8_t, 8> ids{{0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xC, 0xD}};
 
         for (const auto id : ids)
         {

--- a/unittest/validate_spiff_header_test.cpp
+++ b/unittest/validate_spiff_header_test.cpp
@@ -212,3 +212,5 @@ public:
 };
 
 }} // namespace charls::test
+
+MSVC_WARNING_UNSUPPRESS()


### PR DESCRIPTION
Ensure that CharLS can be compiled with zero static analyzer warnings in VS2019 and VS2022. VS2019 needs more explicit lambda capture.