### PR TITLE
Compute the Golomb decoding_tables at compile time.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@
 # -hicpp-signed-bitwise => Rationale: Bad test, types are checked, not values.
 # -clang-diagnostic-c++98-compat* => Rationale: CharLS targets C++17
 # -clang-diagnostic-c++98-c++11-compat => Rationale: CharLS targets C++17
+# -clang-diagnostic-pre-c++14-compat => Rationale: CharLS targets C++17
 # -clang-diagnostic-pre-c++17-compat => Rationale: CharLS targets C++17
 # -clang-diagnostic-unused-macros => Rationale: Macros defined in header are reported as problem
 # -clang-diagnostic-sign-conversion => Rationale: warning will be enabled in additional steps
@@ -65,6 +66,7 @@ Checks:          '*,
                   -hicpp-named-parameter,
                   -clang-diagnostic-c++98-compat*,
                   -clang-diagnostic-c++98-c++11-compat,
+                  -clang-diagnostic-pre-c++14-compat,
                   -clang-diagnostic-pre-c++17-compat,
                   -clang-diagnostic-unused-macros,
                   -clang-diagnostic-sign-conversion,

--- a/src/conditional_static_cast.h
+++ b/src/conditional_static_cast.h
@@ -11,13 +11,13 @@
 namespace charls {
 
 template<typename T, typename U, std::enable_if_t<!std::is_same_v<T, U>, int> = 0>
-T conditional_static_cast(U value) noexcept
+constexpr T conditional_static_cast(U value) noexcept
 {
     return static_cast<T>(value);
 }
 
 template<typename T, typename U, std::enable_if_t<std::is_same_v<T, U>, int> = 0>
-T conditional_static_cast(U value) noexcept
+constexpr T conditional_static_cast(U value) noexcept
 {
     return value;
 }

--- a/src/jpegls.cpp
+++ b/src/jpegls.cpp
@@ -69,37 +69,37 @@ unique_ptr<Strategy> make_codec(const Traits& traits, const frame_info& frame_in
 
 // Functions to build tables used to decode short Golomb codes.
 
-std::pair<int32_t, int32_t> create_encoded_value(const int32_t k, const int32_t mapped_error) noexcept
+constexpr std::pair<int32_t, int32_t> create_encoded_value(const int32_t k, const int32_t mapped_error) noexcept
 {
     const int32_t high_bits{mapped_error >> k};
     return std::make_pair(high_bits + k + 1, (1 << k) | (mapped_error & ((1 << k) - 1)));
 }
 
-golomb_code_table initialize_table(const int32_t k) noexcept
+constexpr golomb_code_table initialize_table(const int32_t k) noexcept
 {
     golomb_code_table table;
     for (int16_t error_value{};; ++error_value)
     {
         // Q is not used when k != 0
         const int32_t mapped_error_value{map_error_value(error_value)};
-        const std::pair<int32_t, int32_t> pair_code{create_encoded_value(k, mapped_error_value)};
-        if (static_cast<size_t>(pair_code.first) > golomb_code_table::byte_bit_count)
+        const auto [code_length, table_value]{create_encoded_value(k, mapped_error_value)};
+        if (static_cast<size_t>(code_length) > golomb_code_table::byte_bit_count)
             break;
 
-        const golomb_code code(error_value, conditional_static_cast<int16_t>(pair_code.first));
-        table.add_entry(static_cast<uint8_t>(pair_code.second), code);
+        const golomb_code code(error_value, conditional_static_cast<int16_t>(code_length));
+        table.add_entry(static_cast<uint8_t>(table_value), code);
     }
 
     for (int16_t error_value{-1};; --error_value)
     {
         // Q is not used when k != 0
         const int32_t mapped_error_value{map_error_value(error_value)};
-        const std::pair<int32_t, int32_t> pair_code{create_encoded_value(k, mapped_error_value)};
-        if (static_cast<size_t>(pair_code.first) > golomb_code_table::byte_bit_count)
+        const auto [code_length, table_value]{create_encoded_value(k, mapped_error_value)};
+        if (static_cast<size_t>(code_length) > golomb_code_table::byte_bit_count)
             break;
 
-        const auto code{golomb_code(error_value, static_cast<int16_t>(pair_code.first))};
-        table.add_entry(static_cast<uint8_t>(pair_code.second), code);
+        const auto code{golomb_code(error_value, static_cast<int16_t>(code_length))};
+        table.add_entry(static_cast<uint8_t>(table_value), code);
     }
 
     return table;
@@ -113,7 +113,6 @@ golomb_code_table initialize_table(const int32_t k) noexcept
 // To avoid threading issues, all tables are created when the program is loaded.
 
 // Lookup table: decode symbols that are smaller or equal to 8 bit (16 tables for each value of k)
-// NOLINTNEXTLINE(clang-diagnostic-global-constructors)
 const array<golomb_code_table, max_k_value> decoding_tables{
     initialize_table(0),  initialize_table(1),  initialize_table(2),  initialize_table(3),
     initialize_table(4),  initialize_table(5),  initialize_table(6),  initialize_table(7),

--- a/src/lookup_table.h
+++ b/src/lookup_table.h
@@ -16,7 +16,7 @@ struct golomb_code final
 {
     golomb_code() = default;
 
-    golomb_code(const int32_t value, const uint32_t length) noexcept : value_{value}, length_{length}
+    constexpr golomb_code(const int32_t value, const uint32_t length) noexcept : value_{value}, length_{length}
     {
     }
 
@@ -25,7 +25,7 @@ struct golomb_code final
         return value_;
     }
 
-    [[nodiscard]] uint32_t length() const noexcept
+    [[nodiscard]] constexpr uint32_t length() const noexcept
     {
         return length_;
     }
@@ -41,15 +41,15 @@ class golomb_code_table final
 public:
     static constexpr size_t byte_bit_count{8};
 
-    void add_entry(const uint8_t value, const golomb_code c) noexcept
+    constexpr void add_entry(const uint8_t value, const golomb_code code) noexcept
     {
-        const uint32_t length{c.length()};
+        const uint32_t length{code.length()};
         ASSERT(static_cast<size_t>(length) <= byte_bit_count);
 
         for (size_t i{}; i < conditional_static_cast<size_t>(1U) << (byte_bit_count - length); ++i)
         {
             ASSERT(types_[(static_cast<size_t>(value) << (byte_bit_count - length)) + i].length() == 0);
-            types_[(static_cast<size_t>(value) << (byte_bit_count - length)) + i] = c;
+            types_[(static_cast<size_t>(value) << (byte_bit_count - length)) + i] = code;
         }
     }
 


### PR DESCRIPTION
This will move the 256 * 16 * 8 = 32768 bytes of the table from the .data section to the .rdata section.