### PR TITLE
Update version to 3.0.0 and minimum C++ version to 17

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,8 +12,8 @@
 # -llvm-header-guard => Rationale: #pragma once is used
 # -hicpp-no-array-decay => Rationale: alias for cppcoreguidelines-pro-bounds-constant-array-index
 # -hicpp-signed-bitwise => Rationale: Bad test, types are checked, not values.
-# -clang-diagnostic-c++98-compat* => Rationale: CharLS targets C++14
-# -clang-diagnostic-c++98-c++11-compat => Rationale: CharLS targets C++14
+# -clang-diagnostic-c++98-compat* => Rationale: CharLS targets C++17
+# -clang-diagnostic-c++98-c++11-compat => Rationale: CharLS targets C++17
 # -clang-diagnostic-unused-macros => Rationale: Macros defined in header are reported as problem
 # -clang-diagnostic-sign-conversion => Rationale: warning will be enabled in additional steps
 # -clang-diagnostic-switch-enum => Rationale: options are handled by default case
@@ -35,7 +35,7 @@
 # -cppcoreguidelines-macro-usage => Rationale: Many false warnings
 # -cppcoreguidelines-pro-bounds-array-to-pointer-decay => Span is not available
 # -cppcoreguidelines-pro-type-const-cast => Rationale: const cast is needed for legacy functions
-# -cppcoreguidelines-pro-type-union-access => Rationale: std::variant not an option as target is C++14
+# -cppcoreguidelines-pro-type-union-access => Rationale: usage of union is more efficient is used scenarios
 # -cppcoreguidelines-non-private-member-variables-in-classes => Warning is too strict, manual review code review is preferred
 # -cppcoreguidelines-pro-bounds-constant-array-index => gsl:at is not used by design
 # -cppcoreguidelines-init-variables => reports false warnings for out parameters (other checkers are better to detect these problems)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: SonarCloud Analysis
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '34 18 * * 6'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0] -
+
+### Changed
+
+- Updated the source code to C++17. This is a breaking change, high version is updated to 3.
+
 ## [2.4.1] - 2023-1-2
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Team CharLS.
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.13...3.25)
+cmake_minimum_required(VERSION 3.13...3.26)
 
 # Extract the version info from version.h
 file(READ "include/charls/version.h" version)
@@ -119,8 +119,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       # The list below ignores not useful Weverything warnings.
       -Wno-weak-vtables                       # Ignore, linker will remove the couple of extra vtables.
       -Wno-padded                             # Ignore, padding optimization is not needed.
-      -Wno-c++98-compat                       # Ignore, CharLS 2.x targets C++14, ignore C++98 compatibility.
-      -Wno-c++98-compat-pedantic              # Ignore, CharLS 2.x targets C++14, ignore C++98 compatibility.
+      -Wno-c++98-compat                       # Ignore, CharLS targets C++17, ignore C++98 compatibility.
+      -Wno-c++98-compat-pedantic              # Ignore, CharLS targets C++17, ignore C++98 compatibility.
       -Wno-global-constructors                # Ignore, by design CharLS uses types created at startup.
       -Wno-switch-enum                        # Ignore, cases are handled by default.
       -Wno-sign-conversion                    # Ignore, would just introduce ugly static_asserts.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,8 +67,8 @@
       <!-- Use all cores to speed up the compilation (MS recommended best practice). -->
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
 
-      <!-- Explicit define that all projects are compiled according the latest offical C++14 standard -->
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <!-- Explicit define that all projects are compiled according the latest offical C++17 standard -->
+      <LanguageStandard>stdcpp17</LanguageStandard>
 
       <!-- Explicit disable non conforming MSVC compiler options that are not compatible with the C++ standard -->
       <ConformanceMode>true</ConformanceMode>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-<img src="https://raw.githubusercontent.com/team-charls/charls/master/doc/jpeg_ls_logo.png" alt="JPEG-LS Logo" width="100"/>
