### PR TITLE
Replace uint8_t with std::byte in test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,10 +51,11 @@
         C5026 = 'type': move constructor was implicitly defined as deleted [Just informational]
         C5027 = 'type': move assignment operator was implicitly defined as deleted [Just informational]
         C5045 = Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified [Just informational]
+        C5246 = the initialization of a subobject should be wrapped in braces [prevents simple usage of std::byte]
         C5264 = 'const' variable is not used [reported for const in header files]
         C5258 = explicit capture of '' is not required for this use [VS 2019 requires capture of constexpr]
       -->
-      <DisableSpecificWarnings Condition="'$(CHARLS_ALL_WARNINGS)'!=''">4061;4365;4464;4514;4571;4623;4625;4626;4710;4711;4738;4820;5026;5027;5045;5264;5258</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(CHARLS_ALL_WARNINGS)'!=''">4061;4365;4464;4514;4571;4623;4625;4626;4710;4711;4738;4820;5026;5027;5045;5246;5264;5258</DisableSpecificWarnings>
 
       <!--
         __cplusplus = Use the correct value for the __cplusplus macro

--- a/test/bitstreamdamage.cpp
+++ b/test/bitstreamdamage.cpp
@@ -21,8 +21,8 @@ namespace {
 
 void test_damaged_bit_stream1()
 {
-    const vector<uint8_t> encoded_buffer{read_file("test/incorrect_images/InfiniteLoopFFMPEG.jls")};
-    vector<uint8_t> destination(size_t{256} * 256 * 2);
+    const auto encoded_buffer{read_file("test/incorrect_images/InfiniteLoopFFMPEG.jls")};
+    vector<std::byte> destination(size_t{256} * 256 * 2);
 
     error_code error;
     try
@@ -40,10 +40,10 @@ void test_damaged_bit_stream1()
 
 void test_damaged_bit_stream2()
 {
-    vector<uint8_t> encoded_buffer{read_file("test/tulips-gray-8bit-512-512-hp-encoder.jls")};
+    auto encoded_buffer{read_file("test/tulips-gray-8bit-512-512-hp-encoder.jls")};
 
     encoded_buffer.resize(900);
-    encoded_buffer.resize(40000, 3);
+    encoded_buffer.resize(40000, std::byte{3});
 
     vector<uint8_t> destination(size_t{512} * 512);
 
@@ -63,10 +63,10 @@ void test_damaged_bit_stream2()
 
 void test_damaged_bit_stream3()
 {
-    vector<uint8_t> encoded_buffer{read_file("test/tulips-gray-8bit-512-512-hp-encoder.jls")};
+    auto encoded_buffer{read_file("test/tulips-gray-8bit-512-512-hp-encoder.jls")};
 
-    encoded_buffer[300] = 0xFF;
-    encoded_buffer[301] = 0xFF;
+    encoded_buffer[300] = std::byte{0xFF};
+    encoded_buffer[301] = std::byte{0xFF};
 
     vector<uint8_t> destination(size_t{512} * 512);
 
@@ -86,26 +86,26 @@ void test_damaged_bit_stream3()
 
 void test_file_with_random_header_damage(const char* filename)
 {
-    const vector<uint8_t> encoded_buffer_original{read_file(filename)};
+    const auto encoded_buffer_original{read_file(filename)};
 
     mt19937 generator(102347325);
 
     MSVC_WARNING_SUPPRESS_NEXT_LINE(26496) // cannot be marked as const as operator() is not always defined const.
     uniform_int_distribution<uint32_t> distribution(0, 255);
 
-    vector<uint8_t> destination(size_t{512} * 512);
+    vector<std::byte> destination(size_t{512} * 512);
 
     for (size_t i{}; i != 40; ++i)
     {
-        vector<uint8_t> encoded_buffer(encoded_buffer_original);
-        vector<int> errors(10, 0);
+        auto encoded_buffer(encoded_buffer_original);
+        vector errors(10, 0);
 
         for (int j{}; j != 20; ++j)
         {
-            encoded_buffer[i] = static_cast<uint8_t>(distribution(generator));
-            encoded_buffer[i + 1] = static_cast<uint8_t>(distribution(generator));
-            encoded_buffer[i + 2] = static_cast<uint8_t>(distribution(generator));
-            encoded_buffer[i + 3] = static_cast<uint8_t>(distribution(generator));
+            encoded_buffer[i] = static_cast<std::byte>(distribution(generator));
+            encoded_buffer[i + 1] = static_cast<std::byte>(distribution(generator));
+            encoded_buffer[i + 2] = static_cast<std::byte>(distribution(generator));
+            encoded_buffer[i + 3] = static_cast<std::byte>(distribution(generator));
 
             error_code error;
             try

--- a/test/compliance.cpp
+++ b/test/compliance.cpp
@@ -18,9 +18,9 @@ using namespace charls;
 
 namespace {
 
-void triplet2_planar(vector<uint8_t>& buffer, const rect_size size)
+void triplet2_planar(vector<std::byte>& buffer, const rect_size size)
 {
-    vector<uint8_t> work_buffer(buffer.size());
+    vector<std::byte> work_buffer(buffer.size());
 
     const size_t byte_count{size.cx * size.cy};
     for (size_t i{}; i != byte_count; ++i)
@@ -68,7 +68,7 @@ bool verify_encoded_bytes(const void* uncompressed_data, const size_t uncompress
 }
 
 
-void test_compliance(const uint8_t* compressed_bytes, const size_t compressed_length, const uint8_t* uncompressed_data,
+void test_compliance(const std::byte* compressed_bytes, const size_t compressed_length, const std::byte* uncompressed_data,
                      const size_t uncompressed_length, const bool check_encode)
 {
     try
@@ -82,7 +82,7 @@ void test_compliance(const uint8_t* compressed_bytes, const size_t compressed_le
                 verify_encoded_bytes(uncompressed_data, uncompressed_length, compressed_bytes, compressed_length));
         }
 
-        const auto destination{decoder.decode<vector<uint8_t>>()};
+        const auto destination{decoder.decode<vector<std::byte>>()};
 
         if (decoder.near_lossless() == 0)
         {
@@ -106,7 +106,7 @@ void test_compliance(const uint8_t* compressed_bytes, const size_t compressed_le
 void decompress_file(const char* name_encoded, const char* name_raw, const int offset, const bool check_encode = true)
 {
     cout << "Conformance test:" << name_encoded << "\n\r";
-    const vector<uint8_t> encoded_buffer{read_file(name_encoded)};
+    const auto encoded_buffer{read_file(name_encoded)};
 
     jpegls_decoder decoder;
     try
@@ -119,7 +119,7 @@ void decompress_file(const char* name_encoded, const char* name_raw, const int o
         return;
     }
 
-    vector<uint8_t> raw_buffer{read_file(name_raw, offset)};
+    auto raw_buffer{read_file(name_raw, offset)};
 
     const auto& frame_info{decoder.frame_info()};
     if (frame_info.bits_per_sample > 8)
@@ -173,9 +173,9 @@ void decompress_file(const char* name_encoded, const char* name_raw, const int o
 
 const array<uint8_t, 16> buffer{0, 0, 90, 74, 68, 50, 43, 205, 64, 145, 145, 145, 100, 145, 145, 145};
 ////const uint8_t bufferEncoded[] =   {   0xFF, 0xD8, 0xFF, 0xF7, 0x00, 0x0B, 0x08, 0x00, 0x04, 0x00, 0x04, 0x01, 0x01, 0x11,
-///0x00, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, /0xC0, 0x00, 0x00, 0x6C, 0x80, 0x20, 0x8E, /0x01, 0xC0,
-///0x00, 0x00, 0x57, 0x40, 0x00, 0x00, 0x6E, 0xE6, 0x00, 0x00, 0x01, 0xBC, 0x18, 0x00, /0x00, 0x05, 0xD8, 0x00, 0x00, 0x91,
-///0x60, 0xFF, 0xD9};
+/// 0x00, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, /0xC0, 0x00, 0x00, 0x6C, 0x80, 0x20, 0x8E, /0x01, 0xC0,
+/// 0x00, 0x00, 0x57, 0x40, 0x00, 0x00, 0x6E, 0xE6, 0x00, 0x00, 0x01, 0xBC, 0x18, 0x00, /0x00, 0x05, 0xD8, 0x00, 0x00, 0x91,
+/// 0x60, 0xFF, 0xD9};
 
 } // namespace
 

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -94,11 +94,11 @@ void decode_performance_tests(const int loop_count)
         // This test expect the file decodetest.jls to exist.
         // It can be any valid JPEG-LS file.
         // Changing the content of this file allows different performance measurements.
-        const vector<uint8_t> encoded_source{read_file("decodetest.jls")};
+        const auto encoded_source{read_file("decodetest.jls")};
 
         // Pre-allocate the destination outside the measurement loop.
         // std::vector initializes its elements and this step needs to be excluded from the measurement.
-        vector<uint8_t> destination(jpegls_decoder{encoded_source, true}.destination_size());
+        vector<std::byte> destination(jpegls_decoder{encoded_source, true}.destination_size());
 
         const auto start{steady_clock::now()};
         for (int i{}; i != loop_count; ++i)

--- a/test/portable_anymap_file.h
+++ b/test/portable_anymap_file.h
@@ -10,21 +10,6 @@
 #include <string>
 #include <vector>
 
-
-// Visual Studio 2015 supports C++14, but not all constexpr scenarios. VS 2017 has full C++14 support.
-#ifdef _MSC_VER
-
-#if _MSC_VER >= 1910
-#define CONSTEXPR constexpr
-#else
-#define CONSTEXPR
-#endif
-
-#else
-#define CONSTEXPR constexpr
-#endif
-
-
 namespace charls_test {
 
 // Purpose: this class can read an image stored in the Portable Anymap Format (PNM).
@@ -57,32 +42,32 @@ public:
         convert_to_little_endian_if_needed();
     }
 
-    int width() const noexcept
+    [[nodiscard]] int width() const noexcept
     {
         return width_;
     }
 
-    int height() const noexcept
+    [[nodiscard]] int height() const noexcept
     {
         return height_;
     }
 
-    int component_count() const noexcept
+    [[nodiscard]] int component_count() const noexcept
     {
         return component_count_;
     }
 
-    int bits_per_sample() const noexcept
+    [[nodiscard]] int bits_per_sample() const noexcept
     {
         return bits_per_sample_;
     }
 
-    std::vector<uint8_t>& image_data() noexcept
+    std::vector<std::byte>& image_data() noexcept
     {
         return input_buffer_;
     }
 
-    const std::vector<uint8_t>& image_data() const noexcept
+    [[nodiscard]] const std::vector<std::byte>& image_data() const noexcept
     {
         return input_buffer_;
     }
@@ -92,10 +77,8 @@ private:
     {
         std::vector<int> result;
 
-        const auto first{static_cast<char>(pnm_file.get())};
-
         // All portable anymap format (PNM) start with the character P.
-        if (first != 'P')
+        if (const auto first{static_cast<char>(pnm_file.get())}; first != 'P')
             throw std::istream::failure("Missing P");
 
         while (result.size() < 4)
@@ -117,7 +100,7 @@ private:
         return result;
     }
 
-    static CONSTEXPR int32_t log_2(const int32_t n) noexcept
+    [[nodiscard]] static constexpr int32_t log_2(const int32_t n) noexcept
     {
         int32_t x{};
         while (n > (1 << x))
@@ -143,7 +126,7 @@ private:
     int width_;
     int height_;
     int bits_per_sample_;
-    std::vector<uint8_t> input_buffer_;
+    std::vector<std::byte> input_buffer_;
 };
 
 } // namespace charls_test

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -53,7 +53,7 @@ ofstream open_output_stream(const char* filename)
 }
 
 
-void fix_endian(vector<uint8_t>* buffer, const bool little_endian_data) noexcept
+void fix_endian(vector<std::byte>* buffer, const bool little_endian_data) noexcept
 {
     if (little_endian_data == is_machine_little_endian())
         return;
@@ -65,7 +65,7 @@ void fix_endian(vector<uint8_t>* buffer, const bool little_endian_data) noexcept
 }
 
 
-vector<uint8_t> read_file(const char* filename, long offset, size_t bytes)
+vector<std::byte> read_file(const char* filename, long offset, size_t bytes)
 {
     ifstream input;
     input.exceptions(ios::eofbit | ios::failbit | ios::badbit);
@@ -85,7 +85,7 @@ vector<uint8_t> read_file(const char* filename, long offset, size_t bytes)
         bytes = static_cast<size_t>(byte_count_file) - offset;
     }
 
-    vector<uint8_t> buffer(bytes);
+    vector<std::byte> buffer(bytes);
     read(input, buffer);
 
     return buffer;
@@ -100,15 +100,15 @@ void write_file(const char* filename, const void* data, const size_t size)
     output.close(); // close explicitly to get feedback on failures.
 }
 
-void test_round_trip(const char* name, const vector<uint8_t>& original_buffer, const rect_size size,
+void test_round_trip(const char* name, const vector<std::byte>& original_buffer, const rect_size size,
                      const int bits_per_sample, const int component_count, const int loop_count)
 {
     const auto height = static_cast<int>(size.cy);
     const auto width = static_cast<int>(size.cx);
 
-    vector<uint8_t> encoded_buffer(height * width * component_count * bits_per_sample / 4);
+    vector<std::byte> encoded_buffer(height * width * component_count * bits_per_sample / 4);
 
-    vector<uint8_t> decoded_buffer(static_cast<size_t>(height) * width * bit_to_byte_count(bits_per_sample) *
+    vector<std::byte> decoded_buffer(static_cast<size_t>(height) * width * bit_to_byte_count(bits_per_sample) *
                                    component_count);
 
     interleave_mode interleave_mode{};
@@ -175,7 +175,7 @@ void test_round_trip(const char* name, const vector<uint8_t>& original_buffer, c
          << ", Encode time:" << encode_time << " ms, Decode time:" << decode_time
          << " ms, Bits per sample:" << bits_per_sample_f << ", Decode rate:" << symbol_rate << " M/s\n";
 
-    const uint8_t* byte_out{decoded_buffer.data()};
+    const std::byte* byte_out{decoded_buffer.data()};
     for (size_t i{}; i != decoded_buffer.size(); ++i)
     {
         if (original_buffer[i] != byte_out[i])
@@ -191,7 +191,7 @@ void test_file(const char* filename, const int offset, const rect_size size2, co
                const int component_count, const bool little_endian_file, const int loop_count)
 {
     const size_t byte_count{size2.cx * size2.cy * component_count * bit_to_byte_count(bits_per_sample)};
-    vector<uint8_t> uncompressed_buffer{read_file(filename, offset, byte_count)};
+    auto uncompressed_buffer{read_file(filename, offset, byte_count)};
 
     if (bits_per_sample > 8)
     {

--- a/test/util.h
+++ b/test/util.h
@@ -21,12 +21,12 @@ struct rect_size final
 
 
 std::ofstream open_output_stream(const char* filename);
-void fix_endian(std::vector<uint8_t>* buffer, bool little_endian_data) noexcept;
-std::vector<uint8_t> read_file(const char* filename, long offset = 0, size_t bytes = 0);
+void fix_endian(std::vector<std::byte>* buffer, bool little_endian_data) noexcept;
+std::vector<std::byte> read_file(const char* filename, long offset = 0, size_t bytes = 0);
 void write_file(const char* filename, const void* data, size_t size);
 void test_file(const char* filename, int offset, rect_size size2, int bits_per_sample, int component_count,
                bool little_endian_file = false, int loop_count = 1);
-void test_round_trip(const char* name, const std::vector<uint8_t>& original_buffer, rect_size size, int bits_per_sample,
+void test_round_trip(const char* name, const std::vector<std::byte>& original_buffer, rect_size size, int bits_per_sample,
                      int component_count, int loop_count = 1);
 void test_portable_anymap_file(const char* filename, int loop_count = 1);
 

--- a/unittest/charls_jpegls_decoder_test.cpp
+++ b/unittest/charls_jpegls_decoder_test.cpp
@@ -12,7 +12,7 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
-using std::vector;
+using std::byte;
 
 MSVC_WARNING_SUPPRESS(6387) // '_Param_(x)' could be '0': this does not adhere to the specification for the function.
 
@@ -36,7 +36,7 @@ public:
 
     TEST_METHOD(set_source_buffer_nullptr) // NOLINT
     {
-        constexpr array<uint8_t, 10> buffer{};
+        constexpr array<byte, 10> buffer{};
 
         auto error{charls_jpegls_decoder_set_source_buffer(nullptr, buffer.data(), buffer.size())};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
@@ -54,7 +54,7 @@ public:
         auto error{charls_jpegls_decoder_read_spiff_header(nullptr, &spiff_header, &header_found)};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
 
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         auto* decoder{charls_jpegls_decoder_create()};
         error = charls_jpegls_decoder_set_source_buffer(decoder, source.data(), source.size());
         Assert::AreEqual(jpegls_errc::success, error);
@@ -143,7 +143,7 @@ public:
 
     TEST_METHOD(decode_to_buffer_nullptr) // NOLINT
     {
-        array<uint8_t, 5> buffer{};
+        array<byte, 5> buffer{};
         auto error{charls_jpegls_decoder_decode_to_buffer(nullptr, buffer.data(), buffer.size(), 0)};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
 
@@ -191,7 +191,7 @@ public:
 private:
     static charls_jpegls_decoder* get_initialized_decoder()
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         auto* const decoder{charls_jpegls_decoder_create()};
         auto error{charls_jpegls_decoder_set_source_buffer(decoder, source.data(), source.size())};
         Assert::AreEqual(jpegls_errc::success, error);

--- a/unittest/charls_jpegls_encoder_test.cpp
+++ b/unittest/charls_jpegls_encoder_test.cpp
@@ -11,6 +11,7 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
+using std::byte;
 
 MSVC_WARNING_SUPPRESS(6387) // '_Param_(x)' could be '0': this does not adhere to the specification for the function.
 
@@ -34,7 +35,7 @@ public:
 
     TEST_METHOD(set_destination_buffer_nullptr) // NOLINT
     {
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         auto error{charls_jpegls_encoder_set_destination_buffer(nullptr, buffer.data(), buffer.size())};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
 
@@ -117,7 +118,7 @@ public:
 
     TEST_METHOD(encode_from_buffer_nullptr) // NOLINT
     {
-        constexpr array<uint8_t, 10> source_buffer{};
+        constexpr array<byte, 10> source_buffer{};
         auto error{charls_jpegls_encoder_encode_from_buffer(nullptr, source_buffer.data(), source_buffer.size(), 0)};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
 
@@ -148,7 +149,7 @@ public:
 
     TEST_METHOD(write_spiff_entry_nullptr) // NOLINT
     {
-        constexpr array<uint8_t, 10> entry_data{};
+        constexpr array<byte, 10> entry_data{};
         auto error{charls_jpegls_encoder_write_spiff_entry(nullptr, 5, entry_data.data(), entry_data.size())};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
 
@@ -166,14 +167,14 @@ public:
 
     TEST_METHOD(write_comment_nullptr) // NOLINT
     {
-        constexpr array<uint8_t, 10> buffer{};
+        constexpr array<byte, 10> buffer{};
         const auto error{charls_jpegls_encoder_write_comment(nullptr, buffer.data(), buffer.size())};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
 
     TEST_METHOD(write_application_data_nullptr) // NOLINT
     {
-        constexpr array<uint8_t, 10> buffer{};
+        constexpr array<byte, 10> buffer{};
         const auto error{charls_jpegls_encoder_write_application_data(nullptr, 0, buffer.data(), buffer.size())};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
@@ -194,7 +195,7 @@ public:
         error = charls_jpegls_encoder_set_frame_info(encoder, &frame_info);
         Assert::AreEqual(jpegls_errc::success, error);
 
-        constexpr array<uint8_t, 10> buffer{};
+        constexpr array<byte, 10> buffer{};
         error = charls_jpegls_encoder_encode_from_buffer(encoder, buffer.data(), buffer.size(), 0);
         Assert::AreEqual(jpegls_errc::destination_buffer_too_small, error);
 
@@ -205,7 +206,7 @@ public:
     {
         auto* encoder{charls_jpegls_encoder_create()};
 
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         auto error{charls_jpegls_encoder_set_destination_buffer(encoder, buffer.data(), buffer.size())};
         Assert::AreEqual(jpegls_errc::success, error);
 

--- a/unittest/color_transform_test.cpp
+++ b/unittest/color_transform_test.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
+using std::byte;
 using std::vector;
 
 namespace charls::test {
@@ -102,11 +103,11 @@ public:
 
     TEST_METHOD(decode_non_8_or_16_bit_that_is_not_supported_throws) // NOLINT
     {
-        const vector<uint8_t> jpegls_data{read_file("land10-10bit-rgb-hp3-invalid.jls")};
+        const auto jpegls_data{read_file("land10-10bit-rgb-hp3-invalid.jls")};
 
         const jpegls_decoder decoder{jpegls_data, true};
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::bit_depth_for_transform_not_supported,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -117,9 +118,9 @@ public:
         constexpr frame_info frame_info{2, 1, 10, 3};
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(40);
+        vector<byte> destination(40);
         encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
-        const vector<uint8_t> source(20);
+        const vector<byte> source(20);
         assert_expect_exception(jpegls_errc::bit_depth_for_transform_not_supported,
                                 [&encoder, &source] { std::ignore = encoder.encode(source); });
     }

--- a/unittest/compliance_test.cpp
+++ b/unittest/compliance_test.cpp
@@ -10,7 +10,6 @@
 #include "../test/portable_anymap_file.h"
 
 using namespace charls_test;
-using std::vector;
 
 namespace charls::test {
 
@@ -120,7 +119,7 @@ public:
 private:
     static void decompress_file(const char* encoded_filename, const char* raw_filename, const bool check_encode = true)
     {
-        const vector<uint8_t> encoded_source{read_file(encoded_filename)};
+        const auto encoded_source{read_file(encoded_filename)};
         const jpegls_decoder decoder{encoded_source, true};
 
         portable_anymap_file reference_file{

--- a/unittest/decoder_strategy_test.cpp
+++ b/unittest/decoder_strategy_test.cpp
@@ -11,6 +11,7 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
+using std::byte;
 using std::unique_ptr;
 
 namespace charls::test {
@@ -20,8 +21,8 @@ namespace {
 class decoder_strategy_tester final : public decoder_strategy
 {
 public:
-    decoder_strategy_tester(const frame_info& frame_info, const coding_parameters& parameters,
-                            uint8_t* const destination, const size_t count) :
+    decoder_strategy_tester(const frame_info& frame_info, const coding_parameters& parameters, byte* const destination,
+                            const size_t count) :
         decoder_strategy(frame_info, parameters)
     {
         initialize({destination, count});
@@ -66,7 +67,7 @@ public:
 
         constexpr array<data_t, 5> in_data{{{0x00, 24}, {0xFF, 8}, {0xFFFF, 16}, {0xFFFF, 16}, {0x12345678, 31}}};
 
-        array<uint8_t, 100> enc_buf{};
+        array<byte, 100> enc_buf{};
         constexpr frame_info frame_info{};
         constexpr coding_parameters parameters{};
 
@@ -96,7 +97,7 @@ public:
         constexpr frame_info frame_info{};
         constexpr coding_parameters parameters{};
 
-        array<uint8_t, 4> buffer{7, 100, 23, 99};
+        array buffer{byte{7}, byte{100}, byte{23}, byte{99}};
 
         decoder_strategy_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
 
@@ -108,7 +109,7 @@ public:
         constexpr frame_info frame_info{};
         constexpr coding_parameters parameters{};
 
-        array<uint8_t, 4> buffer{0xAA, 100, 23, 99};
+        array buffer{byte{0xAA}, byte{100}, byte{23}, byte{99}};
 
         decoder_strategy_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
 
@@ -128,21 +129,21 @@ public:
         constexpr coding_parameters parameters{};
 
         {
-            array<uint8_t, 4> buffer{0xF, 100, 23, 99};
+            array buffer{byte{0xF}, byte{100}, byte{23}, byte{99}};
 
             decoder_strategy_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
             Assert::AreEqual(4, decoder_strategy.peek_0_bits());
         }
 
         {
-            array<uint8_t, 4> buffer{0, 1, 0, 0};
+            array buffer{byte{0}, byte{1}, byte{0}, byte{0}};
 
             decoder_strategy_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
             Assert::AreEqual(15, decoder_strategy.peek_0_bits());
         }
 
         {
-            array<uint8_t, 4> buffer{0, 0, 0, 0};
+            array<byte, 4> buffer{};
 
             decoder_strategy_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
             Assert::AreEqual(-1, decoder_strategy.peek_0_bits());

--- a/unittest/documentation_test.cpp
+++ b/unittest/documentation_test.cpp
@@ -23,9 +23,9 @@ namespace {
 // The following functions are used as sample code in the documentation
 // Ensure that the code compiles and works by unit testing it.
 
-std::vector<uint8_t> decode_simple_8_bit_monochrome(const std::vector<uint8_t>& source)
+std::vector<std::byte> decode_simple_8_bit_monochrome(const std::vector<std::byte>& source)
 {
-    std::vector<uint8_t> destination;
+    std::vector<std::byte> destination;
 
     frame_info frame_info;
     std::tie(frame_info, std::ignore) = jpegls_decoder::decode(source, destination);
@@ -36,7 +36,7 @@ std::vector<uint8_t> decode_simple_8_bit_monochrome(const std::vector<uint8_t>& 
     return destination;
 }
 
-std::vector<uint8_t> decode_advanced(const std::vector<uint8_t>& source)
+std::vector<std::byte> decode_advanced(const std::vector<std::byte>& source)
 {
     const jpegls_decoder decoder{source, true};
 
@@ -50,24 +50,24 @@ std::vector<uint8_t> decode_advanced(const std::vector<uint8_t>& source)
         // Handle lossy images.
     }
 
-    return decoder.decode<std::vector<uint8_t>>();
+    return decoder.decode<std::vector<std::byte>>();
 }
 
-std::vector<uint8_t> encode_simple_8_bit_monochrome(const std::vector<uint8_t>& source, const uint32_t width,
-                                                    const uint32_t height)
+std::vector<std::byte> encode_simple_8_bit_monochrome(const std::vector<std::byte>& source, const uint32_t width,
+                                                      const uint32_t height)
 {
     constexpr auto bits_per_sample{8};
     constexpr auto component_count{1};
     return jpegls_encoder::encode(source, {width, height, bits_per_sample, component_count});
 }
 
-std::vector<uint8_t> encode_advanced_8_bit_monochrome(const std::vector<uint8_t>& source, const uint32_t width,
-                                                      const uint32_t height)
+std::vector<std::byte> encode_advanced_8_bit_monochrome(const std::vector<std::byte>& source, const uint32_t width,
+                                                        const uint32_t height)
 {
     jpegls_encoder encoder;
     encoder.frame_info({width, height, 8, 1});
 
-    std::vector<uint8_t> destination(encoder.estimated_destination_size());
+    std::vector<std::byte> destination(encoder.estimated_destination_size());
     encoder.destination(destination);
 
     encoder.write_standard_spiff_header(spiff_color_space::grayscale);
@@ -86,16 +86,16 @@ TEST_CLASS(documentation_test)
 public:
     TEST_METHOD(call_decode_simple_8_bit_monochrome) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/tulips-gray-8bit-512-512-hp-encoder.jls")};
-        const vector<uint8_t> charls_decoded{decode_simple_8_bit_monochrome(source)};
+        const auto source{read_file("DataFiles/tulips-gray-8bit-512-512-hp-encoder.jls")};
+        const auto charls_decoded{decode_simple_8_bit_monochrome(source)};
 
         test_decoded_data(charls_decoded, "DataFiles/tulips-gray-8bit-512-512.pgm");
     }
 
     TEST_METHOD(call_decode_advanced) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/tulips-gray-8bit-512-512-hp-encoder.jls")};
-        const vector<uint8_t> charls_decoded{decode_advanced(source)};
+        const auto source{read_file("DataFiles/tulips-gray-8bit-512-512-hp-encoder.jls")};
+        const auto charls_decoded{decode_advanced(source)};
 
         test_decoded_data(charls_decoded, "DataFiles/tulips-gray-8bit-512-512.pgm");
     }
@@ -103,9 +103,9 @@ public:
     TEST_METHOD(call_encode_simple_8_bit_monochrome) // NOLINT
     {
         portable_anymap_file reference_file("DataFiles/tulips-gray-8bit-512-512.pgm");
-        const vector<uint8_t> charls_encoded{encode_simple_8_bit_monochrome(reference_file.image_data(),
-                                                                            static_cast<uint32_t>(reference_file.width()),
-                                                                            static_cast<uint32_t>(reference_file.height()))};
+        const auto charls_encoded{encode_simple_8_bit_monochrome(reference_file.image_data(),
+                                                                 static_cast<uint32_t>(reference_file.width()),
+                                                                 static_cast<uint32_t>(reference_file.height()))};
 
         test_by_decoding(charls_encoded, reference_file, interleave_mode::none);
     }
@@ -113,18 +113,18 @@ public:
     TEST_METHOD(call_encode_advanced_8_bit_monochrome) // NOLINT
     {
         portable_anymap_file reference_file("DataFiles/tulips-gray-8bit-512-512.pgm");
-        const vector<uint8_t> charls_encoded{
-            encode_advanced_8_bit_monochrome(reference_file.image_data(), static_cast<uint32_t>(reference_file.width()),
-                                             static_cast<uint32_t>(reference_file.height()))};
+        const auto charls_encoded{encode_advanced_8_bit_monochrome(reference_file.image_data(),
+                                                                   static_cast<uint32_t>(reference_file.width()),
+                                                                   static_cast<uint32_t>(reference_file.height()))};
 
         test_by_decoding(charls_encoded, reference_file, interleave_mode::none);
     }
 
 private:
-    static void test_decoded_data(const vector<uint8_t>& decoded_source, const char* raw_filename)
+    static void test_decoded_data(const vector<std::byte>& decoded_source, const char* raw_filename)
     {
         portable_anymap_file reference_file{read_anymap_reference_file(raw_filename, interleave_mode::none)};
-        const vector<uint8_t>& uncompressed_source{reference_file.image_data()};
+        const vector<std::byte>& uncompressed_source{reference_file.image_data()};
 
         Assert::AreEqual(decoded_source.size(), uncompressed_source.size());
 
@@ -137,7 +137,7 @@ private:
         }
     }
 
-    static void test_by_decoding(const vector<uint8_t>& encoded_source, const portable_anymap_file& reference_file,
+    static void test_by_decoding(const vector<std::byte>& encoded_source, const portable_anymap_file& reference_file,
                                  const interleave_mode interleave_mode)
     {
         jpegls_decoder decoder;
@@ -151,10 +151,10 @@ private:
         Assert::AreEqual(reference_file.bits_per_sample(), frame_info.bits_per_sample);
         Assert::AreEqual(interleave_mode, decoder.interleave_mode());
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<std::byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
-        const vector<uint8_t>& uncompressed_source{reference_file.image_data()};
+        const vector<std::byte>& uncompressed_source{reference_file.image_data()};
 
         Assert::AreEqual(destination.size(), uncompressed_source.size());
 

--- a/unittest/encode_test.cpp
+++ b/unittest/encode_test.cpp
@@ -11,6 +11,7 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using namespace charls_test;
+using std::byte;
 using std::vector;
 
 namespace charls::test {
@@ -69,7 +70,7 @@ private:
                          reference_file.bits_per_sample(), reference_file.component_count()})
             .interleave_mode(interleave_mode);
 
-        vector<uint8_t> charls_encoded(encoder.estimated_destination_size());
+        vector<byte> charls_encoded(encoder.estimated_destination_size());
         encoder.destination(charls_encoded);
 
         const size_t bytes_written{encoder.encode(reference_file.image_data())};
@@ -78,7 +79,7 @@ private:
         test_by_decoding(charls_encoded, reference_file, interleave_mode);
     }
 
-    static void test_by_decoding(const vector<uint8_t>& encoded_source, const portable_anymap_file& reference_file,
+    static void test_by_decoding(const vector<byte>& encoded_source, const portable_anymap_file& reference_file,
                                  const interleave_mode interleave_mode)
     {
         jpegls_decoder decoder;
@@ -92,10 +93,10 @@ private:
         Assert::AreEqual(reference_file.component_count(), frame_info.component_count);
         Assert::IsTrue(interleave_mode == decoder.interleave_mode());
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
-        const vector<uint8_t>& uncompressed_source{reference_file.image_data()};
+        const auto& uncompressed_source{reference_file.image_data()};
 
         Assert::AreEqual(destination.size(), uncompressed_source.size());
 

--- a/unittest/encoder_strategy_test.cpp
+++ b/unittest/encoder_strategy_test.cpp
@@ -4,11 +4,13 @@
 #include "pch.h"
 
 #include "encoder_strategy_tester.h"
+#include "util.h"
 
 #include <array>
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
+using std::byte;
 
 namespace charls::test {
 
@@ -22,7 +24,7 @@ public:
 
         encoder_strategy_tester strategy(frame_info, parameters);
 
-        array<uint8_t, 1024> data{};
+        array<byte, 1024> data{};
 
         strategy.initialize_forward({data.data(), data.size()});
 
@@ -37,8 +39,8 @@ public:
 
         encoder_strategy_tester strategy(frame_info, parameters);
 
-        array<uint8_t, 1024> destination{};
-        destination[13] = 0x77; // marker byte to detect overruns.
+        array<byte, 1024> destination{};
+        destination[13] = byte{0x77}; // marker byte to detect overruns.
 
         strategy.initialize_forward({destination.data(), destination.size()});
 
@@ -57,20 +59,20 @@ public:
 
         // Verify output.
         Assert::AreEqual(size_t{13}, strategy.get_length_forward());
-        Assert::AreEqual(uint8_t{}, destination[0]);
-        Assert::AreEqual(uint8_t{}, destination[1]);
-        Assert::AreEqual(uint8_t{}, destination[2]);
-        Assert::AreEqual(uint8_t{0xFF}, destination[3]);
-        Assert::AreEqual(uint8_t{0x7F}, destination[4]); // extra 0 bit.
-        Assert::AreEqual(uint8_t{0xFF}, destination[5]);
-        Assert::AreEqual(uint8_t{0x7F}, destination[6]); // extra 0 bit.
-        Assert::AreEqual(uint8_t{0xFF}, destination[7]);
-        Assert::AreEqual(uint8_t{0x60}, destination[8]);
-        Assert::AreEqual(uint8_t{}, destination[9]);
-        Assert::AreEqual(uint8_t{}, destination[10]);
-        Assert::AreEqual(uint8_t{}, destination[11]);
-        Assert::AreEqual(uint8_t{0xC0}, destination[12]);
-        Assert::AreEqual(uint8_t{0x77}, destination[13]);
+        Assert::AreEqual({}, destination[0]);
+        Assert::AreEqual({}, destination[1]);
+        Assert::AreEqual({}, destination[2]);
+        Assert::AreEqual(byte{0xFF}, destination[3]);
+        Assert::AreEqual(byte{0x7F}, destination[4]); // extra 0 bit.
+        Assert::AreEqual(byte{0xFF}, destination[5]);
+        Assert::AreEqual(byte{0x7F}, destination[6]); // extra 0 bit.
+        Assert::AreEqual(byte{0xFF}, destination[7]);
+        Assert::AreEqual(byte{0x60}, destination[8]);
+        Assert::AreEqual({}, destination[9]);
+        Assert::AreEqual({}, destination[10]);
+        Assert::AreEqual({}, destination[11]);
+        Assert::AreEqual(byte{0xC0}, destination[12]);
+        Assert::AreEqual(byte{0x77}, destination[13]);
     }
 };
 

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -12,7 +12,9 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
+using std::byte;
 using std::numeric_limits;
+using std::to_integer;
 
 namespace charls::test {
 
@@ -28,19 +30,19 @@ public:
 
     TEST_METHOD(write_start_of_image) // NOLINT
     {
-        array<uint8_t, 2> buffer{};
+        array<byte, 2> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_start_of_image();
 
         Assert::AreEqual(size_t{2}, writer.bytes_written());
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), buffer[1]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), buffer[1]);
     }
 
     TEST_METHOD(write_start_of_image_in_too_small_buffer_throws) // NOLINT
     {
-        array<uint8_t, 1> buffer{};
+        array<byte, 1> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&writer] { writer.write_start_of_image(); });
@@ -49,31 +51,31 @@ public:
 
     TEST_METHOD(write_end_of_image) // NOLINT
     {
-        array<uint8_t, 2> buffer{};
+        array<byte, 2> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_end_of_image(false);
 
         Assert::AreEqual(size_t{2}, writer.bytes_written());
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[1]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::end_of_image), buffer[1]);
     }
 
     TEST_METHOD(write_end_of_image_even_no_extra_byte_needed) // NOLINT
     {
-        array<uint8_t, 2> buffer{};
+        array<byte, 2> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_end_of_image(true);
 
         Assert::AreEqual(size_t{2}, writer.bytes_written());
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[1]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::end_of_image), buffer[1]);
     }
 
     TEST_METHOD(write_end_of_image_even_extra_byte_needed) // NOLINT
     {
-        array<uint8_t, 5 + 3> buffer{};
+        array<byte, 5 + 3> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         // writer.
@@ -82,19 +84,19 @@ public:
         writer.write_end_of_image(true);
 
         Assert::AreEqual(size_t{8}, writer.bytes_written());
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), buffer[1]);
-        Assert::AreEqual(uint8_t{}, buffer[2]);
-        Assert::AreEqual(uint8_t{3}, buffer[3]);
-        Assert::AreEqual(uint8_t{99}, buffer[4]);
-        Assert::AreEqual(uint8_t{0xFF}, buffer[5]);
-        Assert::AreEqual(uint8_t{0xFF}, buffer[6]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[7]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), buffer[1]);
+        Assert::AreEqual(byte{}, buffer[2]);
+        Assert::AreEqual(byte{3}, buffer[3]);
+        Assert::AreEqual(byte{99}, buffer[4]);
+        Assert::AreEqual(byte{0xFF}, buffer[5]);
+        Assert::AreEqual(byte{0xFF}, buffer[6]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::end_of_image), buffer[7]);
     }
 
     TEST_METHOD(write_end_of_image_even_extra_byte_needed_not_enabled) // NOLINT
     {
-        array<uint8_t, 5 + 2> buffer{};
+        array<byte, 5 + 2> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         // writer.
@@ -103,18 +105,18 @@ public:
         writer.write_end_of_image(false);
 
         Assert::AreEqual(size_t{7}, writer.bytes_written());
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), buffer[1]);
-        Assert::AreEqual(uint8_t{}, buffer[2]);
-        Assert::AreEqual(uint8_t{3}, buffer[3]);
-        Assert::AreEqual(uint8_t{99}, buffer[4]);
-        Assert::AreEqual(uint8_t{0xFF}, buffer[5]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::end_of_image), buffer[6]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), buffer[1]);
+        Assert::AreEqual({}, buffer[2]);
+        Assert::AreEqual(byte{3}, buffer[3]);
+        Assert::AreEqual(byte{99}, buffer[4]);
+        Assert::AreEqual(byte{0xFF}, buffer[5]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::end_of_image), buffer[6]);
     }
 
     TEST_METHOD(write_end_of_image_in_too_small_buffer_throws) // NOLINT
     {
-        array<uint8_t, 1> buffer{};
+        array<byte, 1> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&writer] { writer.write_end_of_image(false); });
@@ -123,7 +125,7 @@ public:
 
     TEST_METHOD(write_spiff_segment) // NOLINT
     {
-        array<uint8_t, 34> buffer{};
+        array<byte, 34> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         constexpr spiff_header header{spiff_profile_id::none,
@@ -141,60 +143,60 @@ public:
 
         Assert::AreEqual(size_t{34}, writer.bytes_written());
 
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), buffer[1]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data8), buffer[1]);
 
-        Assert::AreEqual(uint8_t{}, buffer[2]);
-        Assert::AreEqual(uint8_t{32}, buffer[3]);
+        Assert::AreEqual({}, buffer[2]);
+        Assert::AreEqual(byte{32}, buffer[3]);
 
         // Verify SPIFF identifier string.
-        Assert::AreEqual(uint8_t{'S'}, buffer[4]);
-        Assert::AreEqual(uint8_t{'P'}, buffer[5]);
-        Assert::AreEqual(uint8_t{'I'}, buffer[6]);
-        Assert::AreEqual(uint8_t{'F'}, buffer[7]);
-        Assert::AreEqual(uint8_t{'F'}, buffer[8]);
-        Assert::AreEqual(uint8_t{}, buffer[9]);
+        Assert::AreEqual(byte{'S'}, buffer[4]);
+        Assert::AreEqual(byte{'P'}, buffer[5]);
+        Assert::AreEqual(byte{'I'}, buffer[6]);
+        Assert::AreEqual(byte{'F'}, buffer[7]);
+        Assert::AreEqual(byte{'F'}, buffer[8]);
+        Assert::AreEqual({}, buffer[9]);
 
         // Verify version
-        Assert::AreEqual(uint8_t{2}, buffer[10]);
-        Assert::AreEqual(uint8_t{}, buffer[11]);
+        Assert::AreEqual(byte{2}, buffer[10]);
+        Assert::AreEqual({}, buffer[11]);
 
-        Assert::AreEqual(static_cast<uint8_t>(header.profile_id), buffer[12]);
-        Assert::AreEqual(static_cast<uint8_t>(header.component_count), buffer[13]);
+        Assert::AreEqual(static_cast<byte>(header.profile_id), buffer[12]);
+        Assert::AreEqual(static_cast<byte>(header.component_count), buffer[13]);
 
         // Height
-        Assert::AreEqual(uint8_t{}, buffer[14]);
-        Assert::AreEqual(uint8_t{}, buffer[15]);
-        Assert::AreEqual(uint8_t{0x3}, buffer[16]);
-        Assert::AreEqual(uint8_t{0x20}, buffer[17]);
+        Assert::AreEqual({}, buffer[14]);
+        Assert::AreEqual({}, buffer[15]);
+        Assert::AreEqual(byte{0x3}, buffer[16]);
+        Assert::AreEqual(byte{0x20}, buffer[17]);
 
         // Width
-        Assert::AreEqual(uint8_t{}, buffer[18]);
-        Assert::AreEqual(uint8_t{}, buffer[19]);
-        Assert::AreEqual(uint8_t{0x2}, buffer[20]);
-        Assert::AreEqual(uint8_t{0x58}, buffer[21]);
+        Assert::AreEqual({}, buffer[18]);
+        Assert::AreEqual({}, buffer[19]);
+        Assert::AreEqual(byte{0x2}, buffer[20]);
+        Assert::AreEqual(byte{0x58}, buffer[21]);
 
-        Assert::AreEqual(static_cast<uint8_t>(header.color_space), buffer[22]);
-        Assert::AreEqual(static_cast<uint8_t>(header.bits_per_sample), buffer[23]);
-        Assert::AreEqual(static_cast<uint8_t>(header.compression_type), buffer[24]);
-        Assert::AreEqual(static_cast<uint8_t>(header.resolution_units), buffer[25]);
+        Assert::AreEqual(static_cast<byte>(header.color_space), buffer[22]);
+        Assert::AreEqual(static_cast<byte>(header.bits_per_sample), buffer[23]);
+        Assert::AreEqual(static_cast<byte>(header.compression_type), buffer[24]);
+        Assert::AreEqual(static_cast<byte>(header.resolution_units), buffer[25]);
 
         // vertical_resolution
-        Assert::AreEqual(uint8_t{}, buffer[26]);
-        Assert::AreEqual(uint8_t{}, buffer[27]);
-        Assert::AreEqual(uint8_t{}, buffer[28]);
-        Assert::AreEqual(uint8_t{96}, buffer[29]);
+        Assert::AreEqual({}, buffer[26]);
+        Assert::AreEqual({}, buffer[27]);
+        Assert::AreEqual({}, buffer[28]);
+        Assert::AreEqual(byte{96}, buffer[29]);
 
         // header.horizontal_resolution = 1024
-        Assert::AreEqual(uint8_t{}, buffer[30]);
-        Assert::AreEqual(uint8_t{}, buffer[31]);
-        Assert::AreEqual(uint8_t{4}, buffer[32]);
-        Assert::AreEqual(uint8_t{}, buffer[33]);
+        Assert::AreEqual({}, buffer[30]);
+        Assert::AreEqual({}, buffer[31]);
+        Assert::AreEqual(byte{4}, buffer[32]);
+        Assert::AreEqual(byte{}, buffer[33]);
     }
 
     TEST_METHOD(write_spiff_segment_in_too_small_buffer_throws) // NOLINT
     {
-        array<uint8_t, 33> buffer{};
+        array<byte, 33> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         spiff_header header{spiff_profile_id::none,
@@ -215,7 +217,7 @@ public:
 
     TEST_METHOD(write_spiff_end_of_directory_segment) // NOLINT
     {
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_spiff_end_of_directory_entry();
@@ -223,46 +225,46 @@ public:
         Assert::AreEqual(size_t{10}, writer.bytes_written());
 
         // Verify Entry Magic Number (EMN)
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), buffer[1]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data8), buffer[1]);
 
         // Verify EOD Entry Length (EOD = End Of Directory)
-        Assert::AreEqual(uint8_t{}, buffer[2]);
-        Assert::AreEqual(uint8_t{8}, buffer[3]);
+        Assert::AreEqual(byte{}, buffer[2]);
+        Assert::AreEqual(byte{8}, buffer[3]);
 
         // Verify EOD Tag
         Assert::AreEqual({}, buffer[4]);
-        Assert::AreEqual(uint8_t{}, buffer[5]);
-        Assert::AreEqual(uint8_t{}, buffer[6]);
-        Assert::AreEqual(uint8_t{1}, buffer[7]);
+        Assert::AreEqual(byte{}, buffer[5]);
+        Assert::AreEqual(byte{}, buffer[6]);
+        Assert::AreEqual(byte{1}, buffer[7]);
 
         // Verify embedded SOI tag
-        Assert::AreEqual(uint8_t{0xFF}, buffer[8]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), buffer[9]);
+        Assert::AreEqual(byte{0xFF}, buffer[8]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), buffer[9]);
     }
 
     TEST_METHOD(write_spiff_directory_entry) // NOLINT
     {
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         jpeg_stream_writer writer{{buffer.data(), buffer.size()}};
 
-        const array<uint8_t, 2> data{0x77, 0x66};
+        const array data{byte{0x77}, byte{0x66}};
 
         writer.write_spiff_directory_entry(2, data.data(), data.size());
 
         // Verify Entry Magic Number (EMN)
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), buffer[1]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data8), buffer[1]);
 
         // Verify Entry Length
-        Assert::AreEqual(uint8_t{}, buffer[2]);
-        Assert::AreEqual(uint8_t{8}, buffer[3]);
+        Assert::AreEqual({}, buffer[2]);
+        Assert::AreEqual(byte{8}, buffer[3]);
 
         // Verify Entry Tag
-        Assert::AreEqual(uint8_t{}, buffer[4]);
-        Assert::AreEqual(uint8_t{}, buffer[5]);
-        Assert::AreEqual(uint8_t{}, buffer[6]);
-        Assert::AreEqual(uint8_t{2}, buffer[7]);
+        Assert::AreEqual({}, buffer[4]);
+        Assert::AreEqual({}, buffer[5]);
+        Assert::AreEqual({}, buffer[6]);
+        Assert::AreEqual(byte{2}, buffer[7]);
 
         // Verify embedded data
         Assert::AreEqual(data[0], buffer[8]);
@@ -274,7 +276,7 @@ public:
         constexpr int32_t bits_per_sample{8};
         constexpr int32_t component_count{3};
 
-        array<uint8_t, 19> buffer{};
+        array<byte, 19> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         const bool oversized_image{
@@ -283,28 +285,28 @@ public:
         Assert::IsFalse(oversized_image);
         Assert::AreEqual(size_t{19}, writer.bytes_written());
 
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(uint8_t{0xF7}, buffer[1]); // JPEG_SOF_55
-        Assert::AreEqual(uint8_t{}, buffer[2]);     // 6 + (3 * 3) + 2 (in big endian)
-        Assert::AreEqual(uint8_t{17}, buffer[3]);   // 6 + (3 * 3) + 2 (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(bits_per_sample), buffer[4]);
-        Assert::AreEqual(uint8_t{255}, buffer[5]); // height (in big endian)
-        Assert::AreEqual(uint8_t{255}, buffer[6]); // height (in big endian)
-        Assert::AreEqual(uint8_t{}, buffer[7]);    // width (in big endian)
-        Assert::AreEqual(uint8_t{100}, buffer[8]); // width (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(component_count), buffer[9]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(byte{0xF7}, buffer[1]);    // JPEG_SOF_55
+        Assert::AreEqual(byte{}, buffer[2]);      // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(byte{17}, buffer[3]);      // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(static_cast<byte>(bits_per_sample), buffer[4]);
+        Assert::AreEqual(byte{255}, buffer[5]);    // height (in big endian)
+        Assert::AreEqual(byte{255}, buffer[6]);    // height (in big endian)
+        Assert::AreEqual(byte{}, buffer[7]);       // width (in big endian)
+        Assert::AreEqual(byte{100}, buffer[8]);    // width (in big endian)
+        Assert::AreEqual(static_cast<byte>(component_count), buffer[9]);
 
-        Assert::AreEqual(uint8_t{1}, buffer[10]);
-        Assert::AreEqual(uint8_t{0x11}, buffer[11]);
-        Assert::AreEqual(uint8_t{}, buffer[12]);
+        Assert::AreEqual(byte{1}, buffer[10]);
+        Assert::AreEqual(byte{0x11}, buffer[11]);
+        Assert::AreEqual(byte{}, buffer[12]);
 
-        Assert::AreEqual(uint8_t{2}, buffer[13]);
-        Assert::AreEqual(uint8_t{0x11}, buffer[14]);
-        Assert::AreEqual(uint8_t{}, buffer[15]);
+        Assert::AreEqual(byte{2}, buffer[13]);
+        Assert::AreEqual(byte{0x11}, buffer[14]);
+        Assert::AreEqual(byte{}, buffer[15]);
 
-        Assert::AreEqual(uint8_t{3}, buffer[16]);
-        Assert::AreEqual(uint8_t{0x11}, buffer[17]);
-        Assert::AreEqual(uint8_t{}, buffer[18]);
+        Assert::AreEqual(byte{3}, buffer[16]);
+        Assert::AreEqual(byte{0x11}, buffer[17]);
+        Assert::AreEqual(byte{}, buffer[18]);
     }
 
     TEST_METHOD(write_start_of_frame_segment_large_image) // NOLINT
@@ -312,7 +314,7 @@ public:
         constexpr int32_t bits_per_sample{8};
         constexpr int32_t component_count{3};
 
-        array<uint8_t, 19> buffer{};
+        array<byte, 19> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         const bool oversized_image{writer.write_start_of_frame_segment(
@@ -321,28 +323,28 @@ public:
         Assert::IsTrue(oversized_image);
         Assert::AreEqual(size_t{19}, writer.bytes_written());
 
-        Assert::AreEqual(uint8_t{0xFF}, buffer[0]);
-        Assert::AreEqual(uint8_t{0xF7}, buffer[1]); // JPEG_SOF_55
-        Assert::AreEqual(uint8_t{}, buffer[2]);     // 6 + (3 * 3) + 2 (in big endian)
-        Assert::AreEqual(uint8_t{17}, buffer[3]);   // 6 + (3 * 3) + 2 (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(bits_per_sample), buffer[4]);
-        Assert::AreEqual(uint8_t{}, buffer[5]); // height (in big endian)
-        Assert::AreEqual(uint8_t{}, buffer[6]); // height (in big endian)
-        Assert::AreEqual(uint8_t{}, buffer[7]); // width (in big endian)
-        Assert::AreEqual(uint8_t{}, buffer[8]); // width (in big endian)
-        Assert::AreEqual(static_cast<uint8_t>(component_count), buffer[9]);
+        Assert::AreEqual(byte{0xFF}, buffer[0]);
+        Assert::AreEqual(byte{0xF7}, buffer[1]);    // JPEG_SOF_55
+        Assert::AreEqual(byte{}, buffer[2]);      // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(byte{17}, buffer[3]);      // 6 + (3 * 3) + 2 (in big endian)
+        Assert::AreEqual(static_cast<byte>(bits_per_sample), buffer[4]);
+        Assert::AreEqual(byte{}, buffer[5]);    // height (in big endian)
+        Assert::AreEqual(byte{}, buffer[6]);    // height (in big endian)
+        Assert::AreEqual(byte{}, buffer[7]);    // width (in big endian)
+        Assert::AreEqual(byte{}, buffer[8]);    // width (in big endian)
+        Assert::AreEqual(static_cast<byte>(component_count), buffer[9]);
 
-        Assert::AreEqual(uint8_t{1}, buffer[10]);
-        Assert::AreEqual(uint8_t{0x11}, buffer[11]);
-        Assert::AreEqual(uint8_t{}, buffer[12]);
+        Assert::AreEqual(byte{1}, buffer[10]);
+        Assert::AreEqual(byte{0x11}, buffer[11]);
+        Assert::AreEqual(byte{}, buffer[12]);
 
-        Assert::AreEqual(uint8_t{2}, buffer[13]);
-        Assert::AreEqual(uint8_t{0x11}, buffer[14]);
-        Assert::AreEqual(uint8_t{}, buffer[15]);
+        Assert::AreEqual(byte{2}, buffer[13]);
+        Assert::AreEqual(byte{0x11}, buffer[14]);
+        Assert::AreEqual(byte{}, buffer[15]);
 
-        Assert::AreEqual(uint8_t{3}, buffer[16]);
-        Assert::AreEqual(uint8_t{0x11}, buffer[17]);
-        Assert::AreEqual(uint8_t{}, buffer[18]);
+        Assert::AreEqual(byte{3}, buffer[16]);
+        Assert::AreEqual(byte{0x11}, buffer[17]);
+        Assert::AreEqual(byte{}, buffer[18]);
     }
 
     TEST_METHOD(write_start_of_frame_marker_segment_with_low_boundary_values) // NOLINT
@@ -350,139 +352,138 @@ public:
         constexpr int32_t bits_per_sample{2};
         constexpr int32_t component_count{1};
 
-        array<uint8_t, 13> buffer{};
+        array<byte, 13> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_start_of_frame_segment({1, 1, bits_per_sample, component_count});
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(static_cast<uint8_t>(bits_per_sample), buffer[4]);
-        Assert::AreEqual(static_cast<uint8_t>(component_count), buffer[9]);
+        Assert::AreEqual(static_cast<byte>(bits_per_sample), buffer[4]);
+        Assert::AreEqual(static_cast<byte>(component_count), buffer[9]);
     }
 
     TEST_METHOD(write_start_of_frame_marker_segment_with_high_boundary_values_and_serialize) // NOLINT
     {
-        array<uint8_t, 775> buffer{};
+        array<byte, 775> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_start_of_frame_segment(
             {numeric_limits<uint16_t>::max(), numeric_limits<uint16_t>::max(), 16, numeric_limits<uint8_t>::max()});
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(uint8_t{16}, buffer[4]);
-        Assert::AreEqual(numeric_limits<uint8_t>::max(), buffer[9]);
-
-        Assert::AreEqual(numeric_limits<uint8_t>::max(), buffer[buffer.size() - 3]); // Last component index.
+        Assert::AreEqual(byte{16}, buffer[4]);
+        Assert::AreEqual(numeric_limits<uint8_t>::max(), to_integer<uint8_t>(buffer[9]));
+        Assert::AreEqual(numeric_limits<uint8_t>::max(), to_integer<uint8_t>(buffer[buffer.size() - 3])); // Last component index.
     }
 
     TEST_METHOD(write_color_transform_segment) // NOLINT
     {
         constexpr color_transformation transformation = color_transformation::hp1;
 
-        array<uint8_t, 9> buffer{};
+        array<byte, 9> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_color_transform_segment(transformation);
         Assert::AreEqual(buffer.size(), writer.bytes_written());
 
         // Verify mrfx identifier string.
-        Assert::AreEqual(uint8_t{'m'}, buffer[4]);
-        Assert::AreEqual(uint8_t{'r'}, buffer[5]);
-        Assert::AreEqual(uint8_t{'f'}, buffer[6]);
-        Assert::AreEqual(uint8_t{'x'}, buffer[7]);
+        Assert::AreEqual(byte{'m'}, buffer[4]);
+        Assert::AreEqual(byte{'r'}, buffer[5]);
+        Assert::AreEqual(byte{'f'}, buffer[6]);
+        Assert::AreEqual(byte{'x'}, buffer[7]);
 
-        Assert::AreEqual(static_cast<uint8_t>(transformation), buffer[8]);
+        Assert::AreEqual(static_cast<byte>(transformation), buffer[8]);
     }
 
     TEST_METHOD(write_jpegls_extended_parameters_marker_and_serialize) // NOLINT
     {
         constexpr jpegls_pc_parameters presets{2, 1, 2, 3, 7};
 
-        array<uint8_t, 15> buffer{};
+        array<byte, 15> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_jpegls_preset_parameters_segment(presets);
         Assert::AreEqual(buffer.size(), writer.bytes_written());
 
         // Parameter ID.
-        Assert::AreEqual(uint8_t{0x1}, buffer[4]);
+        Assert::AreEqual(byte{0x1}, buffer[4]);
 
         // MaximumSampleValue
-        Assert::AreEqual(uint8_t{}, buffer[5]);
-        Assert::AreEqual(uint8_t{2}, buffer[6]);
+        Assert::AreEqual({}, buffer[5]);
+        Assert::AreEqual(byte{2}, buffer[6]);
 
         // Threshold1
-        Assert::AreEqual(uint8_t{}, buffer[7]);
-        Assert::AreEqual(uint8_t{1}, buffer[8]);
+        Assert::AreEqual({}, buffer[7]);
+        Assert::AreEqual(byte{1}, buffer[8]);
 
         // Threshold2
-        Assert::AreEqual(uint8_t{}, buffer[9]);
-        Assert::AreEqual(uint8_t{2}, buffer[10]);
+        Assert::AreEqual({}, buffer[9]);
+        Assert::AreEqual(byte{2}, buffer[10]);
 
         // Threshold3
-        Assert::AreEqual(uint8_t{}, buffer[11]);
-        Assert::AreEqual(uint8_t{3}, buffer[12]);
+        Assert::AreEqual({}, buffer[11]);
+        Assert::AreEqual(byte{3}, buffer[12]);
 
         // ResetValue
-        Assert::AreEqual(uint8_t{}, buffer[13]);
-        Assert::AreEqual(uint8_t{7}, buffer[14]);
+        Assert::AreEqual({}, buffer[13]);
+        Assert::AreEqual(byte{7}, buffer[14]);
     }
 
     TEST_METHOD(write_jpegls_preset_parameters_segment_for_oversized_image_dimensions) // NOLINT
     {
-        array<uint8_t, 14> buffer{};
+        array<byte, 14> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_jpegls_preset_parameters_segment(100, numeric_limits<uint32_t>::max());
         Assert::AreEqual(buffer.size(), writer.bytes_written());
 
         // Parameter ID.
-        Assert::AreEqual(uint8_t{0x4}, buffer[4]);
+        Assert::AreEqual(byte{0x4}, buffer[4]);
 
         // Wxy
-        Assert::AreEqual(uint8_t{4}, buffer[5]);
+        Assert::AreEqual(byte{4}, buffer[5]);
 
         // Height (in big endian)
-        Assert::AreEqual(uint8_t{}, buffer[6]);
-        Assert::AreEqual(uint8_t{}, buffer[7]);
-        Assert::AreEqual(uint8_t{}, buffer[8]);
-        Assert::AreEqual(uint8_t{100}, buffer[9]);
+        Assert::AreEqual({}, buffer[6]);
+        Assert::AreEqual({}, buffer[7]);
+        Assert::AreEqual({}, buffer[8]);
+        Assert::AreEqual(byte{100}, buffer[9]);
 
         // Width (in big endian)
-        Assert::AreEqual(uint8_t{255}, buffer[10]);
-        Assert::AreEqual(uint8_t{255}, buffer[11]);
-        Assert::AreEqual(uint8_t{255}, buffer[12]);
-        Assert::AreEqual(uint8_t{255}, buffer[13]);
+        Assert::AreEqual(byte{255}, buffer[10]);
+        Assert::AreEqual(byte{255}, buffer[11]);
+        Assert::AreEqual(byte{255}, buffer[12]);
+        Assert::AreEqual(byte{255}, buffer[13]);
     }
 
     TEST_METHOD(write_start_of_scan_marker) // NOLINT
     {
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(uint8_t{1}, buffer[4]); // component count.
-        Assert::AreEqual(uint8_t{1}, buffer[5]); // component index.
-        Assert::AreEqual(uint8_t{}, buffer[6]);  // table ID.
-        Assert::AreEqual(uint8_t{2}, buffer[7]); // NEAR parameter.
-        Assert::AreEqual(uint8_t{}, buffer[8]);  // ILV parameter.
-        Assert::AreEqual(uint8_t{}, buffer[9]);  // transformation.
+        Assert::AreEqual(byte{1}, buffer[4]);    // component count.
+        Assert::AreEqual(byte{1}, buffer[5]);    // component index.
+        Assert::AreEqual(byte{}, buffer[6]);     // table ID.
+        Assert::AreEqual(byte{2}, buffer[7]);    // NEAR parameter.
+        Assert::AreEqual(byte{}, buffer[8]);     // ILV parameter.
+        Assert::AreEqual(byte{}, buffer[9]);     // transformation.
     }
 
     TEST_METHOD(rewind) // NOLINT
     {
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         jpeg_stream_writer writer({buffer.data(), buffer.size()});
 
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);
         writer.rewind();
-        buffer[4] = 0;
+        buffer[4] = {};
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);
 
         Assert::AreEqual(buffer.size(), writer.bytes_written());
-        Assert::AreEqual(uint8_t{1}, buffer[4]); // component count.
+        Assert::AreEqual(byte{1}, buffer[4]); // component count.
     }
 };
 

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -18,6 +18,7 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
+using std::byte;
 using std::error_code;
 using std::ignore;
 using std::numeric_limits;
@@ -29,7 +30,7 @@ namespace charls::test {
 
 namespace {
 
-jpegls_decoder create_decoder(const vector<uint8_t>& source)
+jpegls_decoder create_decoder(const vector<byte>& source)
 {
     return {source, true};
 }
@@ -53,7 +54,7 @@ public:
         jpegls_decoder decoder2(std::move(decoder1));
 
         jpegls_decoder decoder3;
-        constexpr array<uint8_t, 10> buffer{};
+        constexpr array<byte, 10> buffer{};
         decoder3.source(buffer.data(), buffer.size());
         decoder3 = std::move(decoder2);
 
@@ -65,7 +66,7 @@ public:
     {
         jpegls_decoder decoder;
 
-        const vector<uint8_t> source(2000);
+        const vector<byte> source(2000);
         decoder.source(source);
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder, &source] { decoder.source(source); });
     }
@@ -93,7 +94,7 @@ public:
 
     TEST_METHOD(read_header_from_non_jpegls_data) // NOLINT
     {
-        const vector<uint8_t> source(100);
+        const vector<byte> source(100);
         jpegls_decoder decoder{source, false};
 
         error_code ec;
@@ -104,7 +105,7 @@ public:
 
     TEST_METHOD(frame_info_without_read_header) // NOLINT
     {
-        const vector<uint8_t> source(2000);
+        const vector<byte> source(2000);
         const jpegls_decoder decoder{source, false};
 
         Assert::AreEqual(0, decoder.frame_info().bits_per_sample);
@@ -125,7 +126,7 @@ public:
 
     TEST_METHOD(interleave_mode_without_read_header_throws) // NOLINT
     {
-        const vector<uint8_t> source(2000);
+        const vector<byte> source(2000);
         const jpegls_decoder decoder{source, false};
 
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder] { ignore = decoder.interleave_mode(); });
@@ -133,7 +134,7 @@ public:
 
     TEST_METHOD(near_lossless_without_read_header_throws) // NOLINT
     {
-        const vector<uint8_t> source(2000);
+        const vector<byte> source(2000);
         const jpegls_decoder decoder{source, false};
 
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder] { ignore = decoder.near_lossless(); });
@@ -143,7 +144,7 @@ public:
     {
         jpegls_decoder decoder;
 
-        const vector<uint8_t> source(2000);
+        const vector<byte> source(2000);
         decoder.source(source);
 
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder] { ignore = decoder.preset_coding_parameters(); });
@@ -151,7 +152,7 @@ public:
 
     TEST_METHOD(destination_size) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
 
         const jpegls_decoder decoder{source, true};
 
@@ -161,7 +162,7 @@ public:
 
     TEST_METHOD(destination_size_stride_interleave_none) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr size_t stride{512};
@@ -172,7 +173,7 @@ public:
 
     TEST_METHOD(destination_size_stride_interleave_none_16_bit) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t16e0.jls")};
+        const auto source{read_file("DataFiles/t16e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr size_t stride{513};
@@ -183,7 +184,7 @@ public:
 
     TEST_METHOD(destination_size_stride_interleave_line) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c1e0.jls")};
+        const auto source{read_file("DataFiles/t8c1e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr size_t stride{1024};
@@ -194,7 +195,7 @@ public:
 
     TEST_METHOD(destination_size_stride_interleave_sample) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c2e0.jls")};
+        const auto source{read_file("DataFiles/t8c2e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr size_t stride{1024};
@@ -205,7 +206,7 @@ public:
 
     TEST_METHOD(destination_size_for_interleave_none_with_bad_stride_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr uint32_t correct_stride{256};
@@ -215,7 +216,7 @@ public:
 
     TEST_METHOD(destination_size_for_interleave_none_16_bit_with_bad_stride_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t16e0.jls")};
+        const auto source{read_file("DataFiles/t16e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr uint32_t correct_stride{256 * 2};
@@ -225,7 +226,7 @@ public:
 
     TEST_METHOD(destination_size_for_sample_interleave_with_bad_stride_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c2e0.jls")};
+        const auto source{read_file("DataFiles/t8c2e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr uint32_t correct_stride{3 * 256};
@@ -235,23 +236,23 @@ public:
 
     TEST_METHOD(destination_size_for_small_image_with_custom_stride) // NOLINT
     {
-        const vector<uint8_t> source{read_file("8bit-monochrome-2x2.jls")};
+        const auto source{read_file("8bit-monochrome-2x2.jls")};
         const jpegls_decoder decoder{source, true};
 
         constexpr uint32_t stride{4};
         const size_t destination_size{decoder.destination_size(stride)};
         Assert::AreEqual(size_t{6}, destination_size);
 
-        vector<uint8_t> destination(destination_size);
+        vector<byte> destination(destination_size);
         decoder.decode(destination, stride);
     }
 
     TEST_METHOD(decode_reference_file_from_buffer) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         const jpegls_decoder decoder{source, true};
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
         portable_anymap_file reference_file{
@@ -266,12 +267,12 @@ public:
 
     TEST_METHOD(decode_with_default_pc_parameters_before_each_sos) // NOLINT
     {
-        vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        auto source{read_file("DataFiles/t8c0e0.jls")};
         insert_pc_parameters_segments(source, 3);
 
         const jpegls_decoder decoder{source, true};
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
         portable_anymap_file reference_file{
@@ -290,11 +291,11 @@ public:
         writer.write_start_of_image();
         writer.write_start_of_frame_segment(1, 1, 8, 3);
         writer.write_start_of_scan_segment(0, 1, 0, interleave_mode::none);
-        writer.write_byte(0x80);
+        writer.write_byte(byte{0x80});
         writer.write_start_of_scan_segment(1, 2, 0, interleave_mode::sample);
 
         const jpegls_decoder decoder(writer.buffer, true);
-        std::vector<uint8_t> destination(decoder.destination_size());
+        std::vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::parameter_value_not_supported,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -302,9 +303,9 @@ public:
 
     TEST_METHOD(decode_with_destination_as_return) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         const jpegls_decoder decoder{source, true};
-        const auto destination{decoder.decode<vector<uint8_t>>()};
+        const auto destination{decoder.decode<vector<byte>>()};
 
         portable_anymap_file reference_file{
             read_anymap_reference_file("DataFiles/test8.ppm", decoder.interleave_mode(), decoder.frame_info())};
@@ -318,7 +319,7 @@ public:
 
     TEST_METHOD(decode_with_16_bit_destination_as_return) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         const jpegls_decoder decoder{source, true};
         const auto destination{decoder.decode<vector<uint16_t>>()};
 
@@ -326,7 +327,7 @@ public:
             read_anymap_reference_file("DataFiles/test8.ppm", decoder.interleave_mode(), decoder.frame_info())};
 
         const auto& reference_image_data{reference_file.image_data()};
-        const auto* destination_as_bytes{reinterpret_cast<const uint8_t*>(destination.data())};
+        const auto* destination_as_bytes{reinterpret_cast<const byte*>(destination.data())};
         for (size_t i{}; i != reference_image_data.size(); ++i)
         {
             Assert::AreEqual(reference_image_data[i], destination_as_bytes[i]);
@@ -337,7 +338,7 @@ public:
     {
         const jpegls_decoder decoder;
 
-        vector<uint8_t> buffer(1000);
+        vector<byte> buffer(1000);
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder, &buffer] { decoder.decode(buffer); });
     }
 
@@ -363,10 +364,10 @@ public:
 
     TEST_METHOD(decode_color_interleave_none_with_too_small_stride_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         constexpr uint32_t correct_stride{256};
         assert_expect_exception(jpegls_errc::invalid_argument_stride, [&decoder, &destination, &correct_stride] {
@@ -376,10 +377,10 @@ public:
 
     TEST_METHOD(decode_color_interleave_sample_with_too_small_stride_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c2e0.jls")};
+        const auto source{read_file("DataFiles/t8c2e0.jls")};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         constexpr uint32_t correct_stride{256 * 3};
         assert_expect_exception(jpegls_errc::invalid_argument_stride, [&decoder, &destination, correct_stride] {
@@ -389,10 +390,10 @@ public:
 
     TEST_METHOD(decode_color_interleave_none_with_standard_stride_works) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         const uint32_t standard_stride{decoder.frame_info().width};
         decoder.decode(destination, standard_stride);
 
@@ -402,10 +403,10 @@ public:
 
     TEST_METHOD(decode_color_interleave_sample_with_standard_stride_works) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c2e0.jls")};
+        const auto source{read_file("DataFiles/t8c2e0.jls")};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         const uint32_t standard_stride{decoder.frame_info().width * 3};
         decoder.decode(destination, standard_stride);
 
@@ -416,10 +417,10 @@ public:
     TEST_METHOD(decode_color_interleave_none_with_custom_stride_works) // NOLINT
     {
         constexpr uint32_t custom_stride{256 + 1};
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size(custom_stride));
+        vector<byte> destination(decoder.destination_size(custom_stride));
         decoder.decode(destination, custom_stride);
 
         verify_decoded_bytes(decoder.interleave_mode(), decoder.frame_info(), destination, custom_stride,
@@ -429,10 +430,10 @@ public:
     TEST_METHOD(decode_color_interleave_sample_with_custom_stride_works) // NOLINT
     {
         constexpr uint32_t custom_stride{256 * 3 + 1};
-        const vector<uint8_t> source{read_file("DataFiles/t8c2e0.jls")};
+        const auto source{read_file("DataFiles/t8c2e0.jls")};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size(custom_stride));
+        vector<byte> destination(decoder.destination_size(custom_stride));
         decoder.decode(destination, custom_stride);
 
         verify_decoded_bytes(decoder.interleave_mode(), decoder.frame_info(), destination, custom_stride,
@@ -455,7 +456,7 @@ public:
 
     TEST_METHOD(read_spiff_header) // NOLINT
     {
-        const vector<uint8_t> source{create_test_spiff_header()};
+        const auto source{create_test_spiff_header()};
         const jpegls_decoder decoder{source, true};
 
         Assert::IsTrue(decoder.spiff_header_has_value());
@@ -495,7 +496,7 @@ public:
 
     TEST_METHOD(read_spiff_header_from_non_jpegls_data) // NOLINT
     {
-        const vector<uint8_t> source(100);
+        const vector<byte> source(100);
         jpegls_decoder decoder{source, false};
 
         error_code ec;
@@ -506,8 +507,7 @@ public:
 
     TEST_METHOD(read_spiff_header_from_jpegls_without_spiff) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
-
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         const jpegls_decoder decoder{source, true};
 
         Assert::IsFalse(decoder.spiff_header_has_value());
@@ -522,7 +522,7 @@ public:
 
     TEST_METHOD(read_invalid_spiff_header_with_read_header) // NOLINT
     {
-        const vector<uint8_t> source{create_test_spiff_header(2, 0, true, 1)};
+        const auto source{create_test_spiff_header(2, 0, true, 1)};
         jpegls_decoder decoder{source, false};
 
         decoder.read_spiff_header();
@@ -534,7 +534,7 @@ public:
 
     TEST_METHOD(read_invalid_spiff_header_throws) // NOLINT
     {
-        const vector<uint8_t> source{create_test_spiff_header(2, 0, true, 1)};
+        const auto source{create_test_spiff_header(2, 0, true, 1)};
 
         assert_expect_exception(jpegls_errc::invalid_spiff_header, [&source] {
             // ReSharper disable once CppLocalVariableWithNonTrivialDtorIsNeverUsed
@@ -544,8 +544,7 @@ public:
 
     TEST_METHOD(read_header_twice_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
-
+        const auto source{read_file("DataFiles/t8c0e0.jls")};
         jpegls_decoder decoder{source, true};
 
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder] { ignore = decoder.read_header(); });
@@ -554,12 +553,12 @@ public:
     TEST_METHOD(decode_twice_throws) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source_to_encode(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source_to_encode(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         const auto encoded{jpegls_encoder::encode(source_to_encode, frame_info)};
 
         const jpegls_decoder decoder{encoded, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder, &destination] { decoder.decode(destination); });
@@ -567,9 +566,9 @@ public:
 
     TEST_METHOD(simple_decode) // NOLINT
     {
-        const vector<uint8_t> encoded_source{read_file("DataFiles/t8c0e0.jls")};
+        const auto encoded_source{read_file("DataFiles/t8c0e0.jls")};
 
-        vector<uint8_t> decoded_destination;
+        vector<byte> decoded_destination;
         frame_info frame_info;
         interleave_mode interleave_mode;
         tie(frame_info, interleave_mode) = jpegls_decoder::decode(encoded_source, decoded_destination);
@@ -586,7 +585,7 @@ public:
 
     TEST_METHOD(simple_decode_to_uint16_buffer) // NOLINT
     {
-        const vector<uint8_t> encoded_source{read_file("DataFiles/t8c0e0.jls")};
+        const auto encoded_source{read_file("DataFiles/t8c0e0.jls")};
 
         vector<uint16_t> decoded_destination;
         frame_info frame_info;
@@ -605,7 +604,7 @@ public:
 
     TEST_METHOD(decode_file_with_ff_in_entropy_data_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("ff_in_entropy_data.jls")};
+        const auto source{read_file("ff_in_entropy_data.jls")};
 
         const jpegls_decoder decoder{source, true};
 
@@ -615,7 +614,7 @@ public:
         Assert::AreEqual(1216U, frame_info.height);
         Assert::AreEqual(968U, frame_info.width);
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::invalid_encoded_data,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -624,35 +623,35 @@ public:
     TEST_METHOD(decode_with_missing_end_of_image_marker_throws) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source_to_encode(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source_to_encode(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         const auto encoded{jpegls_encoder::encode(source_to_encode, frame_info)};
 
         {
             // Copy the vector to ensure source buffer has a defined limit (resize() keeps memory)
             // that can be checked with address sanitizer.
-            const vector<uint8_t> source(encoded.cbegin(), encoded.cend() - 1);
+            const vector<byte> source(encoded.cbegin(), encoded.cend() - 1);
 
             const jpegls_decoder decoder{source, true};
-            vector<uint8_t> destination(decoder.destination_size());
+            vector<byte> destination(decoder.destination_size());
             assert_expect_exception(jpegls_errc::source_buffer_too_small,
                                     [&decoder, &destination] { decoder.decode(destination); });
         }
 
         {
-            const vector<uint8_t> source(encoded.cbegin(), encoded.cend() - 2);
+            const vector<byte> source(encoded.cbegin(), encoded.cend() - 2);
             const jpegls_decoder decoder{source, true};
-            vector<uint8_t> destination(decoder.destination_size());
+            vector<byte> destination(decoder.destination_size());
 
             assert_expect_exception(jpegls_errc::source_buffer_too_small,
                                     [&decoder, &destination] { decoder.decode(destination); });
         }
 
         {
-            vector<uint8_t> source(encoded);
-            source[source.size() - 1] = 0x33;
+            auto source(encoded);
+            source[source.size() - 1] = byte{0x33};
             const jpegls_decoder decoder{source, true};
-            vector<uint8_t> destination(decoder.destination_size());
+            vector<byte> destination(decoder.destination_size());
 
             assert_expect_exception(jpegls_errc::end_of_image_marker_not_found,
                                     [&decoder, &destination] { decoder.decode(destination); });
@@ -661,7 +660,7 @@ public:
 
     TEST_METHOD(decode_file_with_golomb_large_then_k_max_throws) // NOLINT
     {
-        const vector<uint8_t> source{read_file("fuzzy_input_golomb_16.jls")};
+        const auto source{read_file("fuzzy_input_golomb_16.jls")};
 
         const jpegls_decoder decoder{source, true};
 
@@ -671,7 +670,7 @@ public:
         Assert::AreEqual(65516U, frame_info.height);
         Assert::AreEqual(1U, frame_info.width);
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::invalid_encoded_data,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -679,7 +678,7 @@ public:
 
     TEST_METHOD(decode_file_with_missing_restart_marker_throws) // NOLINT
     {
-        vector<uint8_t> source{read_file("DataFiles/t8c0e0.jls")};
+        auto source{read_file("DataFiles/t8c0e0.jls")};
 
         // Insert a DRI marker segment to trigger that restart markers are used.
         jpeg_test_stream_writer stream_writer;
@@ -688,7 +687,7 @@ public:
         source.insert(it, stream_writer.buffer.cbegin(), stream_writer.buffer.cend());
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::restart_marker_not_found,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -696,16 +695,16 @@ public:
 
     TEST_METHOD(decode_file_with_incorrect_restart_marker_throws) // NOLINT
     {
-        vector<uint8_t> source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
+        auto source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
 
         // Change the first restart marker to the second.
         auto it{find_scan_header(source.begin(), source.end())};
         it = find_first_restart_marker(it + 1, source.end());
         ++it;
-        *it = 0xD1;
+        *it = byte{0xD1};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::restart_marker_not_found,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -713,12 +712,13 @@ public:
 
     TEST_METHOD(decode_file_with_extra_begin_bytes_for_restart_marker_code) // NOLINT
     {
-        vector<uint8_t> source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
+        auto source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
 
         // Add additional 0xFF marker begin bytes
         auto it{find_scan_header(source.begin(), source.end())};
         it = find_first_restart_marker(it + 1, source.end());
-        const array<uint8_t, 7> extra_begin_bytes{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+        const array<byte, 7> extra_begin_bytes{byte{0xFF}, byte{0xFF}, byte{0xFF}, byte{0xFF},
+                                               byte{0xFF}, byte{0xFF}, byte{0xFF}};
         source.insert(it, extra_begin_bytes.cbegin(), extra_begin_bytes.cend());
 
         const jpegls_decoder decoder{source, true};
@@ -730,17 +730,17 @@ public:
 
     TEST_METHOD(decode_file_that_ends_after_restart_marker_throws) // NOLINT
     {
-        vector<uint8_t> source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
+        auto source{read_file("DataFiles/test8_ilv_none_rm_7.jls")};
 
         auto it{find_scan_header(source.begin(), source.end())};
         it = find_first_restart_marker(it + 1, source.end());
 
         // Copy the vector to ensure source buffer has a defined limit (resize() keeps memory)
         // that can be checked with address sanitizer.
-        const vector<uint8_t> too_small_source(source.begin(), it);
+        const vector too_small_source(source.begin(), it);
 
         const jpegls_decoder decoder{too_small_source, true};
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::source_buffer_too_small,
                                 [&decoder, &destination] { decoder.decode(destination); });
@@ -783,7 +783,7 @@ public:
 
         bool callback_called{};
         decoder.at_comment([&callback_called](const void*, const size_t) noexcept { callback_called = true; })
-               .at_comment(nullptr);
+            .at_comment(nullptr);
 
         decoder.read_header();
 
@@ -821,11 +821,11 @@ public:
         const void* actual_data{};
         size_t actual_size{};
         decoder.at_application_data([&actual_application_data_id, &actual_data, &actual_size](
-            const int32_t application_data_id, const void* data, const size_t size) noexcept {
-                actual_application_data_id = application_data_id;
-                actual_data = data;
-                actual_size = size;
-            });
+                                        const int32_t application_data_id, const void* data, const size_t size) noexcept {
+            actual_application_data_id = application_data_id;
+            actual_data = data;
+            actual_size = size;
+        });
 
         decoder.read_header();
 
@@ -994,16 +994,16 @@ public:
     {
         // These are compile time checks to detect issues with overloads that have similar conversions.
         constexpr frame_info frame_info{100, 100, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
-        const vector<uint8_t> encoded_source{
+        const vector<byte> encoded_source{
             jpegls_encoder::encode(source, frame_info, interleave_mode::none, encoding_options::even_destination_size)};
 
         jpegls_decoder decoder;
         decoder.source(encoded_source);
         decoder.read_header();
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
 
         void* data{destination.data()};
         const uint16_t size{static_cast<uint16_t>(destination.size())};
@@ -1013,42 +1013,42 @@ public:
     }
 
 private:
-    static vector<uint8_t>::iterator find_scan_header(const vector<uint8_t>::iterator begin,
-                                                      const vector<uint8_t>::iterator end) noexcept
+    static vector<byte>::iterator find_scan_header(const vector<byte>::iterator begin,
+                                                   const vector<byte>::iterator end) noexcept
     {
-        constexpr uint8_t start_of_scan{0xDA};
+        constexpr byte start_of_scan{0xDA};
 
         for (auto it{begin}; it != end; ++it)
         {
-            if (*it == 0xFF && it + 1 != end && *(it + 1) == start_of_scan)
+            if (*it == byte{0xFF} && it + 1 != end && *(it + 1) == start_of_scan)
                 return it;
         }
 
         return end;
     }
 
-    static vector<uint8_t>::iterator find_first_restart_marker(const vector<uint8_t>::iterator begin,
-                                                               const vector<uint8_t>::iterator end) noexcept
+    static vector<byte>::iterator find_first_restart_marker(const vector<byte>::iterator begin,
+                                                               const vector<byte>::iterator end) noexcept
     {
-        constexpr uint8_t first_restart_marker{0xD0};
+        constexpr byte first_restart_marker{0xD0};
 
         for (auto it{begin}; it != end; ++it)
         {
-            if (*it == 0xFF && it + 1 != end && *(it + 1) == first_restart_marker)
+            if (*it == byte{0xFF} && it + 1 != end && *(it + 1) == first_restart_marker)
                 return it;
         }
 
         return end;
     }
 
-    static vector<uint8_t> create_default_pc_parameters_segment()
+    static vector<byte> create_default_pc_parameters_segment()
     {
-        vector<uint8_t> segment;
+        vector<byte> segment;
 
-        segment.push_back(uint8_t{0xFF});
-        segment.push_back(static_cast<uint8_t>(jpeg_marker_code::jpegls_preset_parameters));
+        segment.push_back(byte{0xFF});
+        segment.push_back(static_cast<byte>(jpeg_marker_code::jpegls_preset_parameters));
         push_back(segment, static_cast<uint16_t>(11 + sizeof(uint16_t)));
-        segment.push_back(static_cast<uint8_t>(jpegls_preset_parameters_type::preset_coding_parameters));
+        segment.push_back(static_cast<byte>(jpegls_preset_parameters_type::preset_coding_parameters));
         push_back(segment, uint16_t{0});
         push_back(segment, uint16_t{0});
         push_back(segment, uint16_t{0});
@@ -1058,7 +1058,7 @@ private:
         return segment;
     }
 
-    static void insert_pc_parameters_segments(vector<uint8_t> & jpegls_source, const int component_count)
+    static void insert_pc_parameters_segments(vector<byte> & jpegls_source, const int component_count)
     {
         const auto pcp_segment{create_default_pc_parameters_segment()};
 
@@ -1067,7 +1067,7 @@ private:
         {
             it = find_scan_header(it, jpegls_source.end());
             it = jpegls_source.insert(it, pcp_segment.cbegin(), pcp_segment.cend());
-            it += static_cast<vector<uint8_t>::difference_type>(pcp_segment.size() + 2U);
+            it += static_cast<vector<byte>::difference_type>(pcp_segment.size() + 2U);
         }
     }
 
@@ -1089,10 +1089,10 @@ private:
 
     static void decode_image_with_too_small_buffer_throws(const char* image_filename, const uint32_t stride = 0)
     {
-        const vector<uint8_t> source{read_file(image_filename)};
+        const auto source{read_file(image_filename)};
 
         const jpegls_decoder decoder{source, true};
-        vector<uint8_t> destination(decoder.destination_size(stride) - 1);
+        vector<byte> destination(decoder.destination_size(stride) - 1);
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small,
                                 [&decoder, &destination, &stride] { decoder.decode(destination, stride); });

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -16,8 +16,10 @@
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
+using std::byte;
 using std::ignore;
 using std::numeric_limits;
+using std::to_integer;
 using std::vector;
 using namespace std::string_literals;
 
@@ -41,7 +43,7 @@ public:
         jpegls_encoder encoder2(std::move(encoder1));
 
         jpegls_encoder encoder3;
-        array<uint8_t, 10> buffer{};
+        array<byte, 10> buffer{};
         encoder3.destination(buffer.data(), buffer.size());
         encoder3 = std::move(encoder2);
     }
@@ -114,7 +116,7 @@ public:
     TEST_METHOD(interleave_mode_does_not_match_component_count_throws) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         assert_expect_exception(jpegls_errc::invalid_argument_interleave_mode, [&frame_info, &source] {
             jpegls_encoder::encode(source, frame_info, interleave_mode::sample);
@@ -225,7 +227,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(200);
+        vector<byte> destination(200);
         encoder.destination(destination);
     }
 
@@ -233,7 +235,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(200);
+        vector<byte> destination(200);
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_operation,
@@ -246,7 +248,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
@@ -254,20 +256,20 @@ public:
         Assert::AreEqual(serialized_spiff_header_size + 2, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APP8 with SPIFF has been written (details already verified by jpeg_stream_writer_test).
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{32}, destination[5]);
-        Assert::AreEqual(uint8_t{'S'}, destination[6]);
-        Assert::AreEqual(uint8_t{'P'}, destination[7]);
-        Assert::AreEqual(uint8_t{'I'}, destination[8]);
-        Assert::AreEqual(uint8_t{'F'}, destination[9]);
-        Assert::AreEqual(uint8_t{'F'}, destination[10]);
-        Assert::AreEqual(uint8_t{}, destination[11]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data8), destination[3]);
+        Assert::AreEqual({}, destination[4]);
+        Assert::AreEqual(byte{32}, destination[5]);
+        Assert::AreEqual(byte{'S'}, destination[6]);
+        Assert::AreEqual(byte{'P'}, destination[7]);
+        Assert::AreEqual(byte{'I'}, destination[8]);
+        Assert::AreEqual(byte{'F'}, destination[9]);
+        Assert::AreEqual(byte{'F'}, destination[10]);
+        Assert::AreEqual({}, destination[11]);
     }
 
     TEST_METHOD(write_standard_spiff_header_without_destination_throws) // NOLINT
@@ -284,7 +286,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(100);
+        vector<byte> destination(100);
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_operation,
@@ -297,7 +299,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
 
@@ -311,7 +313,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         spiff_header spiff_header{};
@@ -322,20 +324,20 @@ public:
         Assert::AreEqual(serialized_spiff_header_size + 2, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APP8 with SPIFF has been written (details already verified by jpeg_stream_writer_test).
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{32}, destination[5]);
-        Assert::AreEqual(uint8_t{'S'}, destination[6]);
-        Assert::AreEqual(uint8_t{'P'}, destination[7]);
-        Assert::AreEqual(uint8_t{'I'}, destination[8]);
-        Assert::AreEqual(uint8_t{'F'}, destination[9]);
-        Assert::AreEqual(uint8_t{'F'}, destination[10]);
-        Assert::AreEqual(uint8_t{}, destination[11]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data8), destination[3]);
+        Assert::AreEqual({}, destination[4]);
+        Assert::AreEqual(byte{32}, destination[5]);
+        Assert::AreEqual(byte{'S'}, destination[6]);
+        Assert::AreEqual(byte{'P'}, destination[7]);
+        Assert::AreEqual(byte{'I'}, destination[8]);
+        Assert::AreEqual(byte{'F'}, destination[9]);
+        Assert::AreEqual(byte{'F'}, destination[10]);
+        Assert::AreEqual(byte{}, destination[11]);
     }
 
     TEST_METHOD(write_spiff_header_invalid_height_throws) // NOLINT
@@ -344,7 +346,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         spiff_header spiff_header{};
@@ -361,7 +363,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         spiff_header spiff_header{};
@@ -378,7 +380,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
 
@@ -393,7 +395,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
 
@@ -409,7 +411,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
 
@@ -424,7 +426,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
 
@@ -437,12 +439,12 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.write_standard_spiff_header(spiff_color_space::cmyk);
 
         assert_expect_exception(jpegls_errc::invalid_argument_size, [&encoder] {
-            const vector<uint8_t> spiff_entry(65528 + 1);
+            const vector<byte> spiff_entry(65528 + 1);
             encoder.write_spiff_entry(spiff_entry_tag::image_title, spiff_entry.data(), spiff_entry.size());
         });
     }
@@ -453,11 +455,11 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_operation, [&encoder] {
-            const vector<uint8_t> spiff_entry(65528);
+            const vector<byte> spiff_entry(65528);
             encoder.write_spiff_entry(spiff_entry_tag::image_title, spiff_entry.data(), spiff_entry.size());
         });
     }
@@ -468,21 +470,21 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(300);
+        vector<byte> destination(300);
         encoder.destination(destination);
 
         encoder.write_standard_spiff_header(spiff_color_space::none);
         encoder.write_spiff_end_of_directory_entry();
 
-        Assert::AreEqual(uint8_t{0xFF}, destination[44]);
-        Assert::AreEqual(uint8_t{0xD8}, destination[45]); // 0xD8 = SOI: Marks the start of an image.
+        Assert::AreEqual(byte{0xFF}, destination[44]);
+        Assert::AreEqual(byte{0xD8}, destination[45]); // 0xD8 = SOI: Marks the start of an image.
     }
 
     TEST_METHOD(write_spiff_end_of_directory_entry_before_header_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(300);
+        vector<byte> destination(300);
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_operation,
@@ -495,7 +497,7 @@ public:
 
         encoder.frame_info({1, 1, 2, 1});
 
-        vector<uint8_t> destination(300);
+        vector<byte> destination(300);
         encoder.destination(destination);
 
         encoder.write_standard_spiff_header(spiff_color_space::none);
@@ -509,7 +511,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        array<uint8_t, 10> destination;
+        array<byte, 10> destination;
         encoder.destination(destination);
 
         encoder.write_comment("123");
@@ -517,25 +519,25 @@ public:
         Assert::AreEqual(size_t{10}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
-        Assert::AreEqual(uint8_t{'1'}, destination[6]);
-        Assert::AreEqual(uint8_t{'2'}, destination[7]);
-        Assert::AreEqual(uint8_t{'3'}, destination[8]);
-        Assert::AreEqual(uint8_t{}, destination[9]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), destination[3]);
+        Assert::AreEqual({}, destination[4]);
+        Assert::AreEqual(byte{2 + 4}, destination[5]);
+        Assert::AreEqual(byte{'1'}, destination[6]);
+        Assert::AreEqual(byte{'2'}, destination[7]);
+        Assert::AreEqual(byte{'3'}, destination[8]);
+        Assert::AreEqual(byte{}, destination[9]);
     }
 
     TEST_METHOD(write_empty_comment) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(6);
+        vector<byte> destination(6);
         encoder.destination(destination);
 
         encoder.write_comment("");
@@ -543,21 +545,21 @@ public:
         Assert::AreEqual(size_t{6}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2}, destination[5]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), destination[3]);
+        Assert::AreEqual({}, destination[4]);
+        Assert::AreEqual(byte{2}, destination[5]);
     }
 
     TEST_METHOD(write_empty_comment_buffer) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(6);
+        vector<byte> destination(6);
         encoder.destination(destination);
 
         encoder.write_comment(nullptr, 0);
@@ -565,45 +567,45 @@ public:
         Assert::AreEqual(size_t{6}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2}, destination[5]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), destination[3]);
+        Assert::AreEqual({}, destination[4]);
+        Assert::AreEqual(byte{2}, destination[5]);
     }
 
     TEST_METHOD(write_max_comment) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()));
+        vector<byte> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()));
         encoder.destination(destination);
 
         constexpr size_t max_size_comment_data{static_cast<size_t>(numeric_limits<uint16_t>::max()) - 2};
-        const vector<uint8_t> data(max_size_comment_data);
+        const vector<byte> data(max_size_comment_data);
         encoder.write_comment(data.data(), data.size());
 
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a COM segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(uint8_t{255}, destination[4]);
-        Assert::AreEqual(uint8_t{255}, destination[5]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), destination[3]);
+        Assert::AreEqual(byte{255}, destination[4]);
+        Assert::AreEqual(byte{255}, destination[5]);
     }
 
     TEST_METHOD(write_two_comment) // NOLINT
     {
         jpegls_encoder encoder;
 
-        array<uint8_t, 14> destination;
+        array<byte, 14> destination;
         encoder.destination(destination);
 
         encoder.write_comment("123");
@@ -612,34 +614,34 @@ public:
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that the COM segments have been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
-        Assert::AreEqual(uint8_t{'1'}, destination[6]);
-        Assert::AreEqual(uint8_t{'2'}, destination[7]);
-        Assert::AreEqual(uint8_t{'3'}, destination[8]);
-        Assert::AreEqual(uint8_t{}, destination[9]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), destination[3]);
+        Assert::AreEqual(byte{}, destination[4]);
+        Assert::AreEqual(byte{2 + 4}, destination[5]);
+        Assert::AreEqual(byte{'1'}, destination[6]);
+        Assert::AreEqual(byte{'2'}, destination[7]);
+        Assert::AreEqual(byte{'3'}, destination[8]);
+        Assert::AreEqual(byte{}, destination[9]);
 
-        Assert::AreEqual(uint8_t{0xFF}, destination[10]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::comment), destination[11]);
-        Assert::AreEqual(uint8_t{}, destination[12]);
-        Assert::AreEqual(uint8_t{2}, destination[13]);
+        Assert::AreEqual(byte{0xFF}, destination[10]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::comment), destination[11]);
+        Assert::AreEqual(byte{}, destination[12]);
+        Assert::AreEqual(byte{2}, destination[13]);
     }
 
     TEST_METHOD(write_too_large_comment_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()) + 1);
+        vector<byte> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()) + 1);
         encoder.destination(destination);
 
         constexpr size_t max_size_comment_data{static_cast<size_t>(numeric_limits<uint16_t>::max()) - 2};
-        const vector<uint8_t> data(max_size_comment_data + 1);
+        const vector<byte> data(max_size_comment_data + 1);
 
         assert_expect_exception(jpegls_errc::invalid_argument_size,
                                 [&encoder, &data] { ignore = encoder.write_comment(data.data(), data.size()); });
@@ -649,7 +651,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(100);
+        vector<byte> destination(100);
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] {
@@ -660,11 +662,11 @@ public:
 
     TEST_METHOD(write_comment_after_encode_throws) // NOLINT
     {
-        const vector<uint8_t> source{0, 1, 2, 3, 4, 5};
+        const vector source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
 
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(100);
+        vector<byte> destination(100);
         encoder.destination(destination);
         encoder.frame_info({3, 1, 16, 1});
         ignore = encoder.encode(source);
@@ -675,11 +677,11 @@ public:
 
     TEST_METHOD(write_comment_before_encode) // NOLINT
     {
-        const vector<uint8_t> source{0, 1, 2, 3, 4, 5};
+        const vector source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
         constexpr frame_info frame_info{3, 1, 16, 1};
 
         jpegls_encoder encoder;
-        vector<uint8_t> encoded(100);
+        vector<byte> encoded(100);
         encoder.destination(encoded);
         encoder.frame_info(frame_info);
 
@@ -693,34 +695,34 @@ public:
     {
         jpegls_encoder encoder;
 
-        array<uint8_t, 10> destination;
+        array<byte, 10> destination;
         encoder.destination(destination);
 
-        const array<uint8_t, 4> application_data{1, 2, 3, 4};
+        const array application_data{byte{1}, byte{2}, byte{3}, byte{4}};
         encoder.write_application_data(1, application_data.data(), application_data.size());
 
         Assert::AreEqual(size_t{10}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APPn segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data1), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
-        Assert::AreEqual(uint8_t{1}, destination[6]);
-        Assert::AreEqual(uint8_t{2}, destination[7]);
-        Assert::AreEqual(uint8_t{3}, destination[8]);
-        Assert::AreEqual(uint8_t{4}, destination[9]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data1), destination[3]);
+        Assert::AreEqual(byte{}, destination[4]);
+        Assert::AreEqual(byte{2 + 4}, destination[5]);
+        Assert::AreEqual(byte{1}, destination[6]);
+        Assert::AreEqual(byte{2}, destination[7]);
+        Assert::AreEqual(byte{3}, destination[8]);
+        Assert::AreEqual(byte{4}, destination[9]);
     }
 
     TEST_METHOD(write_empty_application_data) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(6);
+        vector<byte> destination(6);
         encoder.destination(destination);
 
         encoder.write_application_data(2, nullptr, 0);
@@ -728,82 +730,82 @@ public:
         Assert::AreEqual(size_t{6}, encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APPn segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data2), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2}, destination[5]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data2), destination[3]);
+        Assert::AreEqual({}, destination[4]);
+        Assert::AreEqual(byte{2}, destination[5]);
     }
 
     TEST_METHOD(write_max_application_data) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()));
+        vector<byte> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()));
         encoder.destination(destination);
 
         constexpr size_t max_size_application_data{static_cast<size_t>(numeric_limits<uint16_t>::max()) - 2};
-        const vector<uint8_t> data(max_size_application_data);
+        const vector<byte> data(max_size_application_data);
         encoder.write_application_data(15, data.data(), data.size());
 
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that a APPn segment has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data15), destination[3]);
-        Assert::AreEqual(uint8_t{255}, destination[4]);
-        Assert::AreEqual(uint8_t{255}, destination[5]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data15), destination[3]);
+        Assert::AreEqual(byte{255}, destination[4]);
+        Assert::AreEqual(byte{255}, destination[5]);
     }
 
     TEST_METHOD(write_two_application_data) // NOLINT
     {
         jpegls_encoder encoder;
 
-        array<uint8_t, 14> destination;
+        array<byte, 14> destination;
         encoder.destination(destination);
 
-        const array<uint8_t, 4> application_data{1, 2, 3, 4};
+        const array application_data{byte{1}, byte{2}, byte{3}, byte{4}};
         encoder.write_application_data(0, application_data.data(), application_data.size());
         encoder.write_application_data(8, nullptr, 0);
 
         Assert::AreEqual(destination.size(), encoder.bytes_written());
 
         // Check that SOI marker has been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[0]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::start_of_image), destination[1]);
+        Assert::AreEqual(byte{0xFF}, destination[0]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::start_of_image), destination[1]);
 
         // Verify that the COM segments have been written.
-        Assert::AreEqual(uint8_t{0xFF}, destination[2]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data0), destination[3]);
-        Assert::AreEqual(uint8_t{}, destination[4]);
-        Assert::AreEqual(uint8_t{2 + 4}, destination[5]);
-        Assert::AreEqual(uint8_t{1}, destination[6]);
-        Assert::AreEqual(uint8_t{2}, destination[7]);
-        Assert::AreEqual(uint8_t{3}, destination[8]);
-        Assert::AreEqual(uint8_t{4}, destination[9]);
+        Assert::AreEqual(byte{0xFF}, destination[2]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data0), destination[3]);
+        Assert::AreEqual(byte{}, destination[4]);
+        Assert::AreEqual(byte{2 + 4}, destination[5]);
+        Assert::AreEqual(byte{1}, destination[6]);
+        Assert::AreEqual(byte{2}, destination[7]);
+        Assert::AreEqual(byte{3}, destination[8]);
+        Assert::AreEqual(byte{4}, destination[9]);
 
-        Assert::AreEqual(uint8_t{0xFF}, destination[10]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::application_data8), destination[11]);
-        Assert::AreEqual(uint8_t{}, destination[12]);
-        Assert::AreEqual(uint8_t{2}, destination[13]);
+        Assert::AreEqual(byte{0xFF}, destination[10]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::application_data8), destination[11]);
+        Assert::AreEqual(byte{}, destination[12]);
+        Assert::AreEqual(byte{2}, destination[13]);
     }
 
     TEST_METHOD(write_too_large_application_data_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()) + 1);
+        vector<byte> destination(2 + 2 + static_cast<size_t>(numeric_limits<uint16_t>::max()) + 1);
         encoder.destination(destination);
 
         constexpr size_t max_size_application_data{static_cast<size_t>(numeric_limits<uint16_t>::max()) - 2};
-        const vector<uint8_t> data(max_size_application_data + 1);
+        const vector<byte> data(max_size_application_data + 1);
 
         assert_expect_exception(jpegls_errc::invalid_argument_size,
                                 [&encoder, &data] { ignore = encoder.write_application_data(0, data.data(), data.size()); });
@@ -813,7 +815,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(100);
+        vector<byte> destination(100);
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] {
@@ -824,11 +826,11 @@ public:
 
     TEST_METHOD(write_application_data_after_encode_throws) // NOLINT
     {
-        const vector<uint8_t> source{0, 1, 2, 3, 4, 5};
+        const vector source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
 
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(100);
+        vector<byte> destination(100);
         encoder.destination(destination);
         encoder.frame_info({3, 1, 16, 1});
         ignore = encoder.encode(source);
@@ -841,7 +843,7 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(100);
+        vector<byte> destination(100);
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] {
@@ -857,11 +859,11 @@ public:
 
     TEST_METHOD(write_application_data_before_encode) // NOLINT
     {
-        const vector<uint8_t> source{0, 1, 2, 3, 4, 5};
+        const vector source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
         constexpr frame_info frame_info{3, 1, 16, 1};
 
         jpegls_encoder encoder;
-        vector<uint8_t> encoded(100);
+        vector<byte> encoded(100);
         encoder.destination(encoded);
         encoder.frame_info(frame_info);
 
@@ -884,12 +886,12 @@ public:
 
     TEST_METHOD(set_preset_coding_parameters_bad_values_throws) // NOLINT
     {
-        const array<uint8_t, 5> source{0, 1, 1, 1, 0};
+        const array source{byte{0}, byte{1}, byte{1}, byte{1}, byte{0}};
         constexpr frame_info frame_info{5, 1, 8, 1};
         jpegls_encoder encoder;
 
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         constexpr jpegls_pc_parameters bad_pc_parameters{1, 1, 1, 1, 1};
@@ -922,7 +924,7 @@ public:
         jpegls_encoder encoder;
 
         encoder.frame_info({1, 1, 2, 1});
-        vector<uint8_t> source(20);
+        vector<byte> source(20);
         assert_expect_exception(jpegls_errc::invalid_operation, [&encoder, &source] { ignore = encoder.encode(source); });
     }
 
@@ -930,20 +932,20 @@ public:
     {
         jpegls_encoder encoder;
 
-        vector<uint8_t> destination(20);
+        vector<byte> destination(20);
         encoder.destination(destination);
-        const vector<uint8_t> source(20);
+        const vector<byte> source(20);
         assert_expect_exception(jpegls_errc::invalid_operation, [&encoder, &source] { ignore = encoder.encode(source); });
     }
 
     TEST_METHOD(encode_with_spiff_header) // NOLINT
     {
-        const array<uint8_t, 5> source{0, 1, 2, 3, 4};
+        const array source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}};
         constexpr frame_info frame_info{5, 1, 8, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         encoder.write_standard_spiff_header(spiff_color_space::grayscale);
@@ -956,12 +958,12 @@ public:
 
     TEST_METHOD(encode_with_color_transformation) // NOLINT
     {
-        const array<uint8_t, 6> source{0, 1, 2, 3, 4, 5};
+        const array source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
         constexpr frame_info frame_info{2, 1, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination).color_transformation(color_transformation::hp1);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -973,13 +975,13 @@ public:
 
     TEST_METHOD(encode_16_bit) // NOLINT
     {
-        const array<uint8_t, 6> source{0, 1, 2, 3, 4, 5};
+        const array source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
         constexpr frame_info frame_info{3, 1, 16, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -990,7 +992,7 @@ public:
 
     TEST_METHOD(simple_encode) // NOLINT
     {
-        const vector<uint8_t> source{0, 1, 2, 3, 4, 5};
+        const vector source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
 
         constexpr frame_info frame_info{3, 1, 16, 1};
         const auto encoded{jpegls_encoder::encode(source, frame_info)};
@@ -1000,36 +1002,38 @@ public:
 
     TEST_METHOD(encode_with_stride_interleave_none_8_bit) // NOLINT
     {
-        const array<uint8_t, 30> source{100, 100, 100, 0, 0, 0, 0, 0, 0,   0,   150, 150,
-                                        150, 0,   0,   0, 0, 0, 0, 0, 200, 200, 200};
+        const array<byte, 30> source{byte{100}, byte{100}, byte{100}, byte{0},   byte{0},   byte{0},   byte{0},  byte{0},
+                                     byte{0},   byte{0},   byte{150}, byte{150}, byte{150}, byte{0},   byte{0},  byte{0},
+                                     byte{0},   byte{0},   byte{0},   byte{0},   byte{200}, byte{200}, byte{200}};
         constexpr frame_info frame_info{3, 1, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source, 10)};
         destination.resize(bytes_written);
 
-        const array<uint8_t, 9> expected{100, 100, 100, 150, 150, 150, 200, 200, 200};
+        const array expected{byte{100}, byte{100}, byte{100}, byte{150}, byte{150},
+                             byte{150}, byte{200}, byte{200}, byte{200}};
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::none);
     }
 
     TEST_METHOD(encode_with_stride_interleave_none_8_bit_small_image) // NOLINT
     {
-        const array<uint8_t, 6> source{100, 99, 0, 0, 101, 98};
+        const array source{byte{100}, byte{99}, byte{0}, byte{0}, byte{101}, byte{98}};
         constexpr frame_info frame_info{2, 2, 8, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source, 4)};
         destination.resize(bytes_written);
 
-        const array<uint8_t, 4> expected{100, 99, 101, 98};
+        const array expected{byte{100}, byte{99}, byte{101}, byte{98}};
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::none);
     }
 
@@ -1041,7 +1045,7 @@ public:
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source, 10 * sizeof(uint16_t))};
@@ -1054,18 +1058,20 @@ public:
 
     TEST_METHOD(encode_with_stride_interleave_sample_8_bit) // NOLINT
     {
-        const array<uint8_t, 10> source{100, 150, 200, 100, 150, 200, 100, 150, 200, 0};
+        const array source{byte{100}, byte{150}, byte{200}, byte{100}, byte{150},
+                           byte{200}, byte{100}, byte{150}, byte{200}, byte{0}};
         constexpr frame_info frame_info{3, 1, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source, 10)};
         destination.resize(bytes_written);
 
-        const array<uint8_t, 9> expected{100, 150, 200, 100, 150, 200, 100, 150, 200};
+        const array expected{byte{100}, byte{150}, byte{200}, byte{100}, byte{150},
+                             byte{200}, byte{100}, byte{150}, byte{200}};
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::sample);
     }
 
