### PR TITLE
Make encoding_options::include_pc_parameters_jai not enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Updated the source code to C++17. This is a breaking change, high version is updated to 3.
+- encoding_options::include_pc_parameters_jai is not enabled by default anymore. This is a breaking change.
 
 ## [2.4.1] - 2023-1-2
 

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -461,14 +461,14 @@ enum class encoding_options : unsigned
     /// an extra 0xFF byte to the End Of Image (EOI) marker.
     /// DICOM requires that data is always even. This can be done by adding a zero padding byte
     /// after the encoded data or with this option.
-    /// This option is not default enabled.
+    /// This option is not enabled by default.
     /// </summary>
     even_destination_size = impl::CHARLS_ENCODING_OPTIONS_EVEN_DESTINATION_SIZE,
 
     /// <summary>
     /// Add a comment (COM) segment with the content: "charls [version-number]" to the encoded data.
     /// Storing the used encoder version can be helpful for long term archival of images.
-    /// This option is not default enabled.
+    /// This option is not enabled by default.
     /// </summary>
     include_version_number = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_VERSION_NUMBER,
 
@@ -478,7 +478,7 @@ enum class encoding_options : unsigned
     /// The Java Advanced Imaging (JAI) JPEG-LS codec has a defect that causes it to use invalid
     /// preset coding parameters for these types of images.
     /// Most users of this codec are aware of this problem and have implemented a work-around.
-    /// This option is default enabled. Will not be default enabled in the next major version upgrade.
+    /// This option is not enabled by default.
     /// </summary>
     include_pc_parameters_jai = impl::CHARLS_ENCODING_OPTIONS_INCLUDE_PC_PARAMETERS_JAI
 };

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -342,7 +342,7 @@ private:
     int32_t near_lossless_{};
     charls::interleave_mode interleave_mode_{};
     charls::color_transformation color_transformation_{};
-    charls::encoding_options encoding_options_{encoding_options::include_pc_parameters_jai};
+    charls::encoding_options encoding_options_{};
     state state_{};
     jpeg_stream_writer writer_;
     jpegls_pc_parameters user_preset_coding_parameters_{};

--- a/unittest/documentation_test.cpp
+++ b/unittest/documentation_test.cpp
@@ -7,7 +7,6 @@
 
 #include <charls/charls.h>
 
-#include <tuple>
 #include <vector>
 
 #include "../test/portable_anymap_file.h"
@@ -27,10 +26,8 @@ std::vector<std::byte> decode_simple_8_bit_monochrome(const std::vector<std::byt
 {
     std::vector<std::byte> destination;
 
-    frame_info frame_info;
-    std::tie(frame_info, std::ignore) = jpegls_decoder::decode(source, destination);
-
-    if (frame_info.component_count != 1 || frame_info.bits_per_sample != 8)
+    if (const auto [frame_info, _] = jpegls_decoder::decode(source, destination);
+        frame_info.component_count != 1 || frame_info.bits_per_sample != 8)
         throw std::runtime_error("Not a 8 bit monochrome image");
 
     return destination;
@@ -65,7 +62,8 @@ std::vector<std::byte> encode_advanced_8_bit_monochrome(const std::vector<std::b
                                                         const uint32_t height)
 {
     jpegls_encoder encoder;
-    encoder.frame_info({width, height, 8, 1});
+    encoder.frame_info({width, height, 8, 1})
+           .encoding_options(encoding_options::include_version_number);
 
     std::vector<std::byte> destination(encoder.estimated_destination_size());
     encoder.destination(destination);

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -1437,7 +1437,8 @@ public:
         encoder.frame_info(frame_info);
 
         vector<byte> destination(encoder.estimated_destination_size());
-        encoder.destination(destination);
+        encoder.destination(destination).encoding_options(encoding_options::include_pc_parameters_jai);
+
         // Note: encoding_options::include_pc_parameters_jai is enabled by default (until the next major version)
 
         const size_t bytes_written{encoder.encode(source)};
@@ -1512,7 +1513,7 @@ public:
         encoder.destination(destination);
 
         const size_t bytes_written{encoder.encode(source)};
-        Assert::AreEqual(size_t{61}, bytes_written);
+        Assert::AreEqual(size_t{46}, bytes_written);
 
         destination.resize(bytes_written);
         const auto it{find_first_lse_segment(destination.cbegin(), destination.cend())};


### PR DESCRIPTION
3.0 is a major version and can contain breaking changes. Make include_pc_parameters_jai not default enabled. Java code that uses JAI is aware of this defect and decoders have workaround to prevent it. There is no need to enable this option by default during encoding anymore.