### PR TITLE
Extract quantization lookup tables to it's own file.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,8 @@ target_sources(charls
     "${CMAKE_CURRENT_LIST_DIR}/jpegls_preset_parameters_type.h"
     "${CMAKE_CURRENT_LIST_DIR}/lossless_traits.h"
     "${CMAKE_CURRENT_LIST_DIR}/process_line.h"
+    "${CMAKE_CURRENT_LIST_DIR}/quantization_lut.h"
+    "${CMAKE_CURRENT_LIST_DIR}/quantization_lut.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/scan.h"
     "${CMAKE_CURRENT_LIST_DIR}/scan_codec.h"
     "${CMAKE_CURRENT_LIST_DIR}/util.h"

--- a/src/CharLS.vcxproj
+++ b/src/CharLS.vcxproj
@@ -212,6 +212,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="golomb_lut.cpp" />
+    <ClCompile Include="quantization_lut.cpp" />
     <ClCompile Include="validate_spiff_header.cpp" />
     <ClCompile Include="version.cpp" />
     <ClCompile Include="charls_jpegls_decoder.cpp" />
@@ -250,6 +251,7 @@
     <ClInclude Include="lossless_traits.h" />
     <ClInclude Include="jpegls_preset_parameters_type.h" />
     <ClInclude Include="process_line.h" />
+    <ClInclude Include="quantization_lut.h" />
     <ClInclude Include="scan.h" />
     <ClInclude Include="byte_span.h" />
     <ClInclude Include="scan_codec.h" />

--- a/src/CharLS.vcxproj.filters
+++ b/src/CharLS.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClCompile Include="golomb_lut.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="quantization_lut.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="context_regular_mode.h">
@@ -124,6 +127,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="golomb_lut.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="quantization_lut.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/jpegls_algorithm.h
+++ b/src/jpegls_algorithm.h
@@ -12,7 +12,7 @@ namespace charls {
 /// This is the optimized inverse algorithm of ISO/IEC 14495-1, A.5.2, Code Segment A.11 (second else branch)
 /// It will map unsigned values back to signed values.
 /// </summary>
-constexpr int32_t unmap_error_value(const int32_t mapped_error) noexcept
+[[nodiscard]] constexpr int32_t unmap_error_value(const int32_t mapped_error) noexcept
 {
     const int32_t sign{static_cast<int32_t>(static_cast<uint32_t>(mapped_error) << (int32_t_bit_count - 1)) >>
                        (int32_t_bit_count - 1)};
@@ -24,7 +24,7 @@ constexpr int32_t unmap_error_value(const int32_t mapped_error) noexcept
 /// This is the algorithm of ISO/IEC 14495-1, A.5.2, Code Segment A.11 (second else branch)
 /// It will map signed values to unsigned values. It has been optimized to prevent branching.
 /// </summary>
-constexpr int32_t map_error_value(const int32_t error_value) noexcept
+[[nodiscard]] constexpr int32_t map_error_value(const int32_t error_value) noexcept
 {
     ASSERT(error_value <= std::numeric_limits<int32_t>::max() / 2);
 
@@ -33,19 +33,19 @@ constexpr int32_t map_error_value(const int32_t error_value) noexcept
 }
 
 
-constexpr int32_t sign(const int32_t n) noexcept
+[[nodiscard]] constexpr int32_t sign(const int32_t n) noexcept
 {
     return (n >> (int32_t_bit_count - 1)) | 1;
 }
 
 
-constexpr int32_t bit_wise_sign(const int32_t i) noexcept
+[[nodiscard]] constexpr int32_t bit_wise_sign(const int32_t i) noexcept
 {
     return i >> (int32_t_bit_count - 1);
 }
 
 
-constexpr int32_t apply_sign(const int32_t i, const int32_t sign) noexcept
+[[nodiscard]] constexpr int32_t apply_sign(const int32_t i, const int32_t sign) noexcept
 {
     return (sign ^ i) - sign;
 }
@@ -54,7 +54,8 @@ constexpr int32_t apply_sign(const int32_t i, const int32_t sign) noexcept
 /// <summary>
 /// Computes the parameter RANGE. When NEAR = 0, RANGE = MAXVAL + 1. (see ISO/IEC 14495-1, A.2.1)
 /// </summary>
-constexpr int32_t compute_range_parameter(const int32_t maximum_sample_value, const int32_t near_lossless) noexcept
+[[nodiscard]] constexpr int32_t compute_range_parameter(const int32_t maximum_sample_value,
+                                                        const int32_t near_lossless) noexcept
 {
     return (maximum_sample_value + 2 * near_lossless) / (2 * near_lossless + 1) + 1;
 }
@@ -63,13 +64,13 @@ constexpr int32_t compute_range_parameter(const int32_t maximum_sample_value, co
 /// <summary>
 /// Computes the parameter LIMIT. (see ISO/IEC 14495-1, A.2.1)
 /// </summary>
-constexpr int32_t compute_limit_parameter(const int32_t bits_per_pixel)
+[[nodiscard]] constexpr int32_t compute_limit_parameter(const int32_t bits_per_pixel)
 {
     return 2 * (bits_per_pixel + std::max(8, bits_per_pixel));
 }
 
 
-inline int32_t get_predicted_value(const int32_t ra, const int32_t rb, const int32_t rc) noexcept
+[[nodiscard]] inline int32_t get_predicted_value(const int32_t ra, const int32_t rb, const int32_t rc) noexcept
 {
     // sign trick reduces the number of if statements (branches)
     const int32_t sign{bit_wise_sign(rb - ra)};
@@ -89,10 +90,34 @@ inline int32_t get_predicted_value(const int32_t ra, const int32_t rb, const int
 }
 
 
-constexpr int32_t compute_context_id(const int32_t q1, const int32_t q2, const int32_t q3) noexcept
+[[nodiscard]] constexpr int32_t compute_context_id(const int32_t q1, const int32_t q2, const int32_t q3) noexcept
 {
     return (q1 * 9 + q2) * 9 + q3;
 }
 
+
+// See JPEG-LS standard ISO/IEC 14495-1, A.3.3, golomb_code Segment A.4
+[[nodiscard]] constexpr int8_t quantize_gradient_org(const int32_t di, const int32_t threshold1, const int32_t threshold2,
+                                                  const int32_t threshold3, const int32_t near_lossless = 0) noexcept
+{
+    if (di <= -threshold3)
+        return -4;
+    if (di <= -threshold2)
+        return -3;
+    if (di <= -threshold1)
+        return -2;
+    if (di < -near_lossless)
+        return -1;
+    if (di <= near_lossless)
+        return 0;
+    if (di < threshold1)
+        return 1;
+    if (di < threshold2)
+        return 2;
+    if (di < threshold3)
+        return 3;
+
+    return 4;
+}
 
 } // namespace charls

--- a/src/quantization_lut.cpp
+++ b/src/quantization_lut.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "quantization_lut.h"
+
+#include "charls/public_types.h"
+#include "jpegls_algorithm.h"
+
+#include "jpegls_preset_coding_parameters.h"
+
+namespace charls {
+
+using std::vector;
+
+namespace {
+
+vector<int8_t> create_quantize_lut_lossless(const int32_t bit_count)
+{
+    const jpegls_pc_parameters preset{compute_default(calculate_maximum_sample_value(bit_count), 0)};
+    const int32_t range{preset.maximum_sample_value + 1};
+
+    vector<int8_t> lut(static_cast<size_t>(range) * 2);
+    for (size_t i{}; i != lut.size(); ++i)
+    {
+        lut[i] =
+            quantize_gradient_org(static_cast<int32_t>(i) - range, preset.threshold1, preset.threshold2, preset.threshold3);
+    }
+
+    return lut;
+}
+
+} // namespace
+
+// Lookup tables: sample differences to bin indexes.
+// ReSharper disable CppTemplateArgumentsCanBeDeduced
+// NOLINTNEXTLINE(clang-diagnostic-global-constructors)
+const vector<int8_t> quantization_lut_lossless_8{create_quantize_lut_lossless(8)};
+
+// NOLINTNEXTLINE(clang-diagnostic-global-constructors)
+const vector<int8_t> quantization_lut_lossless_10{create_quantize_lut_lossless(10)};
+
+// NOLINTNEXTLINE(clang-diagnostic-global-constructors)
+const vector<int8_t> quantization_lut_lossless_12{create_quantize_lut_lossless(12)};
+
+// NOLINTNEXTLINE(clang-diagnostic-global-constructors)
+const vector<int8_t> quantization_lut_lossless_16{create_quantize_lut_lossless(16)};
+// ReSharper restore CppTemplateArgumentsCanBeDeduced
+
+} // namespace charls

--- a/src/quantization_lut.h
+++ b/src/quantization_lut.h
@@ -1,0 +1,16 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace charls {
+
+extern const std::vector<int8_t> quantization_lut_lossless_8;
+extern const std::vector<int8_t> quantization_lut_lossless_10;
+extern const std::vector<int8_t> quantization_lut_lossless_12;
+extern const std::vector<int8_t> quantization_lut_lossless_16;
+
+} // namespace charls

--- a/src/scan_codec.h
+++ b/src/scan_codec.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include "jpegls_algorithm.h"
+#include "quantization_lut.h"
+
 #include <array>
 
 namespace charls {
@@ -11,6 +14,56 @@ namespace charls {
 // step 3.
 constexpr std::array<int, 32> J{
     {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15}};
+
+
+// C4127 = conditional expression is constant (caused by some template methods that are not fully specialized) [VS2017]
+// C6326 = Potential comparison of a constant with another constant. (false warning, triggered by template construction
+// in Checked build)
+// C26814 = The const variable 'RANGE' can be computed at compile-time. [incorrect warning, VS 16.3.0 P3]
+MSVC_WARNING_SUPPRESS(4127 6326 26814)
+
+template<typename Traits>
+const int8_t* initialize_quantization_lut(Traits traits, const int32_t threshold1, const int32_t threshold2,
+                                          const int32_t threshold3, std::vector<int8_t>& quantization_lut)
+{
+    // for lossless mode with default parameters, we have precomputed the look up table for bit counts 8, 10, 12 and 16.
+    if (traits.near_lossless == 0 && traits.maximum_sample_value == (1 << traits.bits_per_pixel) - 1)
+    {
+        if (const jpegls_pc_parameters presets{compute_default(traits.maximum_sample_value, traits.near_lossless)};
+            presets.threshold1 == threshold1 && presets.threshold2 == threshold2 && presets.threshold3 == threshold3)
+        {
+            if (traits.bits_per_pixel == 8)
+            {
+                return &quantization_lut_lossless_8[quantization_lut_lossless_8.size() / 2];
+            }
+            if (traits.bits_per_pixel == 10)
+            {
+                return &quantization_lut_lossless_10[quantization_lut_lossless_10.size() / 2];
+            }
+            if (traits.bits_per_pixel == 12)
+            {
+                return &quantization_lut_lossless_12[quantization_lut_lossless_12.size() / 2];
+            }
+            if (traits.bits_per_pixel == 16)
+            {
+                return &quantization_lut_lossless_16[quantization_lut_lossless_16.size() / 2];
+            }
+        }
+    }
+
+    // Initialize the quantization lookup table dynamic.
+    const int32_t range{1 << traits.bits_per_pixel};
+    quantization_lut.resize(static_cast<size_t>(range) * 2);
+    for (size_t i{}; i < quantization_lut.size(); ++i)
+    {
+        quantization_lut[i] =
+            quantize_gradient_org(-range + static_cast<int32_t>(i), threshold1, threshold2, threshold3, traits.near_lossless);
+    }
+
+    return &quantization_lut[range];
+}
+MSVC_WARNING_UNSUPPRESS()
+
 
 /// <summary>
 /// Base class for scan_encoder and scan_decoder
@@ -37,24 +90,7 @@ protected:
 
     [[nodiscard]] int8_t quantize_gradient_org(const int32_t di, const int32_t near_lossless) const noexcept
     {
-        if (di <= -t3_)
-            return -4;
-        if (di <= -t2_)
-            return -3;
-        if (di <= -t1_)
-            return -2;
-        if (di < -near_lossless)
-            return -1;
-        if (di <= near_lossless)
-            return 0;
-        if (di < t1_)
-            return 1;
-        if (di < t2_)
-            return 2;
-        if (di < t3_)
-            return 3;
-
-        return 4;
+        return charls::quantize_gradient_org(di, t1_, t2_, t3_, near_lossless);
     }
 
     [[nodiscard]] const coding_parameters& parameters() const noexcept
@@ -80,6 +116,10 @@ protected:
     int32_t t1_{};
     int32_t t2_{};
     int32_t t3_{};
+
+    // Quantization lookup table
+    const int8_t* quantization_{};
+    std::vector<int8_t> quantization_lut_;
 };
 
 } // namespace charls

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -65,7 +65,7 @@
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(SolutionDir)build\intermediate\CharLS\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(SolutionDir)build\intermediate\CharLS\x86\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>jpegls.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;validate_spiff_header.obj;golomb_lut.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>jpegls.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;validate_spiff_header.obj;golomb_lut.obj;quantization_lut.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Extracting the quantization luts allows de-duplication of scan_encoder/scan_decoder