### PR TITLE
Remove redundant qualifiers

### DIFF
--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -242,7 +242,7 @@ public:
     /// <returns>Frame info of the decoded image and the interleave mode.</returns>
     template<typename SourceContainer, typename DestinationContainer, typename T1 = typename SourceContainer::value_type,
              typename T2 = typename DestinationContainer::value_type>
-    static std::pair<charls::frame_info, charls::interleave_mode>
+    static std::pair<frame_info, interleave_mode>
     decode(const SourceContainer& source, DestinationContainer& destination,
            const size_t maximum_size_in_bytes = size_t{7680} * 4320 * 3)
     {

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -290,9 +290,9 @@ public:
     /// <exception cref="std::bad_alloc">Thrown when memory for the encoder could not be allocated.</exception>
     /// <returns>Container with the JPEG-LS encoded bytes.</returns>
     template<typename Container, typename T = typename Container::value_type>
-    static Container encode(const Container& source, const charls::frame_info& frame,
-                            const charls::interleave_mode interleave_mode = charls::interleave_mode::none,
-                            const encoding_options options = charls::encoding_options::none)
+    static Container encode(const Container& source, const frame_info& frame,
+                            const interleave_mode interleave_mode = interleave_mode::none,
+                            const encoding_options options = encoding_options::none)
     {
         jpegls_encoder encoder;
         encoder.frame_info(frame).interleave_mode(interleave_mode).encoding_options(options);

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -91,14 +91,14 @@ struct charls_jpegls_decoder final
 
         switch (interleave_mode())
         {
-        case charls::interleave_mode::none: {
+        case interleave_mode::none: {
             const size_t minimum_stride{static_cast<size_t>(width) * bit_to_byte_count(bits_per_sample)};
             check_argument(stride >= minimum_stride, jpegls_errc::invalid_argument_stride);
             return checked_mul(checked_mul(stride, component_count), height) - (stride - minimum_stride);
         }
 
-        case charls::interleave_mode::line:
-        case charls::interleave_mode::sample: {
+        case interleave_mode::line:
+        case interleave_mode::sample: {
             const size_t minimum_stride{static_cast<size_t>(width) * component_count *
                                         bit_to_byte_count(bits_per_sample)};
             check_argument(stride >= minimum_stride, jpegls_errc::invalid_argument_stride);

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -48,7 +48,7 @@ struct charls_jpegls_encoder final
         frame_info_ = frame_info;
     }
 
-    void interleave_mode(const charls::interleave_mode interleave_mode)
+    void interleave_mode(const interleave_mode interleave_mode)
     {
         check_interleave_mode(interleave_mode, jpegls_errc::invalid_argument_interleave_mode);
 
@@ -63,7 +63,7 @@ struct charls_jpegls_encoder final
         near_lossless_ = near_lossless;
     }
 
-    void encoding_options(const charls::encoding_options encoding_options)
+    void encoding_options(const encoding_options encoding_options)
     {
         constexpr charls::encoding_options all_options = encoding_options::even_destination_size |
                                                          encoding_options::include_version_number |
@@ -80,10 +80,10 @@ struct charls_jpegls_encoder final
         user_preset_coding_parameters_ = preset_coding_parameters;
     }
 
-    void color_transformation(const charls::color_transformation color_transformation)
+    void color_transformation(const color_transformation color_transformation)
     {
-        check_argument(color_transformation >= charls::color_transformation::none &&
-                           color_transformation <= charls::color_transformation::hp3,
+        check_argument(color_transformation >= color_transformation::none &&
+                           color_transformation <= color_transformation::hp3,
                        jpegls_errc::invalid_argument_color_transformation);
 
         color_transformation_ = color_transformation;
@@ -178,7 +178,7 @@ struct charls_jpegls_encoder final
 
         transition_to_tables_and_miscellaneous_state();
 
-        if (color_transformation_ != charls::color_transformation::none)
+        if (color_transformation_ != color_transformation::none)
         {
             if (UNLIKELY(frame_info_.bits_per_sample != 8 && frame_info_.bits_per_sample != 16))
                 throw_jpegls_error(jpegls_errc::bit_depth_for_transform_not_supported);
@@ -200,7 +200,7 @@ struct charls_jpegls_encoder final
             writer_.write_jpegls_preset_parameters_segment(preset_coding_parameters_);
         }
 
-        if (interleave_mode_ == charls::interleave_mode::none)
+        if (interleave_mode_ == interleave_mode::none)
         {
             const size_t byte_count_component{stride * frame_info_.height};
             const int32_t last_component{frame_info_.component_count - 1};
@@ -272,7 +272,7 @@ private:
     [[nodiscard]] size_t calculate_stride() const noexcept
     {
         const auto stride{static_cast<size_t>(frame_info_.width) * bit_to_byte_count(frame_info_.bits_per_sample)};
-        if (interleave_mode_ == charls::interleave_mode::none)
+        if (interleave_mode_ == interleave_mode::none)
             return stride;
 
         return stride * frame_info_.component_count;
@@ -286,7 +286,7 @@ private:
 
         // Simple check to verify user input, and prevent out-of-bound read access.
         // Stride parameter defines the number of bytes on a scan line.
-        if (interleave_mode_ == charls::interleave_mode::none)
+        if (interleave_mode_ == interleave_mode::none)
         {
             if (const size_t minimum_source_size{stride * frame_info_.component_count * frame_info_.height -
                                                  (stride - minimum_stride)};

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -78,7 +78,7 @@ void jpeg_stream_writer::write_spiff_end_of_directory_entry()
     // but only 6 data bytes. This approach allows to wrap existing bit streams\encoders with a SPIFF header.
     // In this implementation the SOI marker is added as data bytes to simplify the design.
     static constexpr array<uint8_t, 6> spiff_end_of_directory{
-        {0, 0, 0, spiff_end_of_directory_entry_type, 0xFF, to_underlying_type(charls::jpeg_marker_code::start_of_image)}};
+        {0, 0, 0, spiff_end_of_directory_entry_type, 0xFF, to_underlying_type(jpeg_marker_code::start_of_image)}};
 
     write_segment_header(jpeg_marker_code::application_data8, spiff_end_of_directory.size());
     write_bytes(spiff_end_of_directory.data(), spiff_end_of_directory.size());

--- a/src/jpegls.cpp
+++ b/src/jpegls.cpp
@@ -64,7 +64,7 @@ vector<int8_t> create_quantize_lut_lossless(const int32_t bit_count)
 template<typename Strategy, typename Traits>
 unique_ptr<Strategy> make_codec(const Traits& traits, const frame_info& frame_info, const coding_parameters& parameters)
 {
-    return make_unique<charls::jls_codec<Traits, Strategy>>(traits, frame_info, parameters);
+    return make_unique<jls_codec<Traits, Strategy>>(traits, frame_info, parameters);
 }
 
 // Functions to build tables used to decode short Golomb codes.

--- a/src/util.h
+++ b/src/util.h
@@ -373,7 +373,7 @@ inline void check_argument(const bool expression, const jpegls_errc error_value 
 }
 
 
-inline void check_interleave_mode(const charls::interleave_mode mode, const jpegls_errc error_value)
+inline void check_interleave_mode(const interleave_mode mode, const jpegls_errc error_value)
 {
     if (UNLIKELY(!(mode == interleave_mode::none || mode == interleave_mode::line || mode == interleave_mode::sample)))
         impl::throw_jpegls_error(error_value);

--- a/src/validate_spiff_header.cpp
+++ b/src/validate_spiff_header.cpp
@@ -53,7 +53,7 @@ bool is_valid_resolution_units(const spiff_resolution_units resolution_units) no
     return false;
 }
 
-bool is_valid_spiff_header(const spiff_header& header, const charls::frame_info& frame_info) noexcept
+bool is_valid_spiff_header(const spiff_header& header, const frame_info& frame_info) noexcept
 {
     if (header.compression_type != spiff_compression_type::jpeg_ls)
         return false;


### PR DESCRIPTION
Older compilers required additional qualifiers. With the C++ upgrade these are not longer needed.