### PR TITLE
Remove legacy 1.x struct JlsRect

### DIFF
--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -927,15 +927,6 @@ struct charls_jpegls_pc_parameters CHARLS_FINAL
 };
 
 
-struct JlsRect
-{
-    int32_t X;
-    int32_t Y;
-    int32_t Width;
-    int32_t Height;
-};
-
-
 #ifdef __cplusplus
 
 /// <summary>
@@ -987,7 +978,5 @@ typedef int32_t(CHARLS_API_CALLING_CONVENTION* charls_at_application_data_handle
 typedef struct charls_spiff_header charls_spiff_header;
 typedef struct charls_frame_info charls_frame_info;
 typedef struct charls_jpegls_pc_parameters charls_jpegls_pc_parameters;
-
-typedef struct JlsRect JlsRect;
 
 #endif

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -136,11 +136,6 @@ struct charls_jpegls_decoder final
         reader_.output_bgr(value);
     }
 
-    void region(const JlsRect& rect) noexcept
-    {
-        reader_.rect(rect);
-    }
-
 private:
     enum class state
     {

--- a/src/decoder_strategy.h
+++ b/src/decoder_strategy.h
@@ -31,7 +31,7 @@ public:
 
     virtual std::unique_ptr<process_line> create_process_line(byte_span destination, size_t stride) = 0;
     virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters, uint32_t restart_interval) = 0;
-    virtual size_t decode_scan(std::unique_ptr<process_line> output_data, const JlsRect& size, const_byte_span encoded_source) = 0;
+    virtual size_t decode_scan(std::unique_ptr<process_line> output_data, const_byte_span encoded_source) = 0;
 
     void initialize(const const_byte_span source)
     {

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -50,11 +50,6 @@ public:
         parameters_.output_bgr = value;
     }
 
-    void rect(const JlsRect& rect) noexcept
-    {
-        rect_ = rect;
-    }
-
     void at_comment(const callback_function<at_comment_handler> at_comment_callback) noexcept
     {
         at_comment_callback_ = at_comment_callback;
@@ -140,7 +135,6 @@ private:
     charls::frame_info frame_info_{};
     coding_parameters parameters_{};
     jpegls_pc_parameters preset_coding_parameters_{};
-    JlsRect rect_{};
     std::vector<uint8_t> component_ids_;
     state state_{};
     callback_function<at_comment_handler> at_comment_callback_{};

--- a/src/scan.h
+++ b/src/scan.h
@@ -444,12 +444,11 @@ private:
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-explicit-virtual-functions, hicpp-use-override, modernize-use-override, clang-diagnostic-suggest-override)
-    size_t decode_scan(std::unique_ptr<process_line> process_line, const JlsRect& rect, const_byte_span encoded_source)
+    size_t decode_scan(std::unique_ptr<process_line> process_line, const_byte_span encoded_source)
     {
         Strategy::process_line_ = std::move(process_line);
 
         const auto* scan_begin{encoded_source.begin()};
-        rect_ = rect;
 
         Strategy::initialize(encoded_source);
 
@@ -582,13 +581,9 @@ private:
                     current_line_ += pixel_stride;
                 }
 
-                // Only copy the line if it is part of the output rectangle.
-                if (static_cast<uint32_t>(rect_.Y) <= line && line < static_cast<uint32_t>(rect_.Y + rect_.Height))
-                {
-                    Strategy::on_line_end(current_line_ + rect_.X - (static_cast<size_t>(component_count) * pixel_stride),
-                                          rect_.Width,
-                                          pixel_stride);
-                }
+                Strategy::on_line_end(current_line_ - (static_cast<size_t>(component_count) * pixel_stride),
+                                      frame_info().width,
+                                      pixel_stride);
             }
 
             if (line == frame_info().height)
@@ -881,7 +876,6 @@ private:
 
     // codec parameters
     Traits traits_;
-    JlsRect rect_{};
     uint32_t width_;
     int32_t t1_{};
     int32_t t2_{};

--- a/unittest/decoder_strategy_test.cpp
+++ b/unittest/decoder_strategy_test.cpp
@@ -39,7 +39,7 @@ public:
         return nullptr;
     }
 
-    size_t decode_scan(unique_ptr<charls::process_line> /*process_line*/, const JlsRect& /*size*/,
+    size_t decode_scan(unique_ptr<charls::process_line> /*process_line*/,
                        charls::const_byte_span /*encoded_source*/) noexcept(false) override
     {
         return {};


### PR DESCRIPTION
Support to decode only certain regions has been removed. The only advantage was a smaller destination buffer and an optional quicker return. The JPEG-LS algorithm can only decoded starting from the beginning, so no real performance gain was made. Typical scenario is to decode complete image. If needed user code can perform a post processing step to extract a region is needed.