### PR TITLE
Add -Wconversion to GCC and clang as compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     -Wsized-deallocation
     -Wattributes
     -Wuseless-cast
+    -Wconversion
   )
   if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
       set(PEDANTIC_CXX_COMPILE_FLAGS ${PEDANTIC_CXX_COMPILE_FLAGS}
@@ -113,6 +114,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       -Wthread-safety
       -Wthread-safety-beta
       -Wcomma
+      -Wconversion
       # -Weverything provides the option to discover usefull Clang warnings.
       # The list below ignores not useful Weverything warnings.
       -Wno-weak-vtables                       # Ignore, linker will remove the couple of extra vtables.

--- a/src/color_transform.h
+++ b/src/color_transform.h
@@ -49,7 +49,7 @@ struct transform_hp1 final
 
         FORCE_INLINE triplet<T> operator()(const int v1, const int v2, const int v3) const noexcept
         {
-            return triplet<T>(v1 + v2 - range_ / 2, v2, v3 + v2 - range_ / 2);
+            return triplet<T>(static_cast<T>(v1 + v2 - range_ / 2), v2, static_cast<T>(v3 + v2 - range_ / 2));
         }
     };
 
@@ -84,7 +84,7 @@ struct transform_hp2 final
         {
             triplet<T> rgb;
             rgb.R = static_cast<T>(v1 + v2 - range_ / 2);                     // new R
-            rgb.G = static_cast<T>(v2);                                      // new G
+            rgb.G = static_cast<T>(v2);                                       // new G
             rgb.B = static_cast<T>(v3 + ((rgb.R + rgb.G) >> 1) - range_ / 2); // new B
             return rgb;
         }
@@ -92,7 +92,7 @@ struct transform_hp2 final
 
     FORCE_INLINE triplet<T> operator()(const int red, const int green, const int blue) const noexcept
     {
-        return triplet<T>(red - green + range_ / 2, green, blue - ((red + green) >> 1) - range_ / 2);
+        return triplet<T>(static_cast<T>(red - green + range_ / 2), green, static_cast<T>(blue - ((red + green) >> 1) - range_ / 2));
     }
 
 private:
@@ -115,10 +115,10 @@ struct transform_hp3 final
 
         FORCE_INLINE triplet<T> operator()(const int v1, const int v2, const int v3) const noexcept
         {
-            const int g = v1 - ((v3 + v2) >> 2) + range_ / 4;
+            const int g = static_cast<int>(v1 - ((v3 + v2) >> 2) + range_ / 4);
             triplet<T> rgb;
             rgb.R = static_cast<T>(v3 + g - range_ / 2); // new R
-            rgb.G = static_cast<T>(g);                  // new G
+            rgb.G = static_cast<T>(g);                   // new G
             rgb.B = static_cast<T>(v2 + g - range_ / 2); // new B
             return rgb;
         }
@@ -129,7 +129,7 @@ struct transform_hp3 final
         triplet<T> hp3;
         hp3.v2 = static_cast<T>(blue - green + range_ / 2);
         hp3.v3 = static_cast<T>(red - green + range_ / 2);
-        hp3.v1 = static_cast<T>(green + ((hp3.v2 + hp3.v3) >> 2)) - range_ / 4;
+        hp3.v1 = static_cast<T>(green + ((hp3.v2 + hp3.v3) >> 2) - range_ / 4);
         return hp3;
     }
 

--- a/src/context_run_mode.h
+++ b/src/context_run_mode.h
@@ -58,8 +58,8 @@ public:
         if (n_ == reset_threshold)
         {
             a_ >>= 1;
-            n_ >>= 1;
-            nn_ >>= 1;
+            n_ = static_cast<uint8_t>(n_ >> 1);
+            nn_ = static_cast<uint8_t>(nn_ >> 1);
         }
 
         ++n_;

--- a/src/process_line.h
+++ b/src/process_line.h
@@ -23,21 +23,19 @@
 
 namespace charls {
 
-class process_line
+struct process_line
 {
-public:
     virtual ~process_line() = default;
-
-    process_line(const process_line&) = delete;
-    process_line(process_line&&) = delete;
-    process_line& operator=(const process_line&) = delete;
-    process_line& operator=(process_line&&) = delete;
 
     virtual void new_line_decoded(const void* source, size_t pixel_count, size_t source_stride) = 0;
     virtual void new_line_requested(void* destination, size_t pixel_count, size_t destination_stride) = 0;
 
 protected:
     process_line() = default;
+    process_line(const process_line&) = default;
+    process_line(process_line&&) = default;
+    process_line& operator=(const process_line&) = default;
+    process_line& operator=(process_line&&) = default;
 };
 
 
@@ -93,7 +91,7 @@ public:
             auto* pixel_destination{static_cast<uint8_t*>(destination)};
             for (size_t i{}; i < pixel_count; ++i)
             {
-                pixel_destination[i] = pixel_source[i] & mask_;
+                pixel_destination[i] = static_cast<uint8_t>(pixel_source[i] & mask_);
             }
         }
         else
@@ -102,7 +100,7 @@ public:
             auto* pixel_destination{static_cast<uint16_t*>(destination)};
             for (size_t i{}; i < pixel_count; ++i)
             {
-                pixel_destination[i] = pixel_source[i] & mask_;
+                pixel_destination[i] = static_cast<uint16_t>(pixel_source[i] & mask_);
             }
         }
 
@@ -126,15 +124,14 @@ private:
 
 template<typename Transform, typename PixelType>
 void transform_line_to_quad(const PixelType* source, const size_t pixel_stride_in, quad<PixelType>* destination,
-                            const size_t pixel_stride,
-                            Transform& transform) noexcept
+                            const size_t pixel_stride, Transform& transform) noexcept
 {
     const auto pixel_count{std::min(pixel_stride, pixel_stride_in)};
 
     for (size_t i{}; i < pixel_count; ++i)
     {
         const quad<PixelType> pixel(transform(source[i], source[i + pixel_stride_in], source[i + 2 * pixel_stride_in]),
-                            source[i + 3 * pixel_stride_in]);
+                                    source[i + 3 * pixel_stride_in]);
         destination[i] = pixel;
     }
 }
@@ -142,8 +139,7 @@ void transform_line_to_quad(const PixelType* source, const size_t pixel_stride_i
 
 template<typename Transform, typename PixelType>
 void transform_quad_to_line(const quad<PixelType>* source, const size_t pixel_stride_in, PixelType* destination,
-                            const size_t pixel_stride,
-                            Transform& transform) noexcept
+                            const size_t pixel_stride, Transform& transform) noexcept
 {
     const auto pixel_count{std::min(pixel_stride, pixel_stride_in)};
 
@@ -313,7 +309,8 @@ public:
         raw_pixels_.data += stride_;
     }
 
-    void encode_transform(const void* source, void* destination, const size_t pixel_count, const size_t destination_stride) noexcept
+    void encode_transform(const void* source, void* destination, const size_t pixel_count,
+                          const size_t destination_stride) noexcept
     {
         if (parameters_.output_bgr)
         {

--- a/test/portable_anymap_file.h
+++ b/test/portable_anymap_file.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <fstream>
 #include <ios>
 #include <sstream>
-#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
-Wconversion will warn when implicit conversion may cause data loss.