### PR TITLE
Move non-template members to base class scan_codec

### DIFF
--- a/src/scan_codec_factory.h
+++ b/src/scan_codec_factory.h
@@ -10,21 +10,19 @@
 
 namespace charls {
 
-class scan_decoder;
-class scan_encoder;
-
 template<typename ScanProcess>
 class scan_codec_factory final
 {
 public:
     std::unique_ptr<ScanProcess> create_codec(const frame_info& frame, const coding_parameters& parameters,
-                                           const jpegls_pc_parameters& preset_coding_parameters);
+                                              const jpegls_pc_parameters& preset_coding_parameters);
 
 private:
     std::unique_ptr<ScanProcess> try_create_optimized_codec(const frame_info& frame, const coding_parameters& parameters);
 };
 
-extern template class scan_codec_factory<scan_decoder>;
-extern template class scan_codec_factory<scan_encoder>;
+
+extern template class scan_codec_factory<class scan_decoder>;
+extern template class scan_codec_factory<class scan_encoder>;
 
 } // namespace charls

--- a/unittest/scan_decoder_test.cpp
+++ b/unittest/scan_decoder_test.cpp
@@ -59,7 +59,7 @@ public:
         constexpr array<data_t, 5> in_data{{{0x00, 24}, {0xFF, 8}, {0xFFFF, 16}, {0xFFFF, 16}, {0x12345678, 31}}};
 
         array<byte, 100> enc_buf{};
-        constexpr frame_info frame_info{};
+        constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
         scan_encoder_tester encoder(frame_info, parameters);
@@ -85,7 +85,7 @@ public:
 
     TEST_METHOD(peek_byte) // NOLINT
     {
-        constexpr frame_info frame_info{};
+        constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
         array buffer{byte{7}, byte{100}, byte{23}, byte{99}};
@@ -97,7 +97,7 @@ public:
 
     TEST_METHOD(read_bit) // NOLINT
     {
-        constexpr frame_info frame_info{};
+        constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
         array buffer{byte{0xAA}, byte{100}, byte{23}, byte{99}};
@@ -116,7 +116,7 @@ public:
 
     TEST_METHOD(peek_0_bits) // NOLINT
     {
-        constexpr frame_info frame_info{};
+        constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
         {
@@ -132,13 +132,17 @@ public:
             scan_decoder_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
             Assert::AreEqual(15, decoder_strategy.peek_0_bits());
         }
+    }
 
-        {
-            array<byte, 4> buffer{};
+    TEST_METHOD(peek_0_bits_empty_buffer) // NOLINT
+    {
+        constexpr frame_info frame_info{1, 1, 8, 1};
+        constexpr coding_parameters parameters{};
 
-            scan_decoder_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
-            Assert::AreEqual(-1, decoder_strategy.peek_0_bits());
-        }
+        array<byte, 4> buffer{};
+
+        scan_decoder_tester decoder_strategy(frame_info, parameters, buffer.data(), buffer.size());
+        Assert::AreEqual(-1, decoder_strategy.peek_0_bits());
     }
 };
 

--- a/unittest/scan_encoder_test.cpp
+++ b/unittest/scan_encoder_test.cpp
@@ -19,7 +19,7 @@ TEST_CLASS(scan_encoder_test)
 public:
     TEST_METHOD(append_to_bit_stream_zero_length) // NOLINT
     {
-        constexpr frame_info frame_info{};
+        constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
         scan_encoder_tester strategy(frame_info, parameters);
@@ -34,7 +34,7 @@ public:
 
     TEST_METHOD(append_to_bit_stream_ff_pattern) // NOLINT
     {
-        constexpr frame_info frame_info{};
+        constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
         scan_encoder_tester strategy(frame_info, parameters);


### PR DESCRIPTION
De-duplicate scan_encoder_impl/scan_decoder_impl by moveing identical members to the base class.