### PR TITLE
Add a unit test for unsupported mixed interleave modes

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -100,26 +100,26 @@ struct lossless_traits final
 
 
 
-__declspec(noinline) int32_t get_predicted_value_default(int32_t Ra, int32_t Rb, int32_t Rc) noexcept
+__declspec(noinline) int32_t get_predicted_value_default(const int32_t ra, const int32_t rb, const int32_t rc) noexcept
 {
-    if (Ra < Rb)
+    if (ra < rb)
     {
-        if (Rc < Ra)
-            return Rb;
+        if (rc < ra)
+            return rb;
 
-        if (Rc > Rb)
-            return Ra;
+        if (rc > rb)
+            return ra;
     }
     else
     {
-        if (Rc < Rb)
-            return Ra;
+        if (rc < rb)
+            return ra;
 
-        if (Rc > Ra)
-            return Rb;
+        if (rc > ra)
+            return rb;
     }
 
-    return Ra + Rb - Rc;
+    return ra + rb - rc;
 }
 
 
@@ -265,8 +265,8 @@ static void bm_resize_vector(benchmark::State& state)
 {
     for (const auto _ : state)
     {
-        benchmark::DoNotOptimize(allocate_buffer(512 * 512 * 16));
-        benchmark::DoNotOptimize(allocate_buffer(1024 * 1024 * 8 * 3));
+        benchmark::DoNotOptimize(allocate_buffer(size_t{512} * 512 * 16));
+        benchmark::DoNotOptimize(allocate_buffer(size_t{1024} * 1024 * 8 * 3));
     }
 }
 BENCHMARK(bm_resize_vector);
@@ -318,8 +318,8 @@ static void bm_resize_overwrite_buffer(benchmark::State& state)
 {
     for (const auto _ : state)
     {
-        benchmark::DoNotOptimize(allocate_buffer(512 * 512 * 16));
-        benchmark::DoNotOptimize(allocate_buffer(1024 * 1024 * 8 * 3));
+        benchmark::DoNotOptimize(allocate_buffer(size_t{512} * 512 * 16));
+        benchmark::DoNotOptimize(allocate_buffer(size_t{1024} * 1024 * 8 * 3));
     }
 }
 BENCHMARK(bm_resize_overwrite_buffer);

--- a/benchmark/context_regular_mode_v220.h
+++ b/benchmark/context_regular_mode_v220.h
@@ -64,7 +64,7 @@ struct jls_context_v220 final
             {
                 b = -n + 1;
             }
-            C = C - static_cast<int16_t>(C > -128);
+            C = static_cast<int16_t>(C - static_cast<int16_t>(C > -128));
         }
         else if (b > 0)
         {
@@ -73,7 +73,7 @@ struct jls_context_v220 final
             {
                 b = 0;
             }
-            C = C + static_cast<int16_t>(C < 127);
+            C = static_cast<int16_t>(C + static_cast<int16_t>(C < 127));
         }
         B = b;
 

--- a/benchmark/log2.cpp
+++ b/benchmark/log2.cpp
@@ -9,12 +9,12 @@
 #include <limits>
 
 
-uint32_t log2_floor(uint32_t n) noexcept
+uint32_t log2_floor(const uint32_t n) noexcept
 {
     return 31 - charls::countl_zero(n);
 }
 
-uint32_t max_value_to_bits_per_sample(uint32_t max_value) noexcept
+uint32_t max_value_to_bits_per_sample(const uint32_t max_value) noexcept
 {
     ASSERT(max_value > 0);
     return log2_floor(max_value) + 1;

--- a/fuzztest/main.cpp
+++ b/fuzztest/main.cpp
@@ -30,11 +30,14 @@ using std::vector;
 #endif
 
 #ifndef __AFL_INIT
+// ReSharper disable once CppInconsistentNaming
 #define __AFL_INIT() // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #endif
 
 #ifndef __AFL_LOOP
+// ReSharper disable once CppInconsistentNaming
 #define __AFL_LOOP(a) true // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define AFL_LOOP_FOREVER
 #endif
 
 #if defined(__clang__)
@@ -92,7 +95,7 @@ int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-
         fd = _open(argv[1], O_RDONLY);
         if (fd < 0)
         {
-            std::cerr << "Failed to open: " << argv[1] << strerror(errno) << '\n';
+            std::cerr << "Failed to open: " << argv[1] << strerror(errno) << '\n';  // NOLINT(concurrency-mt-unsafe)
             return EXIT_FAILURE;
         }
     }
