### PR TITLE
Update byte_span to be equal with std::span

### DIFF
--- a/src/byte_span.h
+++ b/src/byte_span.h
@@ -10,32 +10,44 @@ namespace charls {
 /// <summary>Simplified span class as replacement for C++20 std::span<std::byte>.</summary>
 struct byte_span final
 {
-    using iterator = const std::byte*;
+    using iterator = std::byte*;
+    using pointer = std::byte*;
 
     byte_span() = default;
 
-    constexpr byte_span(void* data_arg, const size_t size_arg) noexcept :
-        data{static_cast<std::byte*>(data_arg)}, size{size_arg}
+    constexpr byte_span(void* data, const size_t size) noexcept :
+        data_{static_cast<std::byte*>(data)}, size_{size}
     {
     }
 
-    constexpr byte_span(const void* data_arg, const size_t size_arg) noexcept :
-        data{static_cast<std::byte*>(const_cast<void*>(data_arg))}, size{size_arg}
+    [[nodiscard]] constexpr size_t size() const noexcept
     {
+        return size_;
+    }
+
+    [[nodiscard]] constexpr pointer data() const noexcept
+    {
+        return data_;
     }
 
     [[nodiscard]] constexpr iterator begin() const noexcept
     {
-        return data;
+        return data_;
     }
 
     [[nodiscard]] constexpr iterator end() const noexcept
     {
-        return data + size;
+        return data_ + size_;
     }
 
-    std::byte* data{};
-    size_t size{};
+    [[nodiscard]] constexpr bool empty() const noexcept
+    {
+        return size_ == 0;
+    }
+
+private:
+    std::byte* data_{};
+    size_t size_{};
 };
 
 
@@ -44,6 +56,7 @@ class const_byte_span final
 {
 public:
     using iterator = const std::byte*;
+    using pointer = const std::byte*;
 
     const_byte_span() = default;
 
@@ -62,7 +75,7 @@ public:
         return size_;
     }
 
-    [[nodiscard]] constexpr const std::byte* data() const noexcept
+    [[nodiscard]] constexpr pointer data() const noexcept
     {
         return data_;
     }

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -122,7 +122,7 @@ struct charls_jpegls_decoder final
 
     void decode(const byte_span destination, const size_t stride)
     {
-        check_argument(destination.data || destination.size == 0);
+        check_argument(destination.data() || destination.empty());
         check_operation(state_ == state::header_read);
 
         reader_.decode(destination, stride);

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -28,7 +28,7 @@ struct charls_jpegls_encoder final
 {
     void destination(const byte_span destination)
     {
-        check_argument(destination.data || destination.size == 0);
+        check_argument(destination.data() || destination.empty());
         check_operation(state_ == state::initial);
 
         writer_.destination(destination);
@@ -156,9 +156,9 @@ struct charls_jpegls_encoder final
         writer_.write_application_data_segment(application_data_id, application_data);
     }
 
-    void encode(byte_span source, size_t stride)
+    void encode(const_byte_span source, size_t stride)
     {
-        check_argument(source.data || source.size == 0);
+        check_argument(source.data() || source.empty());
         check_operation(is_frame_info_configured() && state_ != state::initial);
         check_interleave_mode_against_component_count();
 
@@ -173,7 +173,7 @@ struct charls_jpegls_encoder final
         }
         else
         {
-            check_stride(stride, source.size);
+            check_stride(stride, source.size());
         }
 
         transition_to_tables_and_miscellaneous_state();
@@ -255,7 +255,7 @@ private:
         return frame_info_.width != 0;
     }
 
-    void encode_scan(const byte_span source, const size_t stride, const int32_t component_count)
+    void encode_scan(const const_byte_span source, const size_t stride, const int32_t component_count)
     {
         const charls::frame_info frame_info{frame_info_.width, frame_info_.height, frame_info_.bits_per_sample,
                                             component_count};

--- a/src/encoder_strategy.h
+++ b/src/encoder_strategy.h
@@ -24,7 +24,7 @@ public:
     encoder_strategy& operator=(const encoder_strategy&) = delete;
     encoder_strategy& operator=(encoder_strategy&&) = delete;
 
-    virtual std::unique_ptr<process_line> create_process_line(byte_span stream_info, size_t stride) = 0;
+    virtual std::unique_ptr<process_line> create_process_line(const_byte_span source, size_t stride) = 0;
     virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters, uint32_t restart_interval) = 0;
     virtual size_t encode_scan(std::unique_ptr<process_line> raw_data, byte_span destination) = 0;
 
@@ -39,8 +39,8 @@ protected:
         free_bit_count_ = sizeof(bit_buffer_) * 8;
         bit_buffer_ = 0;
 
-        position_ = destination.data;
-        compressed_length_ = destination.size;
+        position_ = destination.data();
+        compressed_length_ = destination.size();
     }
 
     void append_to_bit_stream(const uint32_t bits, const int32_t bit_count)

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -121,7 +121,7 @@ void jpeg_stream_reader::decode(byte_span destination, size_t stride)
     const size_t bytes_per_plane{stride * frame_info_.height};
     const size_t plane_count{parameters_.interleave_mode == interleave_mode::none ? frame_info_.component_count : 1U};
     if (const size_t minimum_destination_size = bytes_per_plane * plane_count - (stride - minimum_stride);
-        UNLIKELY(destination.size < minimum_destination_size))
+        UNLIKELY(destination.size() < minimum_destination_size))
         throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
 
     for (size_t i{}; i < plane_count; ++i)

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -203,7 +203,7 @@ void jpeg_stream_writer::write_segment_header(const jpeg_marker_code marker_code
     // Other methods assume that the checking in done here and don't check again.
     constexpr size_t marker_code_size{2};
     if (const size_t total_segment_size{marker_code_size + segment_length_size + data_size};
-        UNLIKELY(byte_offset_ + total_segment_size > destination_.size))
+        UNLIKELY(byte_offset_ + total_segment_size > destination_.size()))
         impl::throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
 
     write_marker(marker_code);

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -99,12 +99,12 @@ public:
 
     [[nodiscard]] byte_span remaining_destination() const noexcept
     {
-        return {destination_.data + byte_offset_, destination_.size - byte_offset_};
+        return {destination_.data() + byte_offset_, destination_.size() - byte_offset_};
     }
 
     void seek(const size_t byte_count) noexcept
     {
-        ASSERT(byte_offset_ + byte_count <= destination_.size);
+        ASSERT(byte_offset_ + byte_count <= destination_.size());
         byte_offset_ += byte_count;
     }
 
@@ -164,7 +164,7 @@ private:
     template<typename UnsignedIntType>
     void write_uint(const UnsignedIntType value) noexcept
     {
-        ASSERT(byte_offset_ + sizeof(UnsignedIntType) <= destination_.size);
+        ASSERT(byte_offset_ + sizeof(UnsignedIntType) <= destination_.size());
 
         // Use write_bytes to write to the unaligned byte array.
         // The compiler will perform the correct optimization when the target platform support unaligned writes.
@@ -178,8 +178,8 @@ private:
 
     void write_byte(const std::byte value) noexcept
     {
-        ASSERT(byte_offset_ + sizeof(std::byte) <= destination_.size);
-        destination_.data[byte_offset_++] = value;
+        ASSERT(byte_offset_ + sizeof(std::byte) <= destination_.size());
+        destination_.data()[byte_offset_++] = value;
     }
 
     void write_bytes(const const_byte_span data) noexcept
@@ -189,8 +189,8 @@ private:
 
     void write_bytes(CHARLS_IN_READS_BYTES(size) const void* data, const size_t size) noexcept
     {
-        ASSERT(byte_offset_ + size <= destination_.size);
-        memcpy(destination_.data + byte_offset_, data, size);
+        ASSERT(byte_offset_ + size <= destination_.size());
+        memcpy(destination_.data() + byte_offset_, data, size);
         byte_offset_ += size;
     }
 
@@ -202,7 +202,7 @@ private:
 
     void write_segment_without_data(const jpeg_marker_code marker_code)
     {
-        if (UNLIKELY(byte_offset_ + 2 > destination_.size))
+        if (UNLIKELY(byte_offset_ + 2 > destination_.size()))
             impl::throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
 
         write_byte(jpeg_marker_start_byte);

--- a/src/scan.h
+++ b/src/scan.h
@@ -108,23 +108,23 @@ public:
     }
 
     // Factory function for ProcessLine objects to copy/transform un encoded pixels to/from our scan line buffers.
-    std::unique_ptr<process_line> create_process_line(byte_span info, const size_t stride) override
+    std::unique_ptr<process_line> create_process_line(const_byte_span source, const size_t stride) override
     {
         if (!is_interleaved())
         {
             if (frame_info().bits_per_sample == sizeof(sample_type) * 8)
             {
-                return std::make_unique<post_process_single_component>(info.data, stride,
+                return std::make_unique<post_process_single_component>(source.data(), stride,
                                                                        sizeof(typename Traits::pixel_type));
             }
 
             return std::make_unique<post_process_single_component_masked>(
-                info.data, stride, sizeof(typename Traits::pixel_type), frame_info().bits_per_sample);
+                source.data(), stride, sizeof(typename Traits::pixel_type), frame_info().bits_per_sample);
         }
 
         if (parameters().transformation == color_transformation::none)
             return std::make_unique<process_transformed<transform_none<typename Traits::sample_type>>>(
-                info, stride, frame_info(), parameters(), transform_none<sample_type>());
+                source, stride, frame_info(), parameters(), transform_none<sample_type>());
 
         if (frame_info().bits_per_sample == sizeof(sample_type) * 8)
         {
@@ -132,13 +132,13 @@ public:
             {
             case color_transformation::hp1:
                 return std::make_unique<process_transformed<transform_hp1<sample_type>>>(
-                    info, stride, frame_info(), parameters(), transform_hp1<sample_type>());
+                    source, stride, frame_info(), parameters(), transform_hp1<sample_type>());
             case color_transformation::hp2:
                 return std::make_unique<process_transformed<transform_hp2<sample_type>>>(
-                    info, stride, frame_info(), parameters(), transform_hp2<sample_type>());
+                    source, stride, frame_info(), parameters(), transform_hp2<sample_type>());
             case color_transformation::hp3:
                 return std::make_unique<process_transformed<transform_hp3<sample_type>>>(
-                    info, stride, frame_info(), parameters(), transform_hp3<sample_type>());
+                    source, stride, frame_info(), parameters(), transform_hp3<sample_type>());
             default:
                 impl::throw_jpegls_error(jpegls_errc::color_transform_not_supported);
             }
@@ -645,23 +645,23 @@ public:
     }
 
     // Factory function for ProcessLine objects to copy/transform un encoded pixels to/from our scan line buffers.
-    std::unique_ptr<process_line> create_process_line(byte_span info, const size_t stride) override
+    std::unique_ptr<process_line> create_process_line(byte_span destination, const size_t stride) override
     {
         if (!is_interleaved())
         {
             if (frame_info().bits_per_sample == sizeof(sample_type) * 8)
             {
-                return std::make_unique<post_process_single_component>(info.data, stride,
+                return std::make_unique<post_process_single_component>(destination.data(), stride,
                                                                        sizeof(typename Traits::pixel_type));
             }
 
             return std::make_unique<post_process_single_component_masked>(
-                info.data, stride, sizeof(typename Traits::pixel_type), frame_info().bits_per_sample);
+                destination.data(), stride, sizeof(typename Traits::pixel_type), frame_info().bits_per_sample);
         }
 
         if (parameters().transformation == color_transformation::none)
             return std::make_unique<process_transformed<transform_none<typename Traits::sample_type>>>(
-                info, stride, frame_info(), parameters(), transform_none<sample_type>());
+                destination, stride, frame_info(), parameters(), transform_none<sample_type>());
 
         if (frame_info().bits_per_sample == sizeof(sample_type) * 8)
         {
@@ -669,13 +669,13 @@ public:
             {
             case color_transformation::hp1:
                 return std::make_unique<process_transformed<transform_hp1<sample_type>>>(
-                    info, stride, frame_info(), parameters(), transform_hp1<sample_type>());
+                    destination, stride, frame_info(), parameters(), transform_hp1<sample_type>());
             case color_transformation::hp2:
                 return std::make_unique<process_transformed<transform_hp2<sample_type>>>(
-                    info, stride, frame_info(), parameters(), transform_hp2<sample_type>());
+                    destination, stride, frame_info(), parameters(), transform_hp2<sample_type>());
             case color_transformation::hp3:
                 return std::make_unique<process_transformed<transform_hp3<sample_type>>>(
-                    info, stride, frame_info(), parameters(), transform_hp3<sample_type>());
+                    destination, stride, frame_info(), parameters(), transform_hp3<sample_type>());
             default:
                 impl::throw_jpegls_error(jpegls_errc::color_transform_not_supported);
             }

--- a/src/util.h
+++ b/src/util.h
@@ -332,12 +332,11 @@ T read_big_endian_unaligned(const void* buffer) noexcept
 #endif
 
 
-inline void skip_bytes(byte_span& stream_info, const size_t count) noexcept
+template<typename Span>
+void skip_bytes(Span& span, const size_t count) noexcept
 {
-    ASSERT(count <= stream_info.size);
-
-    stream_info.data += count;
-    stream_info.size -= count;
+    ASSERT(count <= span.size());
+    span = Span{span.data() + count, span.size() - count};
 }
 
 

--- a/unittest/decoder_strategy_test.cpp
+++ b/unittest/decoder_strategy_test.cpp
@@ -33,7 +33,7 @@ public:
     {
     }
 
-    unique_ptr<process_line> create_process_line(byte_span /*rawStreamInfo*/,
+    unique_ptr<process_line> create_process_line(byte_span /*destination*/,
                                                  size_t /*stride*/) noexcept(false) override
     {
         return nullptr;

--- a/unittest/encoder_strategy_tester.h
+++ b/unittest/encoder_strategy_tester.h
@@ -24,7 +24,7 @@ public:
         return 0;
     }
 
-    std::unique_ptr<process_line> create_process_line(byte_span, size_t /*stride*/) noexcept(false) override
+    std::unique_ptr<process_line> create_process_line(const_byte_span, size_t /*stride*/) noexcept(false) override
     {
         return nullptr;
     }

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -24,8 +24,8 @@ public:
     TEST_METHOD(remaining_destination_will_be_zero_after_create_with_default) // NOLINT
     {
         const jpeg_stream_writer writer;
-        Assert::AreEqual(size_t{}, writer.remaining_destination().size);
-        Assert::IsNull(writer.remaining_destination().data);
+        Assert::AreEqual(size_t{}, writer.remaining_destination().size());
+        Assert::IsNull(writer.remaining_destination().data());
     }
 
     TEST_METHOD(write_start_of_image) // NOLINT


### PR DESCRIPTION
const_byte_span is equal with C++20 std::span., byte_span was out of sync. Update byte_span to make it equal with std::span move the const_cast deeper into to the code to allow using const_byte_span in the encode call.