### PR TITLE
Improve the SFINAE constructions: use template parameters

### DIFF
--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -240,11 +240,10 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <exception cref="std::bad_alloc">Thrown when memory for the decoder could not be allocated.</exception>
     /// <returns>Frame info of the decoded image and the interleave mode.</returns>
-    template<typename SourceContainer, typename DestinationContainer, typename T1 = typename SourceContainer::value_type,
-             typename T2 = typename DestinationContainer::value_type>
-    static std::pair<frame_info, interleave_mode>
-    decode(const SourceContainer& source, DestinationContainer& destination,
-           const size_t maximum_size_in_bytes = size_t{7680} * 4320 * 3)
+    template<typename SourceContainer, typename DestinationContainer,
+             typename DestinationContainerValueType = typename DestinationContainer::value_type>
+    static std::pair<frame_info, interleave_mode> decode(const SourceContainer& source, DestinationContainer& destination,
+                                                         const size_t maximum_size_in_bytes = size_t{7680} * 4320 * 3)
     {
         jpegls_decoder decoder{source, true};
 
@@ -252,7 +251,7 @@ public:
         if (destination_size > maximum_size_in_bytes)
             impl::throw_jpegls_error(jpegls_errc::not_enough_memory);
 
-        destination.resize(destination_size / sizeof(typename DestinationContainer::value_type));
+        destination.resize(destination_size / sizeof(DestinationContainerValueType));
         decoder.decode(destination);
 
         return std::make_pair(decoder.frame_info(), decoder.interleave_mode());
@@ -294,10 +293,9 @@ public:
     /// </param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <exception cref="std::bad_alloc">Thrown when memory for the decoder could not be allocated.</exception>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     jpegls_decoder(const Container& source_container, const bool parse_header) :
-        jpegls_decoder(source_container.data(), source_container.size() * sizeof(typename Container::value_type),
-                       parse_header)
+        jpegls_decoder(source_container.data(), source_container.size() * sizeof(ContainerValueType), parse_header)
     {
     }
 
@@ -324,10 +322,10 @@ public:
     /// A STL like container that provides the functions data() and size() and the type value_type.
     /// </param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     jpegls_decoder& source(const Container& source_container)
     {
-        return source(source_container.data(), source_container.size() * sizeof(typename Container::value_type));
+        return source(source_container.data(), source_container.size() * sizeof(ContainerValueType));
     }
 
     /// <summary>
@@ -532,10 +530,10 @@ public:
     /// </param>
     /// <param name="stride">Number of bytes to the next line in the buffer, when zero, decoder will compute it.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     void decode(CHARLS_OUT Container& destination_container, const uint32_t stride = 0) const
     {
-        decode(destination_container.data(), destination_container.size() * sizeof(typename Container::value_type), stride);
+        decode(destination_container.data(), destination_container.size() * sizeof(ContainerValueType), stride);
     }
 
     /// <summary>
@@ -544,12 +542,12 @@ public:
     /// <param name="stride">Number of bytes to the next line in the buffer, when zero, decoder will compute it.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>Container with the decoded data.</returns>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     [[nodiscard]] Container decode(const uint32_t stride = 0) const
     {
-        Container destination(destination_size() / sizeof(typename Container::value_type));
+        Container destination(destination_size() / sizeof(ContainerValueType));
 
-        decode(destination.data(), destination.size() * sizeof(typename Container::value_type), stride);
+        decode(destination.data(), destination.size() * sizeof(ContainerValueType), stride);
         return destination;
     }
 

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -289,7 +289,7 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <exception cref="std::bad_alloc">Thrown when memory for the encoder could not be allocated.</exception>
     /// <returns>Container with the JPEG-LS encoded bytes.</returns>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     static Container encode(const Container& source, const frame_info& frame,
                             const interleave_mode interleave_mode = interleave_mode::none,
                             const encoding_options options = encoding_options::none)
@@ -300,7 +300,7 @@ public:
         Container destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
-        const size_t bytes_written{encoder.encode(source)};
+        const size_t bytes_written{encoder.encode<Container, ContainerValueType>(source)};
         destination.resize(bytes_written);
 
         return destination;
@@ -414,11 +414,10 @@ public:
     /// <param name="destination_container">
     /// The STL like container, that supports the functions data() and size() and the typedef value_type.
     /// </param>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     jpegls_encoder& destination(Container& destination_container)
     {
-        return destination(destination_container.data(),
-                           destination_container.size() * sizeof(typename Container::value_type));
+        return destination(destination_container.data(), destination_container.size() * sizeof(ContainerValueType));
     }
 
     template<typename Container, typename T = typename Container::value_type>
@@ -552,10 +551,10 @@ public:
     /// Stride is sometimes called pitch. If padding bytes are present, the stride is wider than the width of the image.
     /// </param>
     /// <returns>The number of bytes written to the destination.</returns>
-    template<typename Container, typename T = typename Container::value_type>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
     size_t encode(const Container& source_container, const uint32_t stride = 0) const
     {
-        return encode(source_container.data(), source_container.size() * sizeof(typename Container::value_type), stride);
+        return encode(source_container.data(), source_container.size() * sizeof(ContainerValueType), stride);
     }
 
     /// <summary>

--- a/src/jpegls.cpp
+++ b/src/jpegls.cpp
@@ -120,6 +120,7 @@ const array<golomb_code_table, max_k_value> decoding_tables{
     initialize_table(12), initialize_table(13), initialize_table(14), initialize_table(15)};
 
 // Lookup tables: sample differences to bin indexes.
+// ReSharper disable CppTemplateArgumentsCanBeDeduced
 // NOLINTNEXTLINE(clang-diagnostic-global-constructors)
 const vector<int8_t> quantization_lut_lossless_8{create_quantize_lut_lossless(8)};
 
@@ -131,6 +132,7 @@ const vector<int8_t> quantization_lut_lossless_12{create_quantize_lut_lossless(1
 
 // NOLINTNEXTLINE(clang-diagnostic-global-constructors)
 const vector<int8_t> quantization_lut_lossless_16{create_quantize_lut_lossless(16)};
+// ReSharper restore CppTemplateArgumentsCanBeDeduced
 
 
 template<typename Strategy>

--- a/src/jpegls_preset_coding_parameters.h
+++ b/src/jpegls_preset_coding_parameters.h
@@ -91,13 +91,13 @@ inline bool is_valid(const jpegls_pc_parameters& pc_parameters, const int32_t ma
         (pc_parameters.threshold1 < near_lossless + 1 || pc_parameters.threshold1 > maximum_sample_value))
         return false;
 
-    const jpegls_pc_parameters default_parameters{compute_default(maximum_sample_value, near_lossless)};
-    if (const int32_t threshold1{pc_parameters.threshold1 != 0 ? pc_parameters.threshold1 : default_parameters.threshold1};
+    const auto [_, d_threshold1, d_threshold2, d_threshold3, d_reset_value]{compute_default(maximum_sample_value, near_lossless)};
+    if (const int32_t threshold1{pc_parameters.threshold1 != 0 ? pc_parameters.threshold1 : d_threshold1};
         pc_parameters.threshold2 != 0 &&
         (pc_parameters.threshold2 < threshold1 || pc_parameters.threshold2 > maximum_sample_value))
         return false;
 
-    if (const int32_t threshold2{pc_parameters.threshold2 != 0 ? pc_parameters.threshold2 : default_parameters.threshold2};
+    if (const int32_t threshold2{pc_parameters.threshold2 != 0 ? pc_parameters.threshold2 : d_threshold2};
         pc_parameters.threshold3 != 0 &&
         (pc_parameters.threshold3 < threshold2 || pc_parameters.threshold3 > maximum_sample_value))
         return false;
@@ -110,13 +110,13 @@ inline bool is_valid(const jpegls_pc_parameters& pc_parameters, const int32_t ma
     {
         validated_parameters->maximum_sample_value = maximum_sample_value;
         validated_parameters->threshold1 =
-            pc_parameters.threshold1 != 0 ? pc_parameters.threshold1 : default_parameters.threshold1;
+            pc_parameters.threshold1 != 0 ? pc_parameters.threshold1 : d_threshold1;
         validated_parameters->threshold2 =
-            pc_parameters.threshold2 != 0 ? pc_parameters.threshold2 : default_parameters.threshold2;
+            pc_parameters.threshold2 != 0 ? pc_parameters.threshold2 : d_threshold2;
         validated_parameters->threshold3 =
-            pc_parameters.threshold3 != 0 ? pc_parameters.threshold3 : default_parameters.threshold3;
+            pc_parameters.threshold3 != 0 ? pc_parameters.threshold3 : d_threshold3;
         validated_parameters->reset_value =
-            pc_parameters.reset_value != 0 ? pc_parameters.reset_value : default_parameters.reset_value;
+            pc_parameters.reset_value != 0 ? pc_parameters.reset_value : d_reset_value;
     }
 
     return true;

--- a/src/scan.h
+++ b/src/scan.h
@@ -744,7 +744,7 @@ private:
         const pixel_type ra{current_line_[start_index - 1]};
 
         const int32_t run_length{decode_run_pixels(ra, current_line_ + start_index, width_ - start_index)};
-        const uint32_t end_index{static_cast<uint32_t>(start_index + run_length)};
+        const auto end_index{static_cast<uint32_t>(start_index + run_length)};
 
         if (end_index == width_)
             return end_index - start_index;


### PR DESCRIPTION
To prevent that overloads would have similar conversions, additional template parameters were introduced. Use these extra parameters to prevent warnings about not used template parameters. (C++20 concepts cannot be used)