@@ -115,5 +118,7 @@ int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-
         }
     }
 
+#ifndef AFL_LOOP_FOREVER
     return EXIT_SUCCESS;
+#endif
 }

--- a/samples/convert.cpp/main.cpp
+++ b/samples/convert.cpp/main.cpp
@@ -122,7 +122,7 @@ void save_buffer_to_file(const void* buffer, const size_t buffer_size, const cha
     output.exceptions(std::ios::failbit | std::ios::badbit);
 
     output.write(static_cast<const char*>(buffer), static_cast<std::streamsize>(buffer_size));
-    output.close(); // close explict to get feedback on failures.
+    output.close(); // close explicitly to get feedback on failures.
 }
 
 void log_failure(const char* message) noexcept

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -259,7 +259,7 @@ private:
         const auto codec{jls_codec_factory<encoder_strategy>().create_codec(
             frame_info, {near_lossless_, 0, interleave_mode_, color_transformation_, false}, preset_coding_parameters_)};
         std::unique_ptr<process_line> process_line(codec->create_process_line(source, stride));
-        const size_t bytes_written{codec->encode_scan(move(process_line), writer_.remaining_destination())};
+        const size_t bytes_written{codec->encode_scan(std::move(process_line), writer_.remaining_destination())};
 
         // Synchronize the destination encapsulated in the writer (encode_scan works on a local copy)
         writer_.seek(bytes_written);

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -139,7 +139,7 @@ void jpeg_stream_reader::decode(byte_span destination, const size_t stride)
         const unique_ptr<decoder_strategy> codec{jls_codec_factory<decoder_strategy>().create_codec(
             frame_info_, parameters_, get_validated_preset_coding_parameters())};
         unique_ptr<process_line> process_line(codec->create_process_line(destination, destination_stride));
-        const size_t bytes_read{codec->decode_scan(move(process_line), rect_, const_byte_span{position_, end_position_})};
+        const size_t bytes_read{codec->decode_scan(std::move(process_line), rect_, const_byte_span{position_, end_position_})};
         advance_position(bytes_read);
         charls::skip_bytes(destination, bytes_per_plane);
         state_ = state::scan_section;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -55,7 +55,7 @@ ifstream open_input_stream(const char* filename)
 }
 
 
-uint32_t log2_floor(uint32_t n) noexcept
+uint32_t log2_floor(const uint32_t n) noexcept
 {
     ASSERT(n != 0 && "log2 is not defined for 0");
     return 31 - countl_zero(n);
@@ -68,7 +68,7 @@ constexpr int result_to_exit_code(const bool result) noexcept
 }
 
 
-uint32_t max_value_to_bits_per_sample(uint32_t max_value) noexcept
+uint32_t max_value_to_bits_per_sample(const uint32_t max_value) noexcept
 {
     ASSERT(max_value > 0);
     return log2_floor(max_value) + 1;

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -97,7 +97,7 @@ void write_file(const char* filename, const void* data, const size_t size)
     output.exceptions(ios::eofbit | ios::failbit | ios::badbit);
     output.open(filename, ios::out | ios::binary);
     output.write(static_cast<const char*>(data), static_cast<std::streamsize>(size));
-    output.close(); // close explict to get feedback on failures.
+    output.close(); // close explicitly to get feedback on failures.
 }
 
 void test_round_trip(const char* name, const vector<uint8_t>& decoded_buffer, const rect_size size,

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -616,7 +616,7 @@ public:
         callback_output actual;
 
         reader.at_application_data(
-            {[](int32_t id, const void* data, const size_t size, void* user_context) noexcept -> int32_t {
+            {[](const int32_t id, const void* data, const size_t size, void* user_context) noexcept -> int32_t {
                  auto* actual_output = static_cast<callback_output*>(user_context);
                  actual_output->id = id;
                  actual_output->data = data;
@@ -652,7 +652,7 @@ public:
         callback_output actual;
 
         reader.at_application_data(
-            {[](int32_t id, const void* data, const size_t size, void* user_context) noexcept -> int32_t {
+            {[](const int32_t id, const void* data, const size_t size, void* user_context) noexcept -> int32_t {
                  auto* actual_output = static_cast<callback_output*>(user_context);
                  actual_output->id = id;
                  actual_output->data = data;


### PR DESCRIPTION
CharLS doesn't support mixing interleave modes.
Add a unit test to ensure that CharLS will throw a not supported exception. The actual checking was already done.

Note: also resolve some static analyzer warnings, reported with the latest version of ReSharper\clang-tidy.