### PR TITLE
Fix countl_zero: replace __builtin_clzl with __builtin_clzll

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -384,7 +384,7 @@ auto countl_zero(const T value) noexcept -> std::enable_if_t<is_uint_v<64, T>, i
     if (value == 0)
         return 64;
 
-    return __builtin_clzl(value);
+    return __builtin_clzll(value);
 }
 
 /// <summary>


### PR DESCRIPTION
GCC\Clang provide 3 overloads for __builtin_clz:
int __builtin_clz (unsigned int x)
int __builtin_clzl (unsigned long)
int __builtin_clzll (unsigned long long)

GCC and Clang can be used to build CharLS for Linux\macOS (LP64 data model) and Windows (LLP64 data model).

Using __builtin_clzl (unsigned long) for 64 bits works for LP64 (long is 64 bits) but fails for the LLP64 data model (long is 32 bits) __builtin_clzll (unsigned long long) works for both the LP64 and the LLP64 data model (unsigned long long int is always at least 64 bits)