### PR TITLE
Use std::byte as type to define source/destination buffers

### DIFF
--- a/src/byte_span.h
+++ b/src/byte_span.h
@@ -4,48 +4,51 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 
 namespace charls {
 
-/// <summary>Simplified span class as replacement for C++20 (std::span<std::byte>).</summary>
+/// <summary>Simplified span class as replacement for C++20 std::span<std::byte>.</summary>
 struct byte_span final
 {
+    using iterator = const std::byte*;
+
     byte_span() = default;
 
-    constexpr byte_span(void* data_arg, const size_t size_arg) noexcept : data{static_cast<uint8_t*>(data_arg)}, size{size_arg}
+    constexpr byte_span(void* data_arg, const size_t size_arg) noexcept :
+        data{static_cast<std::byte*>(data_arg)}, size{size_arg}
     {
     }
 
     constexpr byte_span(const void* data_arg, const size_t size_arg) noexcept :
-        data{static_cast<uint8_t*>(const_cast<void*>(data_arg))}, size{size_arg}
+        data{static_cast<std::byte*>(const_cast<void*>(data_arg))}, size{size_arg}
     {
     }
 
-    [[nodiscard]] constexpr uint8_t* begin() const noexcept
+    [[nodiscard]] constexpr iterator begin() const noexcept
     {
         return data;
     }
 
-    [[nodiscard]] constexpr uint8_t* end() const noexcept
+    [[nodiscard]] constexpr iterator end() const noexcept
     {
         return data + size;
     }
 
-    uint8_t* data{};
+    std::byte* data{};
     size_t size{};
 };
 
 
-/// <summary>Simplified span class as replacement for C++20 (std::span<const std::byte>).</summary>
+/// <summary>Simplified span class as replacement for C++20 std::span<const std::byte>.</summary>
 class const_byte_span final
 {
 public:
-    using iterator = const uint8_t*;
+    using iterator = const std::byte*;
 
     const_byte_span() = default;
 
-    constexpr const_byte_span(const void* data, const size_t size) noexcept : data_{static_cast<const uint8_t*>(data)}, size_{size}
+    constexpr const_byte_span(const void* data, const size_t size) noexcept :
+        data_{static_cast<const std::byte*>(data)}, size_{size}
     {
     }
 
@@ -59,7 +62,7 @@ public:
         return size_;
     }
 
-    [[nodiscard]] constexpr const uint8_t* data() const noexcept
+    [[nodiscard]] constexpr const std::byte* data() const noexcept
     {
         return data_;
     }
@@ -80,7 +83,7 @@ public:
     }
 
 private:
-    const uint8_t* data_{};
+    const std::byte* data_{};
     size_t size_{};
 };
 

--- a/src/encoder_strategy.h
+++ b/src/encoder_strategy.h
@@ -106,13 +106,13 @@ protected:
             if (is_ff_written_)
             {
                 // JPEG-LS requirement (T.87, A.1) to detect markers: after a xFF value a single 0 bit needs to be inserted.
-                *position_ = static_cast<uint8_t>(bit_buffer_ >> 25);
+                *position_ = static_cast<std::byte>(bit_buffer_ >> 25);
                 bit_buffer_ = bit_buffer_ << 7;
                 free_bit_count_ += 7;
             }
             else
             {
-                *position_ = static_cast<uint8_t>(bit_buffer_ >> 24);
+                *position_ = static_cast<std::byte>(bit_buffer_ >> 24);
                 bit_buffer_ = bit_buffer_ << 8;
                 free_bit_count_ += 8;
             }
@@ -145,7 +145,7 @@ private:
     size_t compressed_length_{};
 
     // encoding
-    uint8_t* position_{};
+    std::byte* position_{};
     bool is_ff_written_{};
     size_t bytes_written_{};
 };

--- a/src/jpeg_marker_code.h
+++ b/src/jpeg_marker_code.h
@@ -15,7 +15,7 @@ namespace charls {
 // 0xF9         is defined in ISO/IEC 14495-2 | ITU T.870: JPEG LS extensions
 // 0x4F - 0x6F, 0x90 - 0x93 are defined in ISO/IEC 15444-1: JPEG 2000
 
-constexpr uint8_t jpeg_marker_start_byte{0xFF};
+constexpr std::byte jpeg_marker_start_byte{0xFF};
 constexpr uint8_t jpeg_restart_marker_base{0xD0}; // RSTm: Marks the next restart interval (range is D0..D7)
 constexpr uint32_t jpeg_restart_marker_range{8};
 

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -66,15 +66,15 @@ private:
         position_ += count;
     }
 
-    [[nodiscard]] uint8_t read_byte_checked();
+    [[nodiscard]] std::byte read_byte_checked();
     [[nodiscard]] uint16_t read_uint16_checked();
 
-    [[nodiscard]] uint8_t read_byte() noexcept;
+    [[nodiscard]] std::byte read_byte() noexcept;
     void skip_byte() noexcept;
 
     [[nodiscard]] uint8_t read_uint8() noexcept
     {
-        return read_byte();
+        return std::to_integer<uint8_t>(read_byte());
     }
 
     [[nodiscard]] uint16_t read_uint16() noexcept;

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -31,7 +31,7 @@ void jpeg_stream_writer::write_end_of_image(const bool even_destination_size)
     if (even_destination_size && bytes_written() % 2 != 0)
     {
         // Write an additional 0xFF byte to ensure that the encoded bit stream has an even size.
-        write_uint8(jpeg_marker_start_byte);
+        write_byte(jpeg_marker_start_byte);
     }
 
     write_segment_without_data(jpeg_marker_code::end_of_image);

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -8,8 +8,6 @@
 #include "jpeg_marker_code.h"
 #include "util.h"
 
-#include <limits>
-
 namespace charls {
 
 // Purpose: 'Writer' class that can generate JPEG-LS file streams.
@@ -126,20 +124,19 @@ private:
 
     void write_uint8(const uint8_t value) noexcept
     {
-        ASSERT(byte_offset_ + sizeof(uint8_t) <= destination_.size);
-        destination_.data[byte_offset_++] = value;
+        write_byte(static_cast<std::byte>(value));
     }
 
     void write_uint8(const int32_t value) noexcept
     {
         ASSERT(value >= 0 && value <= std::numeric_limits<uint8_t>::max());
-        write_uint8(static_cast<uint8_t>(value));
+        write_byte(static_cast<std::byte>(value));
     }
 
     void write_uint8(const size_t value) noexcept
     {
         ASSERT(value <= std::numeric_limits<uint8_t>::max());
-        write_uint8(static_cast<uint8_t>(value));
+        write_byte(static_cast<std::byte>(value));
     }
 
     void write_uint16(const uint16_t value) noexcept
@@ -179,6 +176,12 @@ private:
         write_bytes(&big_endian_value, sizeof big_endian_value);
     }
 
+    void write_byte(const std::byte value) noexcept
+    {
+        ASSERT(byte_offset_ + sizeof(std::byte) <= destination_.size);
+        destination_.data[byte_offset_++] = value;
+    }
+
     void write_bytes(const const_byte_span data) noexcept
     {
         write_bytes(data.data(), data.size());
@@ -193,8 +196,8 @@ private:
 
     void write_marker(const jpeg_marker_code marker_code) noexcept
     {
-        write_uint8(jpeg_marker_start_byte);
-        write_uint8(static_cast<uint8_t>(marker_code));
+        write_byte(jpeg_marker_start_byte);
+        write_byte(static_cast<std::byte>(marker_code));
     }
 
     void write_segment_without_data(const jpeg_marker_code marker_code)
@@ -202,8 +205,8 @@ private:
         if (UNLIKELY(byte_offset_ + 2 > destination_.size))
             impl::throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
 
-        write_uint8(jpeg_marker_start_byte);
-        write_uint8(static_cast<uint8_t>(marker_code));
+        write_byte(jpeg_marker_start_byte);
+        write_byte(static_cast<std::byte>(marker_code));
     }
 
     byte_span destination_{};

--- a/src/scan.h
+++ b/src/scan.h
@@ -602,17 +602,17 @@ private:
 
     void read_restart_marker()
     {
-        auto byte{Strategy::read_byte()};
-        if (UNLIKELY(byte != jpeg_marker_start_byte))
+        auto value{Strategy::read_byte()};
+        if (UNLIKELY(value != jpeg_marker_start_byte))
             impl::throw_jpegls_error(jpegls_errc::restart_marker_not_found);
 
         // Read all preceding 0xFF fill values until a non 0xFF value has been found. (see T.81, B.1.1.2)
         do
         {
-            byte = Strategy::read_byte();
-        } while (byte == jpeg_marker_start_byte);
+            value = Strategy::read_byte();
+        } while (value == jpeg_marker_start_byte);
 
-        if (UNLIKELY(byte != jpeg_restart_marker_base + restart_interval_counter_))
+        if (UNLIKELY(std::to_integer<uint32_t>(value) != jpeg_restart_marker_base + restart_interval_counter_))
             impl::throw_jpegls_error(jpegls_errc::restart_marker_not_found);
     }
 


### PR DESCRIPTION
C++17 introduced std::byte. Use this type to define the buffers. In many cases continue to use uint8_t as often bytes values should be processed integers and not as a collection of 8 bits.