@@ -1076,7 +1082,7 @@ public:
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source, 10 * sizeof(uint16_t))};
@@ -1089,13 +1095,14 @@ public:
 
     TEST_METHOD(encode_with_bad_stride_interleave_none_throws) // NOLINT
     {
-        const array<uint8_t, 21> source{100, 100, 100, 0, 0, 0, 0, 0, 0,   0,   150, 150,
-                                        150, 0,   0,   0, 0, 0, 0, 0, 200};
+        const array<byte, 21> source{byte{100}, byte{100}, byte{100}, byte{0},   byte{0},   byte{0},   byte{0},
+                                     byte{0},   byte{0},   byte{0},   byte{150}, byte{150}, byte{150}, byte{0},
+                                     byte{0},   byte{0},   byte{0},   byte{0},   byte{0},   byte{0},   byte{200}};
         constexpr frame_info frame_info{2, 2, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument_stride,
@@ -1104,12 +1111,13 @@ public:
 
     TEST_METHOD(encode_with_bad_stride_interleave_sample_throws) // NOLINT
     {
-        const array<uint8_t, 12> source{100, 150, 200, 100, 150, 200, 100, 150, 200};
+        const array<byte, 12> source{byte{100}, byte{150}, byte{200}, byte{100}, byte{150},
+                                     byte{200}, byte{100}, byte{150}, byte{200}};
         constexpr frame_info frame_info{2, 2, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument_stride,
@@ -1118,13 +1126,14 @@ public:
 
     TEST_METHOD(encode_with_too_small_stride_interleave_none_throws) // NOLINT
     {
-        const array<uint8_t, 21> source{100, 100, 100, 0, 0, 0, 0, 0, 0,   0,   150, 150,
-                                        150, 0,   0,   0, 0, 0, 0, 0, 200};
+        const array source{byte{100}, byte{100}, byte{100}, byte{},    byte{},    byte{},    byte{},
+                           byte{},    byte{},    byte{},    byte{150}, byte{150}, byte{150}, byte{},
+                           byte{},    byte{},    byte{},    byte{},    byte{},    byte{},    byte{200}};
         constexpr frame_info frame_info{2, 1, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument_stride,
@@ -1133,12 +1142,13 @@ public:
 
     TEST_METHOD(encode_with_too_small_stride_interleave_sample_throws) // NOLINT
     {
-        const array<uint8_t, 12> source{100, 150, 200, 100, 150, 200, 100, 150, 200};
+        const array<byte, 12> source{byte{100}, byte{150}, byte{200}, byte{100}, byte{150},
+                                     byte{200}, byte{100}, byte{150}, byte{200}};
         constexpr frame_info frame_info{2, 1, 8, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         assert_expect_exception(jpegls_errc::invalid_argument_stride,
@@ -1147,31 +1157,31 @@ public:
 
     TEST_METHOD(encode_1_component_4_bit_with_high_bits_set) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512, 0xFF);
+        const vector<byte> source(size_t{512} * 512, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 4, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(size_t{512} * 512, 15);
+        const vector<byte> expected(size_t{512} * 512, byte{15});
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::none);
     }
 
     TEST_METHOD(encode_1_component_12_bit_with_high_bits_set) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 2, 0xFF);
+        const vector<byte> source(size_t{512} * 512 * 2, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 12, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1184,49 +1194,49 @@ public:
 
     TEST_METHOD(encode_3_components_6_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 3, 0xFF);
+        const vector source(size_t{512} * 512 * 3, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 6, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(size_t{512} * 512 * 3, 63);
+        const vector expected(size_t{512} * 512 * 3, byte{63});
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::sample);
     }
 
     TEST_METHOD(encode_3_components_6_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 3, 0xFF);
+        const vector source(size_t{512} * 512 * 3, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 6, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::line);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(size_t{512} * 512 * 3, 63);
+        const vector expected(size_t{512} * 512 * 3, byte{63});
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::line);
     }
 
     TEST_METHOD(encode_3_components_10_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 2 * 3, 0xFF);
+        const vector source(size_t{512} * 512 * 2 * 3, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 10, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1238,13 +1248,13 @@ public:
 
     TEST_METHOD(encode_3_components_10_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 2 * 3, 0xFF);
+        const vector source(size_t{512} * 512 * 2 * 3, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 10, 3};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::line);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1256,49 +1266,49 @@ public:
 
     TEST_METHOD(encode_4_components_6_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 4, 0xFF);
+        const vector source(size_t{512} * 512 * 4, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 6, 4};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(size_t{512} * 512 * 4, 63);
+        const vector expected(size_t{512} * 512 * 4, byte{63});
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::sample);
     }
 
     TEST_METHOD(encode_4_components_6_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 4, 0xFF);
+        const vector source(size_t{512} * 512 * 4, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 6, 4};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::line);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
 
-        const vector<uint8_t> expected(size_t{512} * 512 * 4, 63);
+        const vector expected(size_t{512} * 512 * 4, byte{63});
         test_by_decoding(destination, frame_info, expected.data(), expected.size(), interleave_mode::line);
     }
 
     TEST_METHOD(encode_4_components_10_bit_with_high_bits_set_interleave_mode_sample) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 2 * 4, 0xFF);
+        const vector source(size_t{512} * 512 * 2 * 4, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 10, 4};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::sample);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1310,13 +1320,13 @@ public:
 
     TEST_METHOD(encode_4_components_10_bit_with_high_bits_set_interleave_mode_line) // NOLINT
     {
-        const vector<uint8_t> source(size_t{512} * 512 * 2 * 4, 0xFF);
+        const vector source(size_t{512} * 512 * 2 * 4, byte{0xFF});
         constexpr frame_info frame_info{512, 512, 10, 4};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).interleave_mode(interleave_mode::line);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1328,13 +1338,13 @@ public:
 
     TEST_METHOD(rewind) // NOLINT
     {
-        const array<uint8_t, 6> source{0, 1, 2, 3, 4, 5};
+        const array source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
         constexpr frame_info frame_info{3, 1, 16, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written1{encoder.encode(source)};
@@ -1342,7 +1352,7 @@ public:
 
         test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
 
-        const vector<uint8_t> destination_backup(destination);
+        const vector destination_backup(destination);
 
         encoder.rewind();
         const size_t bytes_written2{encoder.encode(source)};
@@ -1353,13 +1363,13 @@ public:
 
     TEST_METHOD(rewind_before_destination) // NOLINT
     {
-        const array<uint8_t, 6> source{0, 1, 2, 3, 4, 5};
+        const array source{byte{0}, byte{1}, byte{2}, byte{3}, byte{4}, byte{5}};
         constexpr frame_info frame_info{3, 1, 16, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.rewind();
         encoder.destination(destination);
 
@@ -1372,7 +1382,7 @@ public:
     TEST_METHOD(encode_image_odd_size) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         const auto destination{jpegls_encoder::encode(source, frame_info)};
 
@@ -1383,7 +1393,7 @@ public:
     TEST_METHOD(encode_image_odd_size_forced_even) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         const auto destination{
             jpegls_encoder::encode(source, frame_info, interleave_mode::none, encoding_options::even_destination_size)};
@@ -1395,7 +1405,7 @@ public:
     TEST_METHOD(encode_image_forced_version_comment) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         const auto encoded_source{
             jpegls_encoder::encode(source, frame_info, interleave_mode::none, encoding_options::include_version_number)};
@@ -1426,7 +1436,7 @@ public:
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         // Note: encoding_options::include_pc_parameters_jai is enabled by default (until the next major version)
 
@@ -1435,33 +1445,33 @@ public:
 
         Assert::AreEqual(size_t{43}, bytes_written);
 
-        Assert::AreEqual(uint8_t{0xFF}, destination[15]);
-        Assert::AreEqual(static_cast<uint8_t>(jpeg_marker_code::jpegls_preset_parameters), destination[16]);
+        Assert::AreEqual(byte{0xFF}, destination[15]);
+        Assert::AreEqual(static_cast<byte>(jpeg_marker_code::jpegls_preset_parameters), destination[16]);
 
         // Segment size.
-        Assert::AreEqual(uint8_t{}, destination[17]);
-        Assert::AreEqual(uint8_t{13}, destination[18]);
+        Assert::AreEqual(byte{}, destination[17]);
+        Assert::AreEqual(byte{13}, destination[18]);
 
         // Parameter ID.
-        Assert::AreEqual(uint8_t{0x1}, destination[19]);
+        Assert::AreEqual(byte{0x1}, destination[19]);
 
         // MaximumSampleValue
-        Assert::AreEqual(uint8_t{255}, destination[20]);
-        Assert::AreEqual(uint8_t{255}, destination[21]);
+        Assert::AreEqual(byte{255}, destination[20]);
+        Assert::AreEqual(byte{255}, destination[21]);
 
         constexpr thresholds expected{
             compute_defaults_using_reference_implementation(std::numeric_limits<uint16_t>::max(), 0)};
 
-        const int32_t threshold1{destination[22] << 8 | destination[23]};
+        const int32_t threshold1{to_integer<int32_t>(destination[22]) << 8 | to_integer<int32_t>(destination[23])};
         Assert::AreEqual(expected.t1, threshold1);
 
-        const int32_t threshold2{destination[24] << 8 | destination[25]};
+        const int32_t threshold2{to_integer<int32_t>(destination[24]) << 8 | to_integer<int32_t>(destination[25])};
         Assert::AreEqual(expected.t2, threshold2);
 
-        const int32_t threshold3{destination[26] << 8 | destination[27]};
+        const int32_t threshold3{to_integer<int32_t>(destination[26]) << 8 | to_integer<int32_t>(destination[27])};
         Assert::AreEqual(expected.t3, threshold3);
 
-        const int32_t reset{destination[28] << 8 | destination[29]};
+        const int32_t reset{to_integer<int32_t>(destination[28] << 8) | to_integer<int32_t>(destination[29])};
         Assert::AreEqual(expected.reset, reset);
     }
 
@@ -1473,7 +1483,7 @@ public:
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
         encoder.encoding_options(encoding_options::none);
 
@@ -1498,7 +1508,7 @@ public:
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1512,7 +1522,7 @@ public:
     TEST_METHOD(encode_oversized_image) // NOLINT
     {
         constexpr frame_info frame_info{numeric_limits<uint16_t>::max() + 1, 1, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         const auto encoded_source{jpegls_encoder::encode(source, frame_info)};
 
@@ -1522,12 +1532,12 @@ public:
     TEST_METHOD(image_contains_no_preset_coding_parameters_by_default) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1541,12 +1551,12 @@ public:
     TEST_METHOD(image_contains_no_preset_coding_parameters_if_configured_pc_is_default) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).preset_coding_parameters({255, 3, 7, 21, 64});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1560,12 +1570,12 @@ public:
     TEST_METHOD(image_contains_preset_coding_parameters_if_configured_pc_is_non_default) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).preset_coding_parameters({255, 3, 7, 21, 65});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1579,12 +1589,12 @@ public:
     TEST_METHOD(image_contains_preset_coding_parameters_if_configured_pc_has_diff_max_value) // NOLINT
     {
         constexpr frame_info frame_info{512, 512, 8, 1};
-        const vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        const vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info).preset_coding_parameters({100, 0, 0, 0, 0});
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1603,13 +1613,13 @@ public:
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
 
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
 
         void* data1{destination.data()};
         const auto size1{static_cast<uint16_t>(destination.size())};
         encoder.destination(data1, size1);
 
-        vector<uint8_t> source(static_cast<size_t>(frame_info.width) * frame_info.height);
+        vector<byte> source(static_cast<size_t>(frame_info.width) * frame_info.height);
         void* data2{source.data()};
         const auto size2{static_cast<uint16_t>(source.size())};
 
@@ -1622,7 +1632,7 @@ public:
     }
 
 private:
-    static void test_by_decoding(const vector<uint8_t>& encoded_source, const frame_info& source_frame_info,
+    static void test_by_decoding(const vector<byte>& encoded_source, const frame_info& source_frame_info,
                                  const void* expected_destination, const size_t expected_destination_size,
                                  const charls::interleave_mode interleave_mode,
                                  const color_transformation color_transformation = color_transformation::none)
@@ -1639,14 +1649,14 @@ private:
         Assert::IsTrue(interleave_mode == decoder.interleave_mode());
         Assert::IsTrue(color_transformation == decoder.color_transformation());
 
-        vector<uint8_t> destination(decoder.destination_size());
+        vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
         Assert::AreEqual(destination.size(), expected_destination_size);
 
         if (decoder.near_lossless() == 0)
         {
-            const auto* expected_destination_byte{static_cast<const uint8_t*>(expected_destination)};
+            const auto* expected_destination_byte{static_cast<const byte*>(expected_destination)};
 
             for (size_t i{}; i != expected_destination_size; ++i)
             {
@@ -1660,12 +1670,12 @@ private:
 
     static void encode_with_custom_preset_coding_parameters(const jpegls_pc_parameters& pc_parameters)
     {
-        const array<uint8_t, 5> source{0, 1, 1, 1, 0};
+        const array source{byte{0}, byte{1}, byte{1}, byte{1}, byte{0}};
         constexpr frame_info frame_info{5, 1, 8, 1};
 
         jpegls_encoder encoder;
         encoder.frame_info(frame_info);
-        vector<uint8_t> destination(encoder.estimated_destination_size());
+        vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
         encoder.preset_coding_parameters(pc_parameters);
@@ -1676,14 +1686,14 @@ private:
         test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none);
     }
 
-    static vector<uint8_t>::const_iterator find_first_lse_segment(const vector<uint8_t>::const_iterator begin,
-                                                                  const vector<uint8_t>::const_iterator end) noexcept
+    static vector<byte>::const_iterator find_first_lse_segment(const vector<byte>::const_iterator begin,
+                                                               const vector<byte>::const_iterator end) noexcept
     {
-        constexpr uint8_t lse_marker{0xF8};
+        constexpr byte lse_marker{0xF8};
 
         for (auto it{begin}; it != end; ++it)
         {
-            if (*it == 0xFF && it + 1 != end && *(it + 1) == lse_marker)
+            if (*it == byte{0xFF} && it + 1 != end && *(it + 1) == lse_marker)
                 return it;
         }
 

--- a/unittest/util.cpp
+++ b/unittest/util.cpp
@@ -14,6 +14,7 @@
 #include <random>
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
+using std::byte;
 using std::ifstream;
 using std::ios;
 using std::mt19937;
@@ -25,9 +26,9 @@ namespace charls::test {
 
 namespace {
 
-void triplet_to_planar(vector<uint8_t>& buffer, const uint32_t width, const uint32_t height)
+void triplet_to_planar(vector<byte>& buffer, const uint32_t width, const uint32_t height)
 {
-    vector<uint8_t> work_buffer(buffer.size());
+    vector<byte> work_buffer(buffer.size());
 
     const size_t byte_count{static_cast<size_t>(width) * height};
     for (size_t index{}; index != byte_count; index++)
@@ -42,7 +43,7 @@ void triplet_to_planar(vector<uint8_t>& buffer, const uint32_t width, const uint
 } // namespace
 
 
-vector<uint8_t> read_file(const char* filename)
+vector<byte> read_file(const char* filename)
 {
     ifstream input;
     input.exceptions(ios::eofbit | ios::failbit | ios::badbit);
@@ -52,7 +53,7 @@ vector<uint8_t> read_file(const char* filename)
     const auto byte_count_file{static_cast<size_t>(input.tellg())};
     input.seekg(0, ios::beg);
 
-    vector<uint8_t> buffer(byte_count_file);
+    vector<byte> buffer(byte_count_file);
     input.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
 
     return buffer;
@@ -83,60 +84,60 @@ portable_anymap_file read_anymap_reference_file(const char* filename, const inte
     return reference_file;
 }
 
-vector<uint8_t> create_test_spiff_header(const uint8_t high_version, const uint8_t low_version, const bool end_of_directory,
-                                         const uint8_t component_count)
+vector<byte> create_test_spiff_header(const uint8_t high_version, const uint8_t low_version, const bool end_of_directory,
+                                      const uint8_t component_count)
 {
-    vector<uint8_t> buffer;
-    buffer.push_back(0xFF);
-    buffer.push_back(0xD8); // SOI.
-    buffer.push_back(0xFF);
-    buffer.push_back(0xE8); // ApplicationData8
-    buffer.push_back(0);
-    buffer.push_back(32);
+    vector<byte> buffer;
+    buffer.push_back(byte{0xFF});
+    buffer.push_back(byte{0xD8}); // SOI.
+    buffer.push_back(byte{0xFF});
+    buffer.push_back(byte{0xE8}); // ApplicationData8
+    buffer.push_back({});
+    buffer.push_back(byte{32});
 
     // SPIFF identifier string.
-    buffer.push_back('S');
-    buffer.push_back('P');
-    buffer.push_back('I');
-    buffer.push_back('F');
-    buffer.push_back('F');
-    buffer.push_back(0);
+    buffer.push_back(byte{'S'});
+    buffer.push_back(byte{'P'});
+    buffer.push_back(byte{'I'});
+    buffer.push_back(byte{'F'});
+    buffer.push_back(byte{'F'});
+    buffer.push_back({});
 
     // Version
-    buffer.push_back(high_version);
-    buffer.push_back(low_version);
+    buffer.push_back(byte{high_version});
+    buffer.push_back(byte{low_version});
 
-    buffer.push_back(0); // profile id
-    buffer.push_back(component_count);
+    buffer.push_back({}); // profile id
+    buffer.push_back(byte{component_count});
 
     // Height
-    buffer.push_back(0);
-    buffer.push_back(0);
-    buffer.push_back(0x3);
-    buffer.push_back(0x20);
+    buffer.push_back({});
+    buffer.push_back({});
+    buffer.push_back(byte{0x3});
+    buffer.push_back(byte{0x20});
 
     // Width
-    buffer.push_back(0);
-    buffer.push_back(0);
-    buffer.push_back(0x2);
-    buffer.push_back(0x58);
+    buffer.push_back({});
+    buffer.push_back({});
+    buffer.push_back(byte{0x2});
+    buffer.push_back(byte{0x58});
 
-    buffer.push_back(10); // color space
-    buffer.push_back(8);  // bits per sample
-    buffer.push_back(6);  // compression type, 6 = JPEG-LS
-    buffer.push_back(1);  // resolution units
+    buffer.push_back(byte{10}); // color space
+    buffer.push_back(byte{8});  // bits per sample
+    buffer.push_back(byte{6});  // compression type, 6 = JPEG-LS
+    buffer.push_back(byte{1});  // resolution units
 
     // vertical_resolution
-    buffer.push_back(0);
-    buffer.push_back(0);
-    buffer.push_back(0);
-    buffer.push_back(96);
+    buffer.push_back({});
+    buffer.push_back({});
+    buffer.push_back({});
+    buffer.push_back(byte{96});
 
     // header.horizontal_resolution = 1024
-    buffer.push_back(0);
-    buffer.push_back(0);
-    buffer.push_back(4);
-    buffer.push_back(0);
+    buffer.push_back({});
+    buffer.push_back({});
+    buffer.push_back(byte{4});
+    buffer.push_back({});
 
     const size_t spiff_header_size{buffer.size()};
     buffer.resize(buffer.size() + 100);
@@ -154,7 +155,7 @@ vector<uint8_t> create_test_spiff_header(const uint8_t high_version, const uint8
     return buffer;
 }
 
-vector<uint8_t> create_noise_image_16_bit(const size_t pixel_count, const int bit_count, const uint32_t seed)
+vector<byte> create_noise_image_16_bit(const size_t pixel_count, const int bit_count, const uint32_t seed)
 {
     const auto max_value{static_cast<uint16_t>((1U << bit_count) - 1U)};
     mt19937 generator(seed);
@@ -162,28 +163,28 @@ vector<uint8_t> create_noise_image_16_bit(const size_t pixel_count, const int bi
     MSVC_WARNING_SUPPRESS_NEXT_LINE(26496) // cannot be marked as const as operator() is not always defined const.
     uniform_int_distribution<uint16_t> distribution(0, max_value);
 
-    vector<uint8_t> buffer(pixel_count * 2);
+    vector<byte> buffer(pixel_count * 2);
     for (size_t i{}; i != pixel_count; i = i + 2)
     {
         const uint16_t value{distribution(generator)};
 
-        buffer[i] = static_cast<uint8_t>(value);
-        buffer[i] = static_cast<uint8_t>(value >> 8);
+        buffer[i] = static_cast<byte>(value);
+        buffer[i] = static_cast<byte>(value >> 8);
     }
     return buffer;
 }
 
-bool verify_encoded_bytes(const vector<uint8_t>& uncompressed_source, const vector<uint8_t>& encoded_source)
+bool verify_encoded_bytes(const vector<byte>& uncompressed_source, const vector<byte>& encoded_source)
 {
     const jpegls_decoder decoder{encoded_source, true};
 
     jpegls_encoder encoder;
     encoder.frame_info(decoder.frame_info())
-           .interleave_mode(decoder.interleave_mode())
-           .near_lossless(decoder.near_lossless())
-           .preset_coding_parameters(decoder.preset_coding_parameters());
+        .interleave_mode(decoder.interleave_mode())
+        .near_lossless(decoder.near_lossless())
+        .preset_coding_parameters(decoder.preset_coding_parameters());
 
-    vector<uint8_t> our_encoded_bytes(encoded_source.size() + 16);
+    vector<byte> our_encoded_bytes(encoded_source.size() + 16);
     encoder.destination(our_encoded_bytes);
 
     const size_t bytes_written{encoder.encode(uncompressed_source)};
@@ -202,7 +203,7 @@ bool verify_encoded_bytes(const vector<uint8_t>& uncompressed_source, const vect
 }
 
 void verify_decoded_bytes(const interleave_mode interleave_mode, const frame_info& frame_info,
-                          const vector<uint8_t>& uncompressed_data, const size_t destination_stride,
+                          const vector<std::byte>& uncompressed_data, const size_t destination_stride,
                           const char* reference_filename)
 {
     const auto anymap_reference{read_anymap_reference_file(reference_filename, interleave_mode, frame_info)};
@@ -212,7 +213,7 @@ void verify_decoded_bytes(const interleave_mode interleave_mode, const frame_inf
     const int components_in_plane_count{interleave_mode == interleave_mode::none ? 1 : frame_info.component_count};
 
     const size_t source_stride{static_cast<size_t>(frame_info.width) * components_in_plane_count};
-    const uint8_t* sample{uncompressed_data.data()};
+    const byte* sample{uncompressed_data.data()};
     size_t reference_sample{};
     for (int plane{}; plane < plane_count; ++plane)
     {
@@ -232,8 +233,7 @@ void verify_decoded_bytes(const interleave_mode interleave_mode, const frame_inf
     }
 }
 
-void test_compliance(const vector<uint8_t>& encoded_source, const vector<uint8_t>& uncompressed_source,
-                     const bool check_encode)
+void test_compliance(const vector<byte>& encoded_source, const vector<byte>& uncompressed_source, const bool check_encode)
 {
     const jpegls_decoder decoder{encoded_source, true};
 
@@ -242,7 +242,7 @@ void test_compliance(const vector<uint8_t>& encoded_source, const vector<uint8_t
         Assert::IsTrue(verify_encoded_bytes(uncompressed_source, encoded_source));
     }
 
-    vector<uint8_t> destination(decoder.destination_size());
+    vector<byte> destination(decoder.destination_size());
     decoder.decode(destination);
 
     if (decoder.near_lossless() == 0)
@@ -264,7 +264,7 @@ void test_compliance(const vector<uint8_t>& encoded_source, const vector<uint8_t
         {
             for (size_t i{}; i != uncompressed_source.size(); ++i)
             {
-                if (abs(uncompressed_source[i] - destination[i]) >
+                if (abs(static_cast<int>(uncompressed_source[i]) - static_cast<int>(destination[i])) >
                     near_lossless) // AreEqual is very slow, pre-test to speed up 50X
                 {
                     Assert::AreEqual(uncompressed_source[i], destination[i]);

--- a/unittest/util.h
+++ b/unittest/util.h
@@ -14,19 +14,19 @@
 
 namespace charls::test {
 
-std::vector<uint8_t> read_file(const char* filename);
+std::vector<std::byte> read_file(const char* filename);
 
 charls_test::portable_anymap_file read_anymap_reference_file(const char* filename, interleave_mode interleave_mode,
                                                              const frame_info& frame_info);
 charls_test::portable_anymap_file read_anymap_reference_file(const char* filename, interleave_mode interleave_mode);
-std::vector<uint8_t> create_test_spiff_header(uint8_t high_version = 2, uint8_t low_version = 0,
-                                              bool end_of_directory = true, uint8_t component_count = 3);
-std::vector<uint8_t> create_noise_image_16_bit(size_t pixel_count, int bit_count, uint32_t seed);
-bool verify_encoded_bytes(const std::vector<uint8_t>& uncompressed_source, const std::vector<uint8_t>& encoded_source);
+std::vector<std::byte> create_test_spiff_header(uint8_t high_version = 2, uint8_t low_version = 0,
+                                                bool end_of_directory = true, uint8_t component_count = 3);
+std::vector<std::byte> create_noise_image_16_bit(size_t pixel_count, int bit_count, uint32_t seed);
+bool verify_encoded_bytes(const std::vector<std::byte>& uncompressed_source, const std::vector<std::byte>& encoded_source);
 void verify_decoded_bytes(interleave_mode interleave_mode, const frame_info& frame_info,
-                          const std::vector<uint8_t>& uncompressed_data, size_t destination_stride,
+                          const std::vector<std::byte>& uncompressed_data, size_t destination_stride,
                           const char* reference_filename);
-void test_compliance(const std::vector<uint8_t>& encoded_source, const std::vector<uint8_t>& uncompressed_source,
+void test_compliance(const std::vector<std::byte>& encoded_source, const std::vector<std::byte>& uncompressed_source,
                      bool check_encode);
 
 
@@ -73,6 +73,12 @@ Microsoft::VisualStudio::CppUnitTestFramework::ToString<charls::jpegls_errc>(con
 template<>
 inline std::wstring
 Microsoft::VisualStudio::CppUnitTestFramework::ToString<charls::interleave_mode>(const charls::interleave_mode& q)
+{
+    RETURN_WIDE_STRING(static_cast<int>(q));
+}
+
+template<>
+inline std::wstring Microsoft::VisualStudio::CppUnitTestFramework::ToString<std::byte>(const std::byte& q)
 {
     RETURN_WIDE_STRING(static_cast<int>(q));
 }


### PR DESCRIPTION
C++17 introduced std::byte. Use it to replace uint8_t that was used as C++14 was lacking a byte type.