### PR TITLE
Update for Visual Studio 2022 17.8.0

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@
 # -hicpp-signed-bitwise => Rationale: Bad test, types are checked, not values.
 # -clang-diagnostic-c++98-compat* => Rationale: CharLS targets C++17
 # -clang-diagnostic-c++98-c++11-compat => Rationale: CharLS targets C++17
+# -clang-diagnostic-c++98-c++11-c++14-compat => Rationale: CharLS targets C++17
 # -clang-diagnostic-pre-c++14-compat => Rationale: CharLS targets C++17
 # -clang-diagnostic-pre-c++17-compat => Rationale: CharLS targets C++17
 # -clang-diagnostic-unused-macros => Rationale: Macros defined in header are reported as problem
@@ -66,6 +67,7 @@ Checks:          '*,
                   -hicpp-named-parameter,
                   -clang-diagnostic-c++98-compat*,
                   -clang-diagnostic-c++98-c++11-compat,
+                  -clang-diagnostic-c++98-c++11-c++14-compat,
                   -clang-diagnostic-pre-c++14-compat,
                   -clang-diagnostic-pre-c++17-compat,
                   -clang-diagnostic-unused-macros,

--- a/CharLS.sln.DotSettings
+++ b/CharLS.sln.DotSettings
@@ -43,6 +43,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/Rules/=Union_0020members/@EntryIndexedValue">&lt;NamingElement Priority="12"&gt;&lt;Descriptor Static="Indeterminate" Constexpr="Indeterminate" Const="Indeterminate" Volatile="Indeterminate" Accessibility="NOT_APPLICABLE"&gt;&lt;type Name="union member" /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="False" Prefix="" Suffix="" Style="aa_bb" /&gt;&lt;/NamingElement&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/CppEnableCppCli/IsEnabled/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=than/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=alphatest/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=anymap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=banny/@EntryIndexedValue">True</s:Boolean>
@@ -93,6 +94,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NODISCARD/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NOLINTNEXTLINE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=opto/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=oversized/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ptype/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=qbpp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RGBRGBRGB/@EntryIndexedValue">True</s:Boolean>

--- a/default.ruleset
+++ b/default.ruleset
@@ -7,7 +7,6 @@
     <Rule Id="C26446" Action="None" />
     <Rule Id="C26459" Action="None" />
     <Rule Id="C26472" Action="None" />
-    <Rule Id="C26478" Action="None" />
     <Rule Id="C26481" Action="None" />
     <Rule Id="C26482" Action="None" />
     <Rule Id="C26485" Action="None" />

--- a/default.ruleset.md
+++ b/default.ruleset.md
@@ -15,9 +15,6 @@ Rationale: gsl:span() cannot be used. Update to std:span when available (C++20).
 C26472: Don't use static_cast for arithmetic conversions
  -> Rationale: can only be solved with gsl::narrow_cast
 
-C26478: Don't use std::move on constant variables. (es.56).
--> Rationale: false warnings [Visual Studio 2022 17.7.0, note: fixed in 17.8.0]
-
 C26481: Do not pass an array as a single pointer.
 -> Rationale: gsl::span is not available.
 

--- a/include/charls/api_abi.h
+++ b/include/charls/api_abi.h
@@ -22,7 +22,7 @@
 #define CHARLS_API_IMPORT_EXPORT __declspec(dllimport)
 #endif
 
-// Ensure that the exported functions of a 32 bit Windows DLL use the __stdcall convention.
+// Ensure that the exported functions of a 32-bit Windows DLL use the __stdcall convention.
 #if defined(_M_IX86) || defined(__MINGW32__)
 #define CHARLS_API_CALLING_CONVENTION __stdcall
 #else

--- a/src/conditional_static_cast.h
+++ b/src/conditional_static_cast.h
@@ -5,7 +5,7 @@
 
 #include <type_traits>
 
-// Some cross platform builds require an explicit static_cast, while others don't.
+// Some cross-platform builds require an explicit static_cast, while others don't.
 // These templates can be used to keep code compatible with the GCC useless-cast warning and ReSharper.
 
 namespace charls {

--- a/src/jpeg_marker_code.h
+++ b/src/jpeg_marker_code.h
@@ -16,52 +16,118 @@ namespace charls {
 // 0x4F - 0x6F, 0x90 - 0x93 are defined in ISO/IEC 15444-1: JPEG 2000
 
 constexpr std::byte jpeg_marker_start_byte{0xFF};
-constexpr uint8_t jpeg_restart_marker_base{0xD0}; // RSTm: Marks the next restart interval (range is D0..D7)
+constexpr uint8_t jpeg_restart_marker_base{0xD0}; // RSTm: Marks the next restart interval (range is D0 to D7)
 constexpr uint32_t jpeg_restart_marker_range{8};
 
 enum class jpeg_marker_code : uint8_t
 {
-    start_of_image = 0xD8,          // SOI: Marks the start of an image.
-    end_of_image = 0xD9,            // EOI: Marks the end of an image.
-    start_of_scan = 0xDA,           // SOS: Marks the start of scan.
-    define_restart_interval = 0xDD, // DRI: Defines the restart interval used in succeeding scans.
+    /// <summary>SOI: Marks the start of an image.</summary>
+    start_of_image = 0xD8,
 
-    // The following markers are defined in ISO/IEC 10918-1 | ITU T.81.
-    start_of_frame_baseline_jpeg = 0xC0,       // SOF_0:  Marks the start of a baseline jpeg encoded frame.
-    start_of_frame_extended_sequential = 0xC1, // SOF_1:  Marks the start of a extended sequential Huffman encoded frame.
-    start_of_frame_progressive = 0xC2,         // SOF_2:  Marks the start of a progressive Huffman encoded frame.
-    start_of_frame_lossless = 0xC3,            // SOF_3:  Marks the start of a lossless Huffman encoded frame.
-    start_of_frame_differential_sequential =
-        0xC5, // SOF_5:  Marks the start of a differential sequential Huffman encoded frame.
-    start_of_frame_differential_progressive =
-        0xC6, // SOF_6:  Marks the start of a differential progressive Huffman encoded frame.
-    start_of_frame_differential_lossless = 0xC7, // SOF_7:  Marks the start of a differential lossless Huffman encoded frame.
-    start_of_frame_extended_arithmetic = 0xC9, // SOF_9:  Marks the start of a extended sequential arithmetic encoded frame.
-    start_of_frame_progressive_arithmetic = 0xCA, // SOF_10: Marks the start of a progressive arithmetic encoded frame.
-    start_of_frame_lossless_arithmetic = 0xCB,    // SOF_11: Marks the start of a lossless arithmetic encoded frame.
+    /// <summary>EOI: Marks the end of an image.</summary>
+    end_of_image = 0xD9,
 
-    // The following markers are defined in ISO/IEC 14495-1 | ITU T.87.
-    start_of_frame_jpegls = 0xF7,          // SOF_55: Marks the start of a JPEG-LS encoded frame.
-    jpegls_preset_parameters = 0xF8,       // LSE:    Marks the start of a JPEG-LS preset parameters segment.
-    start_of_frame_jpegls_extended = 0xF9, // SOF_57: Marks the start of a JPEG-LS extended (ISO/IEC 14495-2) encoded frame.
+    /// <summary>SOS: Marks the start of scan.</summary>
+    start_of_scan = 0xDA,
 
-    application_data0 = 0xE0,  // APP0:  Application data 0: used for JFIF header.
-    application_data1 = 0xE1,  // APP1:  Application data 1: used for EXIF or XMP header.
-    application_data2 = 0xE2,  // APP2:  Application data 2: used for ICC profile.
-    application_data3 = 0xE3,  // APP3:  Application data 3: used for meta info
-    application_data4 = 0xE4,  // APP4:  Application data 4.
-    application_data5 = 0xE5,  // APP5:  Application data 5.
-    application_data6 = 0xE6,  // APP6:  Application data 6.
-    application_data7 = 0xE7,  // APP7:  Application data 7: used for HP color-space info.
-    application_data8 = 0xE8,  // APP8:  Application data 8: used for HP color-transformation info or SPIFF header.
-    application_data9 = 0xE9,  // APP9:  Application data 9.
-    application_data10 = 0xEA, // APP10: Application data 10.
-    application_data11 = 0xEB, // APP11: Application data 11.
-    application_data12 = 0xEC, // APP12: Application data 12: used for Picture info.
-    application_data13 = 0xED, // APP13: Application data 13: used by PhotoShop IRB
-    application_data14 = 0xEE, // APP14: Application data 14: used by Adobe
-    application_data15 = 0xEF, // APP15: Application data 15.
-    comment = 0xFE             // COM:   Comment block.
+    /// <summary>DRI: Defines the restart interval used in succeeding scans.</summary>
+    define_restart_interval = 0xDD,
+
+
+    // The following markers are defined in ISO/IEC 10918-1 | ITU T.81 (general JPEG standard).
+
+    /// <summary>SOF_0: Marks the start of a baseline jpeg encoded frame.</summary>
+    start_of_frame_baseline_jpeg = 0xC0,
+
+    /// <summary>SOF_1: Marks the start of an extended sequential Huffman encoded frame.</summary>
+    start_of_frame_extended_sequential = 0xC1,
+
+    /// <summary>SOF_2: Marks the start of a progressive Huffman encoded frame.</summary>
+    start_of_frame_progressive = 0xC2, //
+
+    /// <summary>SOF_3: Marks the start of a lossless Huffman encoded frame.</summary>
+    start_of_frame_lossless = 0xC3,
+
+    /// <summary>SOF_5: Marks the start of a differential sequential Huffman encoded frame.</summary>
+    start_of_frame_differential_sequential = 0xC5,
+
+    /// <summary>SOF_6: Marks the start of a differential progressive Huffman encoded frame.</summary>
+    start_of_frame_differential_progressive = 0xC6,
+
+    /// <summary>SOF_7: Marks the start of a differential lossless Huffman encoded frame.</summary>
+    start_of_frame_differential_lossless = 0xC7,
+
+    /// <summary>SOF_9: Marks the start of an extended sequential arithmetic encoded frame.</summary>
+    start_of_frame_extended_arithmetic = 0xC9,
+
+    /// <summary>SOF_10: Marks the start of a progressive arithmetic encoded frame.</summary>
+    start_of_frame_progressive_arithmetic = 0xCA,
+
+    /// <summary>SOF_11: Marks the start of a lossless arithmetic encoded frame.</summary>
+    start_of_frame_lossless_arithmetic = 0xCB,
+
+
+    // The following markers are defined in ISO/IEC 14495-1 | ITU T.87. (JPEG-LS standard)
+
+    /// <summary>SOF_55: Marks the start of a JPEG-LS encoded frame.</summary>
+    start_of_frame_jpegls = 0xF7,
+
+    /// <summary>LSE: Marks the start of a JPEG-LS preset parameters segment.</summary>
+    jpegls_preset_parameters = 0xF8,
+
+    /// <summary>SOF_57: Marks the start of a JPEG-LS extended (ISO/IEC 14495-2) encoded frame.</summary>
+    start_of_frame_jpegls_extended = 0xF9,
+
+    /// <summary>APP0: Application data 0: used for JFIF header.</summary>
+    application_data0 = 0xE0,
+
+    /// <summary>APP1: Application data 1: used for EXIF or XMP header.</summary>
+    application_data1 = 0xE1,
+
+    /// <summary>APP2: Application data 2: used for ICC profile.</summary>
+    application_data2 = 0xE2,
+
+    /// <summary>APP3: Application data 3: used for meta info</summary>
+    application_data3 = 0xE3,
+
+    /// <summary>APP4: Application data 4.</summary>
+    application_data4 = 0xE4,
+
+    /// <summary>APP5: Application data 5.</summary>
+    application_data5 = 0xE5,
+
+    /// <summary>APP6: Application data 6.</summary>
+    application_data6 = 0xE6,
+
+    /// <summary>APP7: Application data 7: used for HP color-space info.</summary>
+    application_data7 = 0xE7,
+
+    /// <summary>APP8: Application data 8: used for HP color-transformation info or SPIFF header.</summary>
+    application_data8 = 0xE8,
+
+    /// <summary>APP9: Application data 9.</summary>
+    application_data9 = 0xE9,
+
+    /// <summary>APP10: Application data 10.</summary>
+    application_data10 = 0xEA,
+
+    /// <summary>APP11: Application data 11.</summary>
+    application_data11 = 0xEB,
+
+    /// <summary>APP12: Application data 12: used for Picture info.</summary>
+    application_data12 = 0xEC,
+
+    /// <summary>APP13: Application data 13: used by PhotoShop IRB</summary>
+    application_data13 = 0xED,
+
+    /// <summary>APP14: Application data 14: used by Adobe</summary>
+    application_data14 = 0xEE,
+
+    /// <summary>APP15: Application data 15.</summary>
+    application_data15 = 0xEF,
+
+    /// <summary>COM: Comment block.</summary>
+    comment = 0xFE
 };
 
 } // namespace charls

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -54,7 +54,7 @@ void jpeg_stream_reader::read_header(spiff_header* header, bool* spiff_header_fo
         if (UNLIKELY(read_next_marker_code() != jpeg_marker_code::start_of_image))
             throw_jpegls_error(jpegls_errc::start_of_image_marker_not_found);
 
-        component_ids_.reserve(4); // expect 4 components or less.
+        component_ids_.reserve(4); // expect 4 components or fewer.
         state_ = state::header_section;
     }
 
@@ -453,7 +453,7 @@ void jpeg_stream_reader::read_start_of_scan_segment()
     check_minimal_segment_size(1);
     const size_t component_count_in_scan{read_uint8()};
 
-    // ISO 10918-1, B2.3. defines the limits for the number of image components parameter in a SOS.
+    // ISO 10918-1, B2.3. defines the limits for the number of image components parameter in an SOS.
     if (UNLIKELY(component_count_in_scan < 1U || component_count_in_scan > 4U ||
                  component_count_in_scan > static_cast<size_t>(frame_info_.component_count)))
         throw_jpegls_error(jpegls_errc::invalid_parameter_component_count);
@@ -609,7 +609,7 @@ void jpeg_stream_reader::try_read_hp_color_transform_segment()
 {
     ASSERT(segment_data_.size() == 5);
 
-    if (const array mrfx_tag{byte{'m'}, byte{'r'}, byte{'f'}, byte{'x'}}; // mrfx = xfrm (in big endian) = colorXFoRM
+    if (constexpr array mrfx_tag{byte{'m'}, byte{'r'}, byte{'f'}, byte{'x'}}; // mrfx = xfrm (in big endian) = colorXFoRM
         !equal(mrfx_tag.cbegin(), mrfx_tag.cend(), read_bytes(mrfx_tag.size()).begin()))
         return;
 
@@ -622,8 +622,8 @@ void jpeg_stream_reader::try_read_hp_color_transform_segment()
         parameters_.transformation = static_cast<color_transformation>(transformation);
         return;
 
-    case 4: // RgbAsYuvLossy (The standard lossy RGB to YCbCr transform used in JPEG.)
-    case 5: // Matrix (transformation is controlled using a matrix that is also stored in the segment.
+    case 4: // RgbAsYuvLossy: the standard lossy RGB to YCbCr transform used in JPEG.
+    case 5: // Matrix: transformation is controlled using a matrix that is also stored in the segment.
         throw_jpegls_error(jpegls_errc::color_transform_not_supported);
 
     default:
@@ -636,7 +636,7 @@ USE_DECL_ANNOTATIONS void jpeg_stream_reader::try_read_spiff_header_segment(spif
 {
     ASSERT(segment_data_.size() >= 30);
 
-    if (const array spiff_tag{byte{'S'}, byte{'P'}, byte{'I'}, byte{'F'}, byte{'F'}, byte{0}};
+    if (constexpr array spiff_tag{byte{'S'}, byte{'P'}, byte{'I'}, byte{'F'}, byte{'F'}, byte{0}};
         !equal(spiff_tag.cbegin(), spiff_tag.cend(), read_bytes(spiff_tag.size()).begin()))
     {
         header = {};
@@ -648,7 +648,7 @@ USE_DECL_ANNOTATIONS void jpeg_stream_reader::try_read_spiff_header_segment(spif
     {
         header = {};
         spiff_header_found = false;
-        return; // Treat unknown versions as if the SPIFF header doesn't exists.
+        return; // Treat unknown versions as if the SPIFF header doesn't exist.
     }
     skip_byte(); // low version
 

--- a/src/lossless_traits.h
+++ b/src/lossless_traits.h
@@ -10,7 +10,7 @@
 
 namespace charls {
 
-// Optimized trait classes for lossless compression of 8 bit color and 8/16 bit monochrome images.
+// Optimized trait classes for lossless compression of 8-bit color and 8/16 bit monochrome images.
 // This class assumes MaximumSampleValue correspond to a whole number of bits, and no custom ResetValue is set when encoding.
 // The point of this is to have the most optimized code for the most common and most demanding scenario.
 template<typename SampleType, int32_t BitsPerPixel>

--- a/src/scan_codec.h
+++ b/src/scan_codec.h
@@ -37,7 +37,7 @@ template<typename Traits>
 const int8_t* initialize_quantization_lut(const Traits& traits, const int32_t threshold1, const int32_t threshold2,
                                           const int32_t threshold3, std::vector<int8_t>& quantization_lut)
 {
-    // For lossless mode with default parameters, we have precomputed the look up table for bit counts 8, 10, 12 and 16.
+    // For lossless mode with default parameters, we have precomputed the lookup table for bit counts 8, 10, 12 and 16.
     if (precomputed_quantization_lut_available(traits, threshold1, threshold2, threshold3))
     {
         if constexpr (Traits::fixed_bits_per_pixel)

--- a/src/scan_encoder.h
+++ b/src/scan_encoder.h
@@ -84,7 +84,7 @@ protected:
         }
         else
         {
-            // Add as much bits in the remaining space as possible and flush.
+            // Add as many bits in the remaining space as possible and flush.
             bit_buffer_ |= bits >> -free_bit_count_;
             flush();
 


### PR DESCRIPTION
- Exclude clang-tidy warning about C++14 (used C++ standard is now 17)
- Remove exclusion for false positive MSVC warning C26478 (fixed in 17.8.0)
- Grammar fixes