### PR TITLE
Add support to import CharLS as a C++20 module

### DIFF
--- a/include/charls/annotations.h
+++ b/include/charls/annotations.h
@@ -6,7 +6,9 @@
 #ifdef _MSC_VER
 
 // Use the Microsoft Source Code Annotation Language when compiling with the MSVC compiler.
+#ifndef CHARLS_BUILD_AS_CPP_MODULE
 #include <sal.h>
+#endif
 
 #define CHARLS_IN _In_
 #define CHARLS_IN_OPT _In_opt_

--- a/include/charls/api_abi.h
+++ b/include/charls/api_abi.h
@@ -50,6 +50,12 @@
 #define CHARLS_NOEXCEPT noexcept
 #define CHARLS_C_VOID
 
+#ifdef CHARLS_BUILD_AS_CPP_MODULE
+#define CHARLS_EXPORT export
+#else
+#define CHARLS_EXPORT
+#endif
+
 #else
 
 #define CHARLS_FINAL

--- a/include/charls/charls.ixx
+++ b/include/charls/charls.ixx
@@ -1,0 +1,20 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+module;
+
+#define CHARLS_BUILD_AS_CPP_MODULE
+
+#include <sal.h>
+#include <cstddef>
+#include <cstdint>
+#include <system_error>
+#include <functional>
+#include <memory>
+#include <utility>
+
+export module charls;
+
+#include "charls_jpegls_decoder.h"
+#include "charls_jpegls_encoder.h"
+#include "version.h"

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -7,9 +7,13 @@
 #include "validate_spiff_header.h"
 
 #ifdef __cplusplus
+
+#ifndef CHARLS_BUILD_AS_CPP_MODULE
 #include <functional>
 #include <memory>
 #include <utility>
+#endif
+
 #else
 #include <stddef.h>
 #endif
@@ -219,6 +223,7 @@ charls_jpegls_decoder_at_application_data(CHARLS_IN charls_jpegls_decoder* decod
 
 } // extern "C"
 
+CHARLS_EXPORT
 namespace charls {
 
 /// <summary>

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -271,6 +271,7 @@ charls_jpegls_encoder_rewind(CHARLS_IN charls_jpegls_encoder* encoder) CHARLS_NO
 
 } // extern "C"
 
+CHARLS_EXPORT
 namespace charls {
 
 /// <summary>

--- a/include/charls/jpegls_error.h
+++ b/include/charls/jpegls_error.h
@@ -15,6 +15,7 @@ CHARLS_API_IMPORT_EXPORT const char* CHARLS_API_CALLING_CONVENTION charls_get_er
 #ifdef __cplusplus
 }
 
+CHARLS_EXPORT
 namespace charls {
 
 [[nodiscard]] inline const std::error_category& jpegls_category() noexcept

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -8,9 +8,11 @@
 
 #ifdef __cplusplus
 
+#ifndef CHARLS_BUILD_AS_CPP_MODULE
 #include <cstddef>
 #include <cstdint>
 #include <system_error>
+#endif
 
 namespace charls::impl {
 
@@ -164,6 +166,7 @@ enum charls_spiff_entry_tag
 #ifdef __cplusplus
 } // namespace charls::impl
 
+CHARLS_EXPORT
 namespace charls {
 
 /// <summary>
@@ -802,6 +805,7 @@ enum class spiff_entry_tag : uint32_t
 
 } // namespace charls
 
+CHARLS_EXPORT
 template<>
 struct std::is_error_code_enum<charls::jpegls_errc> final : std::true_type
 {
@@ -952,6 +956,7 @@ using charls_at_application_data_handler = int32_t(CHARLS_API_CALLING_CONVENTION
                                                                                    const void* data, size_t size,
                                                                                    void* user_context);
 
+CHARLS_EXPORT
 namespace charls {
 
 using spiff_header = charls_spiff_header;


### PR DESCRIPTION
Add a charls.ixx file that external project can include as a source file to import CharLS as a module like: import charls;

External projects need to include charls.ixx and compile it with their compiler settings and in C++20 mode or higher.