+<img src="https://raw.githubusercontent.com/team-charls/charls/main/doc/jpeg_ls_logo.png" alt="JPEG-LS Logo" width="100"/>
 
 # CharLS
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://raw.githubusercontent.com/team-charls/charls/master/LICENSE.md)
-[![Build status](https://ci.appveyor.com/api/projects/status/yq0naf3v2m8nfa8r/branch/master?svg=true)](https://ci.appveyor.com/project/vbaderks/charls/branch/master)
-[![Build Status](https://dev.azure.com/team-charls/charls/_apis/build/status/team-charls.charls?branchName=master)](https://dev.azure.com/team-charls/charls/_build/latest?definitionId=2&branchName=master)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://raw.githubusercontent.com/team-charls/charls/main/LICENSE.md)
+[![Build status](https://ci.appveyor.com/api/projects/status/yq0naf3v2m8nfa8r/branch/main?svg=true)](https://ci.appveyor.com/project/vbaderks/charls/branch/main)
+[![Build Status](https://dev.azure.com/team-charls/charls/_apis/build/status/team-charls.charls?branchName=main)](https://dev.azure.com/team-charls/charls/_build/latest?definitionId=2&branchName=main)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=team-charls_charls&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=team-charls_charls)
 [![Vcpkg package](https://repology.org/badge/version-for-repo/vcpkg/charls.svg)](https://repology.org/metapackage/charls)
 
@@ -14,7 +14,7 @@ JPEG-LS is a low-complexity image compression standard that matches JPEG 2000 co
 
 ## Features
 
-* C++14 library implementation with a binary C interface for maximum interoperability.
+* C++17 library implementation with a binary C interface for maximum interoperability.
 * Supports Windows, Linux and macOS on x86, x64, arm, arm64, mips, s390x and ppc64le.
 * Adapters for .NET, JavaScript (WebAssembly) and Python applications available.
 * Excellent compression and decompression performance.
@@ -27,7 +27,7 @@ Tip: ITU makes their version of the JPEG-LS standard (ITU-T.87) freely available
 
 ## About this software
 
-This project's goal is to provide a full implementation of the ISO/IEC 14495-1:1999, "Lossless and near-lossless compression of continuous-tone still images: Baseline" standard. This library is written from scratch in portable C++. The master branch uses modern C++14. The 1.x branch is maintained in C++03. All mainstream JPEG-LS features are implemented by this library.
+This project's goal is to provide a full implementation of the ISO/IEC 14495-1:1999, "Lossless and near-lossless compression of continuous-tone still images: Baseline" standard. This library is written from scratch in portable C++. The main branch uses C++17. The 2.x branch is maintained in C++14. All mainstream JPEG-LS features are implemented by this library.
 According to preliminary test results published on <https://imagecompression.info/gralic,> CharLS is about *twice as fast* as the original HP code, and beats both JPEG-XR and JPEG 2000 by a factor 3.
 
 ### Limitations
@@ -79,7 +79,7 @@ Support for older compiler versions will be phased out, 5 years from the moment 
 
 ### Long Term Support (LTS) Branches
 
-Before any major breaking change in the API and/or ABI a branch will be created from master to freeze that snapshot as LTS branch.
+Before any major breaking change in the API and/or ABI a branch will be created from main to freeze that snapshot as LTS branch.
 
 ## Related Projects
 

--- a/doc/style_and_design.md
+++ b/doc/style_and_design.md
@@ -130,7 +130,7 @@ sense to define a good naming convention. Not all JPEG-LS names are good C++ var
 
 ### Supported C++ language
 
-CharLS currently targets C++14 on the main branch. This will be done until December 2022 (5 years after the release of C++17)
+CharLS currently targets C++17 on the main branch. This will be done until December 2025 (5 years after the release of C++20)
 
 #### Features currently not available (C++17)
 

--- a/include/charls/annotations.h
+++ b/include/charls/annotations.h
@@ -23,7 +23,7 @@
 #if defined(__cplusplus) && __cplusplus >= 201703
 #define CHARLS_CHECK_RETURN [[nodiscard]]
 #else
-// Use MSVC specific solution for C and C++14.
+// Use MSVC specific solution for C
 #define CHARLS_CHECK_RETURN _Check_return_
 #endif
 

--- a/include/charls/version.h
+++ b/include/charls/version.h
@@ -14,14 +14,14 @@ extern "C" {
 #endif
 
 
-#define CHARLS_VERSION_MAJOR 2
-#define CHARLS_VERSION_MINOR 4
-#define CHARLS_VERSION_PATCH 1
+#define CHARLS_VERSION_MAJOR 3
+#define CHARLS_VERSION_MINOR 0
+#define CHARLS_VERSION_PATCH 0
 
 /// <summary>
 /// Returns the version of CharLS in the semver format "major.minor.patch" or "major.minor.patch-pre_release"
 /// </summary>
-CHARLS_CHECK_RETURN CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT const char*
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT const char*
     CHARLS_API_CALLING_CONVENTION charls_get_version_string(CHARLS_C_VOID);
 
 /// <summary>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,12 +29,12 @@ endif()
 if(WIN32 AND BUILD_SHARED_LIBS)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM64")
-      set_target_properties(charls PROPERTIES OUTPUT_NAME "charls-2-arm64")
+      set_target_properties(charls PROPERTIES OUTPUT_NAME "charls-3-arm64")
     else()
-      set_target_properties(charls PROPERTIES OUTPUT_NAME "charls-2-x64")
+      set_target_properties(charls PROPERTIES OUTPUT_NAME "charls-3-x64")
     endif()
   else()
-    set_target_properties(charls PROPERTIES OUTPUT_NAME "charls-2-x86")
+    set_target_properties(charls PROPERTIES OUTPUT_NAME "charls-3-x86")
   endif()
 endif()
 
@@ -53,8 +53,9 @@ set_target_properties(charls PROPERTIES
                       SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_compile_definitions(charls PRIVATE CHARLS_LIBRARY_BUILD)
-# CharLS requires C++14 or newer.
-target_compile_features(charls PUBLIC cxx_std_14)
+
+# CharLS requires C++17 or newer.
+target_compile_features(charls PUBLIC cxx_std_17)
 
 set(HEADERS
     "include/charls/api_abi.h"

--- a/src/CharLS.vcxproj
+++ b/src/CharLS.vcxproj
@@ -84,31 +84,31 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Checked|Win32'">
-    <TargetName>charls-2-x86</TargetName>
+    <TargetName>charls-3-x86</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <TargetName>charls-2-x86</TargetName>
+    <TargetName>charls-3-x86</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>charls-2-x86</TargetName>
+    <TargetName>charls-3-x86</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Checked|x64'">
-    <TargetName>charls-2-x64</TargetName>
+    <TargetName>charls-3-x64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Checked|ARM64'">
-    <TargetName>charls-2-arm64</TargetName>
+    <TargetName>charls-3-arm64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TargetName>charls-2-x64</TargetName>
+    <TargetName>charls-3-x64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <TargetName>charls-2-arm64</TargetName>
+    <TargetName>charls-3-arm64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <TargetName>charls-2-x64</TargetName>
+    <TargetName>charls-3-x64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <TargetName>charls-2-arm64</TargetName>
+    <TargetName>charls-3-arm64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/byte_span.h
+++ b/src/byte_span.h
@@ -10,7 +10,7 @@
 
 namespace charls {
 
-/// <summary>Simplified span class for C++14 (std::span<std::byte>).</summary>
+/// <summary>Simplified span class for C++20 (std::span<std::byte>).</summary>
 struct byte_span final
 {
     byte_span() = default;
@@ -39,7 +39,7 @@ struct byte_span final
 };
 
 
-/// <summary>Simplified span class for C++14 (std::span<const std::byte>).</summary>
+/// <summary>Simplified span class for C++20 (std::span<const std::byte>).</summary>
 class const_byte_span final
 {
 public:

--- a/src/util.h
+++ b/src/util.h
@@ -66,7 +66,7 @@
 #endif
 
 // C++20 has support for [[likely]] and [[unlikely]]. Use for now the GCC\Clang extension.
-// MSVC has in C++14\C++17 mode no alternative for it.
+// MSVC has in C++17 mode no alternative for it.
 #ifdef __GNUC__
 #define UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -10,7 +10,7 @@ using namespace charls;
 
 extern "C" {
 
-USE_DECL_ANNOTATIONS const char* CHARLS_API_CALLING_CONVENTION charls_get_version_string()
+const char* CHARLS_API_CALLING_CONVENTION charls_get_version_string()
 {
     return TO_STRING(CHARLS_VERSION_MAJOR) "." TO_STRING(CHARLS_VERSION_MINOR) "." TO_STRING(CHARLS_VERSION_PATCH);
 }


### PR DESCRIPTION
The release of C++17 has been 5 years ago. The supported period of C++14 has ended and the minimum required C++ version will be increased to C++17 for building the library and using it.