### PR TITLE
Replace CHARLS_CHECK_RETURN with [[nodiscard]]

### DIFF
--- a/include/charls/annotations.h
+++ b/include/charls/annotations.h
@@ -19,11 +19,10 @@
 #define CHARLS_RETURN_TYPE_SUCCESS(expr) _Return_type_success_(expr)
 #define CHARLS_RET_MAY_BE_NULL _Ret_maybenull_
 
-// When possible use [[nodiscard]] as this can by handled by all C++17 compilers.
-#if defined(__cplusplus) && __cplusplus >= 201703
+#if defined(__cplusplus)
 #define CHARLS_CHECK_RETURN [[nodiscard]]
 #else
-// Use MSVC specific solution for C
+// Use MSVC specific solution for C ([[nodiscard]] required C23)
 #define CHARLS_CHECK_RETURN _Check_return_
 #endif
 
@@ -41,10 +40,10 @@
 #define CHARLS_RETURN_TYPE_SUCCESS(expr)
 #define CHARLS_RET_MAY_BE_NULL
 
-// When possible use [[nodiscard]] as this can by handled by all C++17 compilers.
-#if defined(__cplusplus) && __cplusplus >= 201703
+#if defined(__cplusplus)
     #define CHARLS_CHECK_RETURN [[nodiscard]]
 #else
+    //  Use GCC/clang specific solution for C ([[nodiscard]] required C23)
     #if defined(__GNUC__)
         #define CHARLS_CHECK_RETURN __attribute__((warn_unused_result))
     #else

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -448,7 +448,7 @@ public:
     /// Returns true if a valid SPIFF header was found.
     /// </summary>
     /// <returns>True of false, depending if a SPIFF header was found.</returns>
-    CHARLS_CHECK_RETURN bool spiff_header_has_value() const noexcept
+    [[nodiscard]] bool spiff_header_has_value() const noexcept
     {
         return spiff_header_has_value_;
     }
@@ -458,7 +458,7 @@ public:
     /// Function can be called after read_spiff_header and spiff_header_has_value.
     /// </summary>
     /// <returns>The SPIFF header.</returns>
-    CHARLS_CHECK_RETURN const charls::spiff_header& spiff_header() const& noexcept
+    [[nodiscard]] const charls::spiff_header& spiff_header() const& noexcept
     {
         return spiff_header_;
     }
@@ -468,7 +468,7 @@ public:
     /// Function can be called after read_spiff_header and spiff_header_has_value.
     /// </summary>
     /// <returns>The SPIFF header.</returns>
-    charls::spiff_header spiff_header() const&& noexcept  // Note: CHARLS_CHECK_RETURN causes false C6031 warnings [Visual Studio 2019 v16.11.19]
+    [[nodiscard]] charls::spiff_header spiff_header() const&& noexcept
     {
         return spiff_header_;
     }
@@ -478,7 +478,7 @@ public:
     /// Function can be called after read_header.
     /// </summary>
     /// <returns>The frame info that describes the image stored in the JPEG-LS byte stream.</returns>
-    CHARLS_CHECK_RETURN const charls::frame_info& frame_info() const& noexcept
+    [[nodiscard]] const charls::frame_info& frame_info() const& noexcept
     {
         return frame_info_;
     }
@@ -488,7 +488,7 @@ public:
     /// Function can be called after read_header.
     /// </summary>
     /// <returns>The frame info that describes the image stored in the JPEG-LS byte stream.</returns>
-    charls::frame_info frame_info() const&& noexcept // Note: CHARLS_CHECK_RETURN causes false C6031 warnings [Visual Studio 2019 v16.11.19]
+    [[nodiscard]] charls::frame_info frame_info() const&& noexcept
     {
         return frame_info_;
     }
@@ -499,7 +499,7 @@ public:
     /// <param name="component">The component index for which the NEAR parameter should be retrieved.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the NEAR parameter.</returns>
-    CHARLS_CHECK_RETURN int32_t near_lossless(const int32_t component = 0) const
+    [[nodiscard]] int32_t near_lossless(const int32_t component = 0) const
     {
         int32_t near_lossless;
         check_jpegls_errc(charls_jpegls_decoder_get_near_lossless(decoder_.get(), component, &near_lossless));
@@ -511,7 +511,7 @@ public:
     /// </summary>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the interleave mode.</returns>
-    CHARLS_CHECK_RETURN charls::interleave_mode interleave_mode() const
+    [[nodiscard]] charls::interleave_mode interleave_mode() const
     {
         charls::interleave_mode interleave_mode;
         check_jpegls_errc(charls_jpegls_decoder_get_interleave_mode(decoder_.get(), &interleave_mode));
@@ -523,7 +523,7 @@ public:
     /// </summary>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The values of the JPEG-LS preset coding parameters.</returns>
-    CHARLS_CHECK_RETURN jpegls_pc_parameters preset_coding_parameters() const
+    [[nodiscard]] jpegls_pc_parameters preset_coding_parameters() const
     {
         jpegls_pc_parameters preset_coding_parameters;
         check_jpegls_errc(charls_jpegls_decoder_get_preset_coding_parameters(decoder_.get(), 0, &preset_coding_parameters));
@@ -535,7 +535,7 @@ public:
     /// </summary>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the color transformation.</returns>
-    CHARLS_CHECK_RETURN charls::color_transformation color_transformation() const
+    [[nodiscard]] charls::color_transformation color_transformation() const
     {
         charls::color_transformation color_transformation;
         check_jpegls_errc(charls_jpegls_decoder_get_color_transformation(decoder_.get(), &color_transformation));
@@ -549,7 +549,7 @@ public:
     /// <param name="stride">Number of bytes to the next line in the buffer, when zero, decoder will compute it.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The required size in bytes of the destination buffer.</returns>
-    CHARLS_CHECK_RETURN size_t destination_size(const uint32_t stride = 0) const
+    [[nodiscard]] size_t destination_size(const uint32_t stride = 0) const
     {
         size_t size_in_bytes;
         check_jpegls_errc(charls_jpegls_decoder_get_destination_size(decoder_.get(), stride, &size_in_bytes));
@@ -594,7 +594,7 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>Container with the decoded data.</returns>
     template<typename Container, typename T = typename Container::value_type>
-    CHARLS_CHECK_RETURN Container decode(const uint32_t stride = 0) const
+    [[nodiscard]] Container decode(const uint32_t stride = 0) const
     {
         Container destination(destination_size() / sizeof(typename Container::value_type));
 
@@ -640,7 +640,7 @@ public:
     }
 
 private:
-    CHARLS_CHECK_RETURN static charls_jpegls_decoder* create_decoder()
+    [[nodiscard]] static charls_jpegls_decoder* create_decoder()
     {
         charls_jpegls_decoder* decoder{charls_jpegls_decoder_create()};
         if (!decoder)

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -412,7 +412,7 @@ public:
     /// Size for dynamic extras like SPIFF entries and other tables are not included in this size.
     /// </remarks>
     /// <returns>The estimated size in bytes needed to hold the encoded image.</returns>
-    CHARLS_CHECK_RETURN size_t estimated_destination_size() const
+    [[nodiscard]] size_t estimated_destination_size() const
     {
         size_t size_in_bytes;
         check_jpegls_errc(charls_jpegls_encoder_get_estimated_destination_size(encoder_.get(), &size_in_bytes));
@@ -589,7 +589,7 @@ public:
     /// Returns the size in bytes, that are written to the destination.
     /// </summary>
     /// <returns>The bytes written.</returns>
-    CHARLS_CHECK_RETURN size_t bytes_written() const
+    [[nodiscard]] size_t bytes_written() const
     {
         size_t bytes_written;
         check_jpegls_errc(charls_jpegls_encoder_get_bytes_written(encoder_.get(), &bytes_written));
@@ -605,7 +605,7 @@ public:
     }
 
 private:
-    CHARLS_CHECK_RETURN static charls_jpegls_encoder* create_encoder()
+    [[nodiscard]] static charls_jpegls_encoder* create_encoder()
     {
         charls_jpegls_encoder* encoder{charls_jpegls_encoder_create()};
         if (!encoder)

--- a/include/charls/jpegls_error.h
+++ b/include/charls/jpegls_error.h
@@ -17,12 +17,12 @@ CHARLS_API_IMPORT_EXPORT const char* CHARLS_API_CALLING_CONVENTION charls_get_er
 
 namespace charls {
 
-CHARLS_CHECK_RETURN inline const std::error_category& jpegls_category() noexcept
+[[nodiscard]] inline const std::error_category& jpegls_category() noexcept
 {
     return *(charls_get_jpegls_category());
 }
 
-CHARLS_CHECK_RETURN inline std::error_code make_error_code(jpegls_errc error_value) noexcept
+[[nodiscard]] inline std::error_code make_error_code(jpegls_errc error_value) noexcept
 {
     return {static_cast<int>(error_value), jpegls_category()};
 }

--- a/src/byte_span.h
+++ b/src/byte_span.h
@@ -24,12 +24,12 @@ struct byte_span final
     {
     }
 
-    CHARLS_CHECK_RETURN constexpr uint8_t* begin() const noexcept
+    [[nodiscard]] constexpr uint8_t* begin() const noexcept
     {
         return data;
     }
 
-    CHARLS_CHECK_RETURN constexpr uint8_t* end() const noexcept
+    [[nodiscard]] constexpr uint8_t* end() const noexcept
     {
         return data + size;
     }
@@ -56,27 +56,27 @@ public:
     {
     }
 
-    CHARLS_CHECK_RETURN constexpr size_t size() const noexcept
+    [[nodiscard]] constexpr size_t size() const noexcept
     {
         return size_;
     }
 
-    CHARLS_CHECK_RETURN constexpr const uint8_t* data() const noexcept
+    [[nodiscard]] constexpr const uint8_t* data() const noexcept
     {
         return data_;
     }
 
-    CHARLS_CHECK_RETURN constexpr iterator begin() const noexcept
+    [[nodiscard]] constexpr iterator begin() const noexcept
     {
         return data_;
     }
 
-    CHARLS_CHECK_RETURN constexpr iterator end() const noexcept
+    [[nodiscard]] constexpr iterator end() const noexcept
     {
         return data_ + size_;
     }
 
-    CHARLS_CHECK_RETURN constexpr bool empty() const noexcept
+    [[nodiscard]] constexpr bool empty() const noexcept
     {
         return size_ == 0;
     }

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <array>
 #include <memory>
-#include <tuple>
 
 namespace charls {
 
@@ -179,7 +178,7 @@ void jpeg_stream_reader::read_next_start_of_scan()
 }
 
 
-USE_DECL_ANNOTATIONS jpeg_marker_code jpeg_stream_reader::read_next_marker_code()
+jpeg_marker_code jpeg_stream_reader::read_next_marker_code()
 {
     auto byte{read_byte_checked()};
     if (UNLIKELY(byte != jpeg_marker_start_byte))
@@ -263,7 +262,7 @@ void jpeg_stream_reader::validate_marker_code(const jpeg_marker_code marker_code
 }
 
 
-USE_DECL_ANNOTATIONS jpegls_pc_parameters jpeg_stream_reader::get_validated_preset_coding_parameters() const
+jpegls_pc_parameters jpeg_stream_reader::get_validated_preset_coding_parameters() const
 {
     jpegls_pc_parameters preset_coding_parameters;
 
@@ -546,7 +545,7 @@ void jpeg_stream_reader::read_start_of_scan_segment()
 }
 
 
-USE_DECL_ANNOTATIONS uint8_t jpeg_stream_reader::read_byte_checked()
+uint8_t jpeg_stream_reader::read_byte_checked()
 {
     if (UNLIKELY(position_ == end_position_))
         throw_jpegls_error(jpegls_errc::source_buffer_too_small);
@@ -555,7 +554,7 @@ USE_DECL_ANNOTATIONS uint8_t jpeg_stream_reader::read_byte_checked()
 }
 
 
-USE_DECL_ANNOTATIONS uint16_t jpeg_stream_reader::read_uint16_checked()
+uint16_t jpeg_stream_reader::read_uint16_checked()
 {
     if (UNLIKELY(position_ + sizeof(uint16_t) > end_position_))
         throw_jpegls_error(jpegls_errc::source_buffer_too_small);
@@ -564,7 +563,7 @@ USE_DECL_ANNOTATIONS uint16_t jpeg_stream_reader::read_uint16_checked()
 }
 
 
-USE_DECL_ANNOTATIONS uint8_t jpeg_stream_reader::read_byte() noexcept
+uint8_t jpeg_stream_reader::read_byte() noexcept
 {
     ASSERT(position_ != end_position_);
 
@@ -580,7 +579,7 @@ void jpeg_stream_reader::skip_byte() noexcept
 }
 
 
-USE_DECL_ANNOTATIONS uint16_t jpeg_stream_reader::read_uint16() noexcept
+uint16_t jpeg_stream_reader::read_uint16() noexcept
 {
     ASSERT(position_ + sizeof(uint16_t) <= end_position_);
 
@@ -590,14 +589,14 @@ USE_DECL_ANNOTATIONS uint16_t jpeg_stream_reader::read_uint16() noexcept
 }
 
 
-USE_DECL_ANNOTATIONS uint32_t jpeg_stream_reader::read_uint24() noexcept
+uint32_t jpeg_stream_reader::read_uint24() noexcept
 {
     const uint32_t value{static_cast<uint32_t>(read_uint8()) << 16U};
     return value + read_uint16();
 }
 
 
-USE_DECL_ANNOTATIONS uint32_t jpeg_stream_reader::read_uint32() noexcept
+uint32_t jpeg_stream_reader::read_uint32() noexcept
 {
     ASSERT(position_ + sizeof(uint32_t) <= end_position_);
 
@@ -607,7 +606,7 @@ USE_DECL_ANNOTATIONS uint32_t jpeg_stream_reader::read_uint32() noexcept
 }
 
 
-USE_DECL_ANNOTATIONS const_byte_span jpeg_stream_reader::read_bytes(const size_t byte_count) noexcept
+const_byte_span jpeg_stream_reader::read_bytes(const size_t byte_count) noexcept
 {
     ASSERT(position_ + byte_count <= end_position_);
 
@@ -763,7 +762,7 @@ void jpeg_stream_reader::check_interleave_mode(const interleave_mode mode) const
 }
 
 
-USE_DECL_ANNOTATIONS uint32_t jpeg_stream_reader::maximum_sample_value() const noexcept
+uint32_t jpeg_stream_reader::maximum_sample_value() const noexcept
 {
     if (preset_coding_parameters_.maximum_sample_value != 0)
         return static_cast<uint32_t>(preset_coding_parameters_.maximum_sample_value);

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -76,28 +76,28 @@ private:
         position_ += count;
     }
 
-    CHARLS_CHECK_RETURN uint8_t read_byte_checked();
-    CHARLS_CHECK_RETURN uint16_t read_uint16_checked();
+    [[nodiscard]] uint8_t read_byte_checked();
+    [[nodiscard]] uint16_t read_uint16_checked();
 
-    CHARLS_CHECK_RETURN uint8_t read_byte() noexcept;
+    [[nodiscard]] uint8_t read_byte() noexcept;
     void skip_byte() noexcept;
 
-    CHARLS_CHECK_RETURN uint8_t read_uint8() noexcept
+    [[nodiscard]] uint8_t read_uint8() noexcept
     {
         return read_byte();
     }
 
-    CHARLS_CHECK_RETURN uint16_t read_uint16() noexcept;
-    CHARLS_CHECK_RETURN uint32_t read_uint24() noexcept;
-    CHARLS_CHECK_RETURN uint32_t read_uint32() noexcept;
-    CHARLS_CHECK_RETURN const_byte_span read_bytes(size_t byte_count) noexcept;
+    [[nodiscard]] uint16_t read_uint16() noexcept;
+    [[nodiscard]] uint32_t read_uint24() noexcept;
+    [[nodiscard]] uint32_t read_uint32() noexcept;
+    [[nodiscard]] const_byte_span read_bytes(size_t byte_count) noexcept;
     void read_segment_size();
     void check_minimal_segment_size(size_t minimum_size) const;
     void check_segment_size(size_t expected_size) const;
     void read_next_start_of_scan();
-    CHARLS_CHECK_RETURN jpeg_marker_code read_next_marker_code();
+    [[nodiscard]] jpeg_marker_code read_next_marker_code();
     void validate_marker_code(jpeg_marker_code marker_code) const;
-    CHARLS_CHECK_RETURN jpegls_pc_parameters get_validated_preset_coding_parameters() const;
+    [[nodiscard]] jpegls_pc_parameters get_validated_preset_coding_parameters() const;
     void read_marker_segment(jpeg_marker_code marker_code, spiff_header* header = nullptr,
                              bool* spiff_header_found = nullptr);
     void read_spiff_directory_entry(jpeg_marker_code marker_code);
@@ -115,7 +115,7 @@ private:
     void add_component(uint8_t component_id);
     void check_parameter_coherent() const;
     void check_interleave_mode(interleave_mode mode) const;
-    CHARLS_CHECK_RETURN uint32_t maximum_sample_value() const noexcept;
+    [[nodiscard]] uint32_t maximum_sample_value() const noexcept;
     void skip_remaining_segment_data() noexcept;
     void check_frame_info() const;
     void frame_info_height(uint32_t height);

--- a/src/util.h
+++ b/src/util.h
@@ -281,7 +281,7 @@ template<int Bits, typename T>
 constexpr bool is_uint_v = sizeof(T) == (Bits / 8) && std::is_integral<T>::value && !std::is_signed<T>::value;
 
 template<typename T>
-CHARLS_CHECK_RETURN auto byte_swap(const T value) noexcept -> std::enable_if_t<is_uint_v<16, T>, uint16_t>
+[[nodiscard]] auto byte_swap(const T value) noexcept -> std::enable_if_t<is_uint_v<16, T>, uint16_t>
 {
 #ifdef _MSC_VER
     return _byteswap_ushort(value);
@@ -292,7 +292,7 @@ CHARLS_CHECK_RETURN auto byte_swap(const T value) noexcept -> std::enable_if_t<i
 }
 
 template<typename T>
-CHARLS_CHECK_RETURN auto byte_swap(const T value) noexcept -> std::enable_if_t<is_uint_v<32, T>, uint32_t>
+[[nodiscard]] auto byte_swap(const T value) noexcept -> std::enable_if_t<is_uint_v<32, T>, uint32_t>
 {
 #ifdef _MSC_VER
     return _byteswap_ulong(value);
@@ -303,7 +303,7 @@ CHARLS_CHECK_RETURN auto byte_swap(const T value) noexcept -> std::enable_if_t<i
 }
 
 template<typename T>
-CHARLS_CHECK_RETURN auto byte_swap(const T value) noexcept -> std::enable_if_t<is_uint_v<64, T>, uint64_t>
+[[nodiscard]] auto byte_swap(const T value) noexcept -> std::enable_if_t<is_uint_v<64, T>, uint64_t>
 {
 #ifdef _MSC_VER
     return _byteswap_uint64(value);


### PR DESCRIPTION
C++17 always provide the standard [[nodiscard]] attribute
Use this attribute when compiling in C++ mode. Code that also can be used in C mode still needs to use CHARLS_CHECK_RETURN. C23 will also provide the attribute [[nodiscard]].