### PR TITLE
Remove legacy 1.x option output_bgr

### DIFF
--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -131,11 +131,6 @@ struct charls_jpegls_decoder final
         state_ = state::completed;
     }
 
-    void output_bgr(const bool value) noexcept
-    {
-        reader_.output_bgr(value);
-    }
-
 private:
     enum class state
     {

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -261,7 +261,7 @@ private:
                                             component_count};
 
         const auto codec{jls_codec_factory<encoder_strategy>().create_codec(
-            frame_info, {near_lossless_, 0, interleave_mode_, color_transformation_, false}, preset_coding_parameters_)};
+            frame_info, {near_lossless_, 0, interleave_mode_, color_transformation_}, preset_coding_parameters_)};
         std::unique_ptr<process_line> process_line(codec->create_process_line(source, stride));
         const size_t bytes_written{codec->encode_scan(std::move(process_line), writer_.remaining_destination())};
 

--- a/src/coding_parameters.h
+++ b/src/coding_parameters.h
@@ -13,7 +13,6 @@ struct coding_parameters final
     uint32_t restart_interval;
     charls::interleave_mode interleave_mode;
     color_transformation transformation;
-    bool output_bgr;
 };
 
 } // namespace charls

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -45,11 +45,6 @@ public:
         return preset_coding_parameters_;
     }
 
-    void output_bgr(const bool value) noexcept
-    {
-        parameters_.output_bgr = value;
-    }
-
     void at_comment(const callback_function<at_comment_handler> at_comment_callback) noexcept
     {
         at_comment_callback_ = at_comment_callback;

--- a/src/process_line.h
+++ b/src/process_line.h
@@ -176,17 +176,6 @@ void transform_quad_to_line(const quad<PixelType>* source, const size_t pixel_st
 }
 
 
-template<typename T>
-void transform_rgb_to_bgr(T* buffer, size_t samples_per_pixel, const size_t pixel_count) noexcept
-{
-    for (size_t i{}; i < pixel_count; ++i)
-    {
-        std::swap(buffer[0], buffer[2]);
-        buffer += samples_per_pixel;
-    }
-}
-
-
 template<typename Transform, typename PixelType>
 void transform_line(triplet<PixelType>* destination, const triplet<PixelType>* source, const size_t pixel_count,
                     Transform& transform) noexcept
@@ -312,13 +301,6 @@ public:
     void encode_transform(const void* source, void* destination, const size_t pixel_count,
                           const size_t destination_stride) noexcept
     {
-        if (parameters_.output_bgr)
-        {
-            memcpy(temp_line_.data(), source, sizeof(triplet<size_type>) * pixel_count);
-            transform_rgb_to_bgr(temp_line_.data(), frame_info_.component_count, pixel_count);
-            source = temp_line_.data();
-        }
-
         if (frame_info_.component_count == 3)
         {
             if (parameters_.interleave_mode == interleave_mode::sample)
@@ -374,11 +356,6 @@ public:
                 transform_line_to_quad(static_cast<const size_type*>(source), byte_stride,
                                        static_cast<quad<size_type>*>(destination), pixel_count, inverse_transform_);
             }
-        }
-
-        if (parameters_.output_bgr)
-        {
-            transform_rgb_to_bgr(static_cast<size_type*>(destination), frame_info_.component_count, pixel_count);
         }
     }
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -266,17 +266,6 @@ void test_fail_on_too_small_output_buffer()
 }
 
 
-void test_bgra()
-{
-    array<uint8_t, 20> input{'R', 'G', 'B', 'A', 'R', 'G', 'B', 'A', 'R', 'G', 'B', 'A', 'R', 'G', 'B', 'A', 1, 2, 3, 4};
-    const array<uint8_t, 20> expected{'B', 'G', 'R', 'A', 'B', 'G', 'R', 'A', 'B', 'G',
-                                      'R', 'A', 'B', 'G', 'R', 'A', 1,   2,   3,   4};
-
-    transform_rgb_to_bgr(input.data(), 4, 4);
-    assert::is_true(expected == input);
-}
-
-
 void test_too_small_output_buffer()
 {
     const vector<uint8_t> encoded{read_file("test/tulips-gray-8bit-512-512-hp-encoder.jls")};
@@ -657,9 +646,6 @@ bool unit_test()
         cout << "Test Traits\n";
         test_traits16_bit();
         test_traits8_bit();
-
-        cout << "Windows bitmap BGR/BGRA output\n";
-        test_bgra();
 
         cout << "Test Small buffer\n";
         test_too_small_output_buffer();


### PR DESCRIPTION
This was a Windows only option. Conversion is often not needed and Windows can do the conversion more efficient by itself. DirectX supports RGB encoded bitmaps.