### PR TITLE
Make create_process_line method non-virtual

### DIFF
--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -262,8 +262,7 @@ private:
 
         const auto codec{jls_codec_factory<encoder_strategy>().create_codec(
             frame_info, {near_lossless_, 0, interleave_mode_, color_transformation_}, preset_coding_parameters_)};
-        const size_t bytes_written{
-            codec->encode_scan(codec->create_process_line(source, stride), writer_.remaining_destination())};
+        const size_t bytes_written{codec->encode_scan(source, stride, writer_.remaining_destination())};
 
         // Synchronize the destination encapsulated in the writer (encode_scan works on a local copy)
         writer_.seek(bytes_written);

--- a/src/decoder_strategy.h
+++ b/src/decoder_strategy.h
@@ -29,9 +29,8 @@ public:
     decoder_strategy& operator=(const decoder_strategy&) = delete;
     decoder_strategy& operator=(decoder_strategy&&) = delete;
 
-    virtual std::unique_ptr<process_line> create_process_line(byte_span destination, size_t stride) = 0;
-    virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters, uint32_t restart_interval) = 0;
-    virtual size_t decode_scan(std::unique_ptr<process_line> output_data, const_byte_span encoded_source) = 0;
+    virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters) = 0;
+    virtual size_t decode_scan(const_byte_span source, byte_span destination, size_t stride) = 0;
 
     void initialize(const const_byte_span source)
     {

--- a/src/encoder_strategy.h
+++ b/src/encoder_strategy.h
@@ -24,9 +24,8 @@ public:
     encoder_strategy& operator=(const encoder_strategy&) = delete;
     encoder_strategy& operator=(encoder_strategy&&) = delete;
 
-    virtual std::unique_ptr<process_line> create_process_line(const_byte_span source, size_t stride) = 0;
-    virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters, uint32_t restart_interval) = 0;
-    virtual size_t encode_scan(std::unique_ptr<process_line> raw_data, byte_span destination) = 0;
+    virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters) = 0;
+    virtual size_t encode_scan(const_byte_span source, size_t stride, byte_span destination) = 0;
 
     void on_line_begin(void* destination, const size_t pixel_count, const size_t pixel_stride) const
     {

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -134,8 +134,7 @@ void jpeg_stream_reader::decode(byte_span destination, size_t stride)
 
         const auto codec{jls_codec_factory<decoder_strategy>().create_codec(frame_info_, parameters_,
                                                                             get_validated_preset_coding_parameters())};
-        const size_t bytes_read{
-            codec->decode_scan(codec->create_process_line(destination, stride), const_byte_span{position_, end_position_})};
+        const size_t bytes_read{codec->decode_scan({position_, end_position_}, destination, stride)};
         advance_position(bytes_read);
         state_ = state::scan_section;
     }

--- a/src/jpegls.cpp
+++ b/src/jpegls.cpp
@@ -170,7 +170,7 @@ unique_ptr<Strategy> jls_codec_factory<Strategy>::create_codec(const frame_info&
         }
     }
 
-    codec->set_presets(preset_coding_parameters, parameters.restart_interval);
+    codec->set_presets(preset_coding_parameters);
     return codec;
 }
 

--- a/unittest/decoder_strategy_test.cpp
+++ b/unittest/decoder_strategy_test.cpp
@@ -12,7 +12,6 @@
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
 using std::byte;
-using std::unique_ptr;
 
 namespace charls::test {
 
@@ -28,19 +27,11 @@ public:
         initialize({destination, count});
     }
 
-    void set_presets(const jpegls_pc_parameters& /*preset_coding_parameters*/,
-                     uint32_t /*restart_interval*/) noexcept(false) override
+    void set_presets(const jpegls_pc_parameters& /*preset_coding_parameters*/) noexcept(false) override
     {
     }
 
-    unique_ptr<process_line> create_process_line(byte_span /*destination*/,
-                                                 size_t /*stride*/) noexcept(false) override
-    {
-        return nullptr;
-    }
-
-    size_t decode_scan(unique_ptr<process_line> /*process_line*/,
-                       const_byte_span /*encoded_source*/) noexcept(false) override
+    size_t decode_scan(const_byte_span /*encoded_source*/, byte_span /*destination*/, size_t /*stride*/) noexcept(false) override
     {
         return {};
     }

--- a/unittest/encoder_strategy_tester.h
+++ b/unittest/encoder_strategy_tester.h
@@ -15,18 +15,13 @@ public:
     {
     }
 
-    void set_presets(const jpegls_pc_parameters&, uint32_t /*restart_interval*/) noexcept(false) override
+    void set_presets(const jpegls_pc_parameters&) noexcept(false) override
     {
     }
 
-    size_t encode_scan(std::unique_ptr<process_line>, byte_span) noexcept(false) override
+    size_t encode_scan(const_byte_span /*source*/, size_t /*stride*/, byte_span) noexcept(false) override
     {
         return 0;
-    }
-
-    std::unique_ptr<process_line> create_process_line(const_byte_span, size_t /*stride*/) noexcept(false) override
-    {
-        return nullptr;
     }
 
     void initialize_forward(const byte_span destination) noexcept


### PR DESCRIPTION
The return value of create_process_line is only used by the scan_encoder/decoder class itself. Make it non-virtual and private.