### PR TITLE
Configure SonarCloud scope analysis

### DIFF
--- a/CharLS.sln
+++ b/CharLS.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 		SECURITY.md = SECURITY.md
+		sonar-project.properties = sonar-project.properties
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "convert-c", "samples\convert.c\convert-c.vcxproj", "{F42C0547-FEB3-40F4-9379-0FF87B44FA0F}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,23 @@
-sonar.projectKey=team-charls_charls
-sonar.organization=team-charls
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
+
+sonar.projectKey = team-charls_charls
+sonar.organization = team-charls
 
 # This is the name and version displayed in the SonarCloud UI.
-sonar.projectName=charls
-sonar.projectVersion=2.4.1
+sonar.projectName = CharLS
+sonar.projectVersion = 3.0.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # sonar.sources=./src
 
 # Encoding of the source code. Default is default system encoding
-sonar.sourceEncoding=UTF-8
+sonar.sourceEncoding = UTF-8
 
-sonar.cfamily.cache.enabled=false
+# Define the source code to scan (only scan files that are part of the CharLS library)
+sonar.sources = src/,include/
+sonar.tests = test/,unittest/,benchmark/,fuzztest/
+
+# Duplication exclusions
+# SonarQube reports often false warnings for template classes., exclude these files.
+sonar.cpd.exclusions = src/scan_decoder_impl.h,src/scan_encoder_impl.h


### PR DESCRIPTION
- sonar.cfamily.cache.enabled is obsolete: remove it
- Only analyze the source code of the library
- Exclude the template source code file scan_decoder_impl and scan_encoder_imp. SonarCloud has problems to see that these are different files and cannot be merged.