### PR TITLE
Resolve clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,8 @@
 # -clang-diagnostic-pragma-once-outside-header => Rationale: Generates false warnings for usage in header files
 # -clang-diagnostic-unused-const-variable => Rationale: false warnings for constexpr in .h files
 # -clang-diagnostic-unused-command-line-argument => Rationale: false warning about option passed to MSVC
-# -clang-diagnostic-declaration-after-statement => Rationale: Target is C14 and higher
+# -clang-diagnostic-declaration-after-statement => Rationale: Target is C17 and higher
+# -clang-diagnostic-unsafe-buffer-usage => Rationale: Too many false warnings, access is verified with other tools.
 # -clang-analyzer-core.NonNullParamChecker => Rationale: cannot be effective disabled, already checked by other checkers.
 # -misc-non-private-member-variables-in-classes => Rationale: design can be ok, manual review is better
 # -modernize-use-trailing-return-type => Rationale: A style recommendation, this style is selected for CharLS
@@ -75,6 +76,7 @@ Checks:          '*,
                   -clang-diagnostic-unused-const-variable,
                   -clang-diagnostic-unused-command-line-argument,
                   -clang-diagnostic-declaration-after-statement,
+                  -clang-diagnostic-unsafe-buffer-usage,
                   -clang-analyzer-core.NonNullParamChecker,
                   -misc-non-private-member-variables-in-classes,
                   -modernize-use-trailing-return-type,

--- a/CharLS.sln.DotSettings
+++ b/CharLS.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyClangDiagnosticExitTimeDestructors/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyClangDiagnosticMissingBraces/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyClangDiagnosticSwitchEnum/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyClangDiagnosticUnsafeBufferUsage/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyClangDiagnosticUnusedConstVariable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyCppcoreguidelinesAvoidMagicNumbers/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyCppcoreguidelinesInitVariables/@EntryIndexedValue">DO_NOT_SHOW</s:String>

--- a/src/default_traits.h
+++ b/src/default_traits.h
@@ -29,13 +29,13 @@ struct default_traits final
     static constexpr bool fixed_bits_per_pixel{};
 
     int32_t maximum_sample_value;
-    const int32_t near_lossless;
-    const int32_t range;
-    const int32_t quantized_bits_per_pixel;
-    const int32_t bits_per_pixel;
-    const int32_t limit;
-    const int32_t reset_threshold;
-    const int32_t quantization_range;
+    int32_t near_lossless;
+    int32_t range;
+    int32_t quantized_bits_per_pixel;
+    int32_t bits_per_pixel;
+    int32_t limit;
+    int32_t reset_threshold;
+    int32_t quantization_range;
 
     default_traits(const int32_t arg_maximum_sample_value, const int32_t arg_near_lossless,
                    const int32_t reset = default_reset_value) noexcept :

--- a/src/process_decoded_line.h
+++ b/src/process_decoded_line.h
@@ -116,8 +116,8 @@ class process_decoded_transformed final : public process_decoded_line
 public:
     process_decoded_transformed(std::byte* destination, const size_t stride, const frame_info& info,
                                 const coding_parameters& parameters, TransformType transform) :
-        frame_info_{info},
-        parameters_{parameters},
+        frame_info_{&info},
+        parameters_{&parameters},
         stride_{stride},
         temp_line_(static_cast<size_t>(info.component_count) * info.width),
         buffer_(static_cast<size_t>(info.component_count) * info.width * sizeof(size_type)),
@@ -136,9 +136,9 @@ public:
 
     void decode_transform(const void* source, void* destination, const size_t pixel_count, const size_t byte_stride) noexcept
     {
-        if (frame_info_.component_count == 3)
+        if (frame_info_->component_count == 3)
         {
-            if (parameters_.interleave_mode == interleave_mode::sample)
+            if (parameters_->interleave_mode == interleave_mode::sample)
             {
                 transform_line(static_cast<triplet<size_type>*>(destination), static_cast<const triplet<size_type>*>(source),
                                pixel_count, inverse_transform_);
@@ -149,14 +149,14 @@ public:
                                           static_cast<triplet<size_type>*>(destination), pixel_count, inverse_transform_);
             }
         }
-        else if (frame_info_.component_count == 4)
+        else if (frame_info_->component_count == 4)
         {
-            if (parameters_.interleave_mode == interleave_mode::sample)
+            if (parameters_->interleave_mode == interleave_mode::sample)
             {
                 transform_line(static_cast<quad<size_type>*>(destination), static_cast<const quad<size_type>*>(source),
                                pixel_count, inverse_transform_);
             }
-            else if (parameters_.interleave_mode == interleave_mode::line)
+            else if (parameters_->interleave_mode == interleave_mode::line)
             {
                 transform_line_to_quad(static_cast<const size_type*>(source), byte_stride,
                                        static_cast<quad<size_type>*>(destination), pixel_count, inverse_transform_);
@@ -167,9 +167,9 @@ public:
 private:
     using size_type = typename TransformType::size_type;
 
-    const frame_info& frame_info_;
-    const coding_parameters& parameters_;
-    const size_t stride_;
+    const frame_info* frame_info_;
+    const coding_parameters* parameters_;
+    size_t stride_;
     std::vector<size_type> temp_line_;
     std::vector<uint8_t> buffer_;
     TransformType transform_;

--- a/src/process_encoded_line.h
+++ b/src/process_encoded_line.h
@@ -212,8 +212,8 @@ class process_encoded_transformed final : public process_encoded_line
 public:
     process_encoded_transformed(const std::byte* const source, const size_t stride, const frame_info& info,
                                 const coding_parameters& parameters, TransformType transform) :
-        frame_info_{info},
-        parameters_{parameters},
+        frame_info_{&info},
+        parameters_{&parameters},
         stride_{stride},
         temp_line_(static_cast<size_t>(info.component_count) * info.width),
         buffer_(static_cast<size_t>(info.component_count) * info.width * sizeof(size_type)),
@@ -234,9 +234,9 @@ public:
     void encode_transform(const void* source, void* destination, const size_t pixel_count,
                           const size_t destination_stride) noexcept
     {
-        if (frame_info_.component_count == 3)
+        if (frame_info_->component_count == 3)
         {
-            if (parameters_.interleave_mode == interleave_mode::sample)
+            if (parameters_->interleave_mode == interleave_mode::sample)
             {
                 transform_line(static_cast<triplet<size_type>*>(destination), static_cast<const triplet<size_type>*>(source),
                                pixel_count, transform_, mask_);
@@ -247,14 +247,14 @@ public:
                                           static_cast<size_type*>(destination), destination_stride, transform_, mask_);
             }
         }
-        else if (frame_info_.component_count == 4)
+        else if (frame_info_->component_count == 4)
         {
-            if (parameters_.interleave_mode == interleave_mode::sample)
+            if (parameters_->interleave_mode == interleave_mode::sample)
             {
                 transform_line(static_cast<quad<size_type>*>(destination), static_cast<const quad<size_type>*>(source),
                                pixel_count, transform_, mask_);
             }
-            else if (parameters_.interleave_mode == interleave_mode::line)
+            else if (parameters_->interleave_mode == interleave_mode::line)
             {
                 transform_quad_to_line(static_cast<const quad<size_type>*>(source), pixel_count,
                                        static_cast<size_type*>(destination), destination_stride, transform_, mask_);
@@ -265,9 +265,9 @@ public:
 private:
     using size_type = typename TransformType::size_type;
 
-    const frame_info& frame_info_;
-    const coding_parameters& parameters_;
-    const size_t stride_;
+    const frame_info* frame_info_;
+    const coding_parameters* parameters_;
+    size_t stride_;
     std::vector<size_type> temp_line_;
     std::vector<uint8_t> buffer_;
     TransformType transform_;


### PR DESCRIPTION
Update the code to resolve warnings reported by the latest version of clang-tidy: Remove const for class members (class was never copied, but using const for data members is a-typical) Replace const reference data members with pointers (C++ core guidelines recommendation).

Due to many low level operations pointers are used a lot, disable the warning about unsafe buffers as this warning is not useful in our context.