### PR TITLE
Fix countl_zero: replace __builtin_clzl with __builtin_clzll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.2] - 2023-5-?
+
+### Fixed
+
+- Fixed [#269](https://github.com/team-charls/charls/issues/269), Decoding doesn't work when compiled with mingw64.
+
 ## [2.4.1] - 2023-1-2
 
 ### Fixed
@@ -21,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Improved compatibility of public headers with C++20.
-- Switch order of APP8 and SOF55 markers during encoding to allign with user application data markers.
+- Switch order of APP8 and SOF55 markers during encoding to align with user application data markers.
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.4.1   | :white_check_mark: |
+| 2.4.2   | :white_check_mark: |
+| 2.4.1   | :x:                |
 | 2.4.0   | :x:                |
 | 2.3.4   | :x:                |
 | 2.3.3   | :x:                |

--- a/include/charls/version.h
+++ b/include/charls/version.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define CHARLS_VERSION_MAJOR 2
 #define CHARLS_VERSION_MINOR 4
-#define CHARLS_VERSION_PATCH 1
+#define CHARLS_VERSION_PATCH 2
 
 /// <summary>
 /// Returns the version of CharLS in the semver format "major.minor.patch" or "major.minor.patch-pre_release"

--- a/src/util.h
+++ b/src/util.h
@@ -487,7 +487,7 @@ auto countl_zero(const T value) noexcept -> std::enable_if_t<is_uint_v<64, T>, i
     if (value == 0)
         return 64;
 
-    return __builtin_clzl(value);
+    return __builtin_clzll(value);
 }
 
 /// <summary>


### PR DESCRIPTION
GCC\Clang provide 3 overloads for __builtin_clz:
int __builtin_clz (unsigned int x)
int __builtin_clzl (unsigned long)
int __builtin_clzll (unsigned long long)

GCC and Clang can be used to build CharLS for Linux\macOS (LP64 data model) and Windows (LLP64 data model).

Using __builtin_clzl (unsigned long) for 64 bits works for LP64 (long is 64 bits) but fails for the LLP64 data model (long is 32 bits) __builtin_clzll (unsigned long long) works for both the LP64 and the LLP64 data model (unsigned long long int is always at least 64 bits)