### PR TITLE
Pass VCToolsVersion=14.38.33130 to MSBuild for the CI pipeline to ens…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
       maximumCpuCount: true
-      msbuildArgs: -p:CHARLS_PROFILE=true -p:CHARLS_ALL_WARNINGS=true
+      msbuildArgs: -p:CHARLS_PROFILE=true -p:CHARLS_ALL_WARNINGS=true -p:VCToolsVersion=14.38.33130
 
   - task: VSTest@2
     inputs:

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -23,7 +23,7 @@ struct charls_jpegls_decoder final
         check_argument(source.data() || source.empty());
         check_operation(state_ == state::initial);
 
-        reader_.source({source.data(), source.size()});
+        reader_.source(source);
         state_ = state::source_set;
     }
 

--- a/src/span.h
+++ b/src/span.h
@@ -4,13 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <array>
 
 #include "util.h"
 
 namespace charls {
 
 // Replacement for std::to_address, which is not available in C++17.
-template<typename Ptr> 
+template<typename Ptr>
 constexpr auto to_address(const Ptr& it)
 {
     return &*it;
@@ -33,6 +34,11 @@ public:
 
     template<typename It>
     constexpr span(It first, It last) noexcept : span(first, last - first)
+    {
+    }
+
+    template<typename OtherType, size_t Size>
+    constexpr span(const std::array<OtherType, Size>& data) noexcept : data_{data.data()}, size_{Size}
     {
     }
 

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -55,11 +55,11 @@ public:
 
     TEST_METHOD(read_header_from_buffer_not_starting_with_ff_throws) // NOLINT
     {
-        array buffer{byte{0x0F}, byte{0xFF}, byte{0xD8},
-                     byte{0xFF}, byte{0xFF}, byte{0xDA}}; // 0xDA = SOS: Marks the start of scan.
+        constexpr array buffer{byte{0x0F}, byte{0xFF}, byte{0xD8},
+                               byte{0xFF}, byte{0xFF}, byte{0xDA}}; // 0xDA = SOS: Marks the start of scan.
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::jpeg_marker_start_byte_not_found, [&reader] { reader.read_header(); });
     }
@@ -74,12 +74,12 @@ public:
 
     TEST_METHOD(read_header_with_jpegls_extended_frame_throws) // NOLINT
     {
-        array<byte, 6> buffer{
+        constexpr array<byte, 6> buffer{
             byte{0xFF}, byte{0xD8}, byte{0xFF},
             byte{0xF9}}; // 0xF9 = SOF_57: Marks the start of a JPEG-LS extended (ISO/IEC 14495-2) encoded frame.
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::encoding_not_supported, [&reader] { reader.read_header(); });
     }
@@ -111,36 +111,36 @@ public:
 
     TEST_METHOD(read_header_with_too_small_jpegls_preset_parameter_segment_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
-                           byte{0xF8}, // LSE: Marks the start of a JPEG-LS preset parameters segment.
-                           byte{0x00}, byte{0x02}, byte{0x01}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
+                               byte{0xF8}, // LSE: Marks the start of a JPEG-LS preset parameters segment.
+                               byte{0x00}, byte{0x02}, byte{0x01}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_too_small_jpegls_preset_parameter_segment_with_coding_parameters_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
-                           byte{0xF8}, // LSE: Marks the start of a JPEG-LS preset parameters segment.
-                           byte{0x00}, byte{0x0A}, byte{0x01}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
+                               byte{0xF8}, // LSE: Marks the start of a JPEG-LS preset parameters segment.
+                               byte{0x00}, byte{0x0A}, byte{0x01}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_too_large_jpegls_preset_parameter_segment_with_coding_parameters_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
-                           byte{0xF8}, // LSE: Marks the start of a JPEG-LS preset parameters segment.
-                           byte{0x00}, byte{0x0C}, byte{0x01}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
+                               byte{0xF8}, // LSE: Marks the start of a JPEG-LS preset parameters segment.
+                               byte{0x00}, byte{0x0C}, byte{0x01}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
@@ -157,36 +157,36 @@ public:
 
     TEST_METHOD(read_header_with_too_small_segment_size_throws) // NOLINT
     {
-        const array buffer{
+        constexpr array buffer{
             byte{0xFF}, byte{0xD8}, byte{0xFF}, byte{0xF7},  // SOF_55: Marks the start of JPEG-LS extended scan.
             byte{0x00}, byte{0x01}, byte{0xFF}, byte{0xDA}}; // SOS: Marks the start of scan.
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_too_small_start_of_frame_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8},
-                           byte{0xFF}, byte{0xF7}, // SOF_55: Marks the start of JPEG-LS extended scan.
-                           byte{0x00}, byte{0x07}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8},
+                               byte{0xFF}, byte{0xF7}, // SOF_55: Marks the start of JPEG-LS extended scan.
+                               byte{0x00}, byte{0x07}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_too_small_start_of_frame_in_component_info_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8},
-                           byte{0xFF}, byte{0xF7}, // SOF_55: Marks the start of JPEG-LS extended scan.
-                           byte{0x00}, byte{0x07}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8},
+                               byte{0xFF}, byte{0xF7}, // SOF_55: Marks the start of JPEG-LS extended scan.
+                               byte{0x00}, byte{0x07}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
@@ -325,56 +325,56 @@ public:
 
     TEST_METHOD(read_header_with_too_small_start_of_scan_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8},
-                           byte{0xFF}, byte{0xF7}, // SOF_55: Marks the start of JPEG-LS extended scan.
-                           byte{},     byte{0x08}, // size
-                           byte{0x08},             // bits per sample
-                           byte{},     byte{0x01}, // width
-                           byte{},     byte{0x01}, // height
-                           byte{0x01},             // component count
-                           byte{0xFF}, byte{0xDA}, // SOS
-                           byte{},     byte{0x03}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8},
+                               byte{0xFF}, byte{0xF7}, // SOF_55: Marks the start of JPEG-LS extended scan.
+                               byte{},     byte{0x08}, // size
+                               byte{0x08},             // bits per sample
+                               byte{},     byte{0x01}, // width
+                               byte{},     byte{0x01}, // height
+                               byte{0x01},             // component count
+                               byte{0xFF}, byte{0xDA}, // SOS
+                               byte{},     byte{0x03}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_too_small_start_of_scan_component_count_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
-                           byte{0xF7},             // SOF_55: Marks the start of JPEG-LS extended scan.
-                           byte{0x00}, byte{0x08}, // size
-                           byte{0x08},             // bits per sample
-                           byte{0x00}, byte{0x01}, // width
-                           byte{0x00}, byte{0x01}, // height
-                           byte{0x01},             // component count
-                           byte{0xFF}, byte{0xDA}, // SOS
-                           byte{0x00}, byte{0x07}, byte{0x01}};
+        constexpr array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF},
+                               byte{0xF7},             // SOF_55: Marks the start of JPEG-LS extended scan.
+                               byte{0x00}, byte{0x08}, // size
+                               byte{0x08},             // bits per sample
+                               byte{0x00}, byte{0x01}, // width
+                               byte{0x00}, byte{0x01}, // height
+                               byte{0x01},             // component count
+                               byte{0xFF}, byte{0xDA}, // SOS
+                               byte{0x00}, byte{0x07}, byte{0x01}};
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::invalid_marker_segment_size, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_directly_end_of_image_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF}, byte{0xD9}}; // 0xD9 = EOI
+        constexpr array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF}, byte{0xD9}}; // 0xD9 = EOI
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::unexpected_end_of_image_marker, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_with_duplicate_start_of_image_throws) // NOLINT
     {
-        const array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF}, byte{0xD8}}; // 0xD8 = SOI.
+        constexpr array buffer{byte{0xFF}, byte{0xD8}, byte{0xFF}, byte{0xD8}}; // 0xD8 = SOI.
 
         jpeg_stream_reader reader;
-        reader.source({buffer.data(), buffer.size()});
+        reader.source(buffer);
 
         assert_expect_exception(jpegls_errc::duplicate_start_of_image_marker, [&reader] { reader.read_header(); });
     }
@@ -391,7 +391,7 @@ public:
 
     TEST_METHOD(read_spiff_header_high_version_to_new) // NOLINT
     {
-        auto buffer{create_test_spiff_header(3)};
+        const auto buffer{create_test_spiff_header(3)};
         jpeg_stream_reader reader;
         reader.source({buffer.data(), buffer.size()});
 
@@ -405,7 +405,7 @@ public:
 
     TEST_METHOD(read_spiff_header_without_end_of_directory) // NOLINT
     {
-        auto buffer = create_test_spiff_header(2, 0, false);
+        const auto buffer{create_test_spiff_header(2, 0, false)};
         jpeg_stream_reader reader;
         reader.source({buffer.data(), buffer.size()});
 


### PR DESCRIPTION
…ure latest C++ MSVC compiler is selected

Visual Studio 2022 is installed on the default build agents. 2 toolsets are installed (17.7 and 17.8). An defect in MSVC causes it to not select the latest compiler. Explicit force the latest for the CI pipeline

Also add an extra constructor to span, to make it easier to use in test code.