### PR TITLE
Update coding style (.clang-format) to BreakAfterAttributes: Always

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,5 +40,6 @@ SpaceBeforeCpp11BracedList: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
+BreakAfterAttributes: Always
 
 StatementMacros: ['TEST_CLASS', 'TEST_METHOD']

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -70,7 +70,8 @@ struct scan_decoder
         t3_ = preset.threshold3;
     }
 
-    [[nodiscard]] int8_t quantize_gradient_org(const int32_t di) const noexcept
+    [[nodiscard]]
+    int8_t quantize_gradient_org(const int32_t di) const noexcept
     {
         if (di <= -t3_)
             return -4;
@@ -97,7 +98,6 @@ struct lossless_traits final
 {
     static constexpr int32_t near_lossless{};
 };
-
 
 
 __declspec(noinline) int32_t get_predicted_value_default(const int32_t ra, const int32_t rb, const int32_t rc) noexcept
@@ -288,12 +288,14 @@ public:
         size_ = new_size;
     }
 
-    [[nodiscard]] uint8_t* data() const noexcept
+    [[nodiscard]]
+    uint8_t* data() const noexcept
     {
         return data_.get();
     }
 
-    [[nodiscard]] size_t size() const noexcept
+    [[nodiscard]]
+    size_t size() const noexcept
     {
         return size_;
     }
@@ -304,14 +306,12 @@ private:
 };
 
 
-
 overwrite_buffer allocate_overwrite_buffer(const size_t size)
 {
     overwrite_buffer buffer;
     buffer.reset(size);
     return buffer;
 }
-
 
 
 static void bm_resize_overwrite_buffer(benchmark::State& state)
@@ -323,8 +323,6 @@ static void bm_resize_overwrite_buffer(benchmark::State& state)
     }
 }
 BENCHMARK(bm_resize_overwrite_buffer);
-
-
 
 
 BENCHMARK_MAIN();

--- a/benchmark/context_regular_mode_v220.h
+++ b/benchmark/context_regular_mode_v220.h
@@ -9,7 +9,7 @@
 
 namespace charls {
 
-// Purpose: a JPEG-LS context with it's current statistics.
+// Purpose: a JPEG-LS context with its current statistics.
 struct jls_context_v220 final
 {
     int32_t A{};
@@ -23,7 +23,8 @@ struct jls_context_v220 final
     {
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t get_error_correction(const int32_t k) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t get_error_correction(const int32_t k) const noexcept
     {
         if (k != 0)
             return 0;
@@ -32,8 +33,7 @@ struct jls_context_v220 final
     }
 
     /// <summary>Code segment A.12 – Variables update.</summary>
-    FORCE_INLINE void update_variables(const int32_t error_value, const int32_t near_lossless,
-                                       const int32_t reset_threshold)
+    FORCE_INLINE void update_variables(const int32_t error_value, const int32_t near_lossless, const int32_t reset_threshold)
     {
         ASSERT(N != 0);
 
@@ -80,10 +80,11 @@ struct jls_context_v220 final
     }
 
     /// <summary>
-    /// <para>Computes the Golomb coding parameter using the algorithm as defined in ISO/IEC 14495-1, code segment A.10 </para>
-    /// <para>Original algorithm is: for (k = 0; (N[Q] << k) < A[Q]; k++) </para>
+    /// <para>Computes the Golomb coding parameter using the algorithm as defined in ISO/IEC 14495-1, code segment A.10
+    /// </para> <para>Original algorithm is: for (k = 0; (N[Q] << k) < A[Q]; k++) </para>
     /// </summary>
-    [[nodiscard]] FORCE_INLINE int32_t get_golomb_coding_parameter() const
+    [[nodiscard]]
+    FORCE_INLINE int32_t get_golomb_coding_parameter() const
     {
         int32_t k{};
         for (; N << k < A && k < max_k_value; ++k)

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -402,7 +402,8 @@ public:
     /// Returns true if a valid SPIFF header was found.
     /// </summary>
     /// <returns>True of false, depending if a SPIFF header was found.</returns>
-    [[nodiscard]] bool spiff_header_has_value() const noexcept
+    [[nodiscard]]
+    bool spiff_header_has_value() const noexcept
     {
         return spiff_header_has_value_;
     }
@@ -412,7 +413,8 @@ public:
     /// Function can be called after read_spiff_header and spiff_header_has_value.
     /// </summary>
     /// <returns>The SPIFF header.</returns>
-    [[nodiscard]] const charls::spiff_header& spiff_header() const& noexcept
+    [[nodiscard]]
+    const charls::spiff_header& spiff_header() const& noexcept
     {
         return spiff_header_;
     }
@@ -422,7 +424,8 @@ public:
     /// Function can be called after read_spiff_header and spiff_header_has_value.
     /// </summary>
     /// <returns>The SPIFF header.</returns>
-    [[nodiscard]] charls::spiff_header spiff_header() const&& noexcept
+    [[nodiscard]]
+    charls::spiff_header spiff_header() const&& noexcept
     {
         return spiff_header_;
     }
@@ -432,7 +435,8 @@ public:
     /// Function can be called after read_header.
     /// </summary>
     /// <returns>The frame info that describes the image stored in the JPEG-LS byte stream.</returns>
-    [[nodiscard]] const charls::frame_info& frame_info() const& noexcept
+    [[nodiscard]]
+    const charls::frame_info& frame_info() const& noexcept
     {
         return frame_info_;
     }
@@ -442,7 +446,8 @@ public:
     /// Function can be called after read_header.
     /// </summary>
     /// <returns>The frame info that describes the image stored in the JPEG-LS byte stream.</returns>
-    [[nodiscard]] charls::frame_info frame_info() const&& noexcept
+    [[nodiscard]]
+    charls::frame_info frame_info() const&& noexcept
     {
         return frame_info_;
     }
@@ -453,7 +458,8 @@ public:
     /// <param name="component">The component index for which the NEAR parameter should be retrieved.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the NEAR parameter.</returns>
-    [[nodiscard]] int32_t near_lossless(const int32_t component = 0) const
+    [[nodiscard]]
+    int32_t near_lossless(const int32_t component = 0) const
     {
         int32_t near_lossless;
         check_jpegls_errc(charls_jpegls_decoder_get_near_lossless(decoder_.get(), component, &near_lossless));
@@ -465,7 +471,8 @@ public:
     /// </summary>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the interleave mode.</returns>
-    [[nodiscard]] charls::interleave_mode interleave_mode() const
+    [[nodiscard]]
+    charls::interleave_mode interleave_mode() const
     {
         charls::interleave_mode interleave_mode;
         check_jpegls_errc(charls_jpegls_decoder_get_interleave_mode(decoder_.get(), &interleave_mode));
@@ -477,7 +484,8 @@ public:
     /// </summary>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The values of the JPEG-LS preset coding parameters.</returns>
-    [[nodiscard]] jpegls_pc_parameters preset_coding_parameters() const
+    [[nodiscard]]
+    jpegls_pc_parameters preset_coding_parameters() const
     {
         jpegls_pc_parameters preset_coding_parameters;
         check_jpegls_errc(charls_jpegls_decoder_get_preset_coding_parameters(decoder_.get(), 0, &preset_coding_parameters));
@@ -489,7 +497,8 @@ public:
     /// </summary>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the color transformation.</returns>
-    [[nodiscard]] charls::color_transformation color_transformation() const
+    [[nodiscard]]
+    charls::color_transformation color_transformation() const
     {
         charls::color_transformation color_transformation;
         check_jpegls_errc(charls_jpegls_decoder_get_color_transformation(decoder_.get(), &color_transformation));
@@ -503,7 +512,8 @@ public:
     /// <param name="stride">Number of bytes to the next line in the buffer, when zero, decoder will compute it.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The required size in bytes of the destination buffer.</returns>
-    [[nodiscard]] size_t destination_size(const uint32_t stride = 0) const
+    [[nodiscard]]
+    size_t destination_size(const uint32_t stride = 0) const
     {
         size_t size_in_bytes;
         check_jpegls_errc(charls_jpegls_decoder_get_destination_size(decoder_.get(), stride, &size_in_bytes));
@@ -548,7 +558,8 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>Container with the decoded data.</returns>
     template<typename Container, typename ContainerValueType = typename Container::value_type>
-    [[nodiscard]] Container decode(const uint32_t stride = 0) const
+    [[nodiscard]]
+    Container decode(const uint32_t stride = 0) const
     {
         Container destination(destination_size() / sizeof(ContainerValueType));
 
@@ -594,7 +605,8 @@ public:
     }
 
 private:
-    [[nodiscard]] static charls_jpegls_decoder* create_decoder()
+    [[nodiscard]]
+    static charls_jpegls_decoder* create_decoder()
     {
         charls_jpegls_decoder* decoder{charls_jpegls_decoder_create()};
         if (!decoder)

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -226,8 +226,7 @@ charls_jpegls_encoder_write_comment(CHARLS_IN charls_jpegls_encoder* encoder,
 /// <returns>The result of the operation: success or a failure code.</returns>
 CHARLS_ATTRIBUTE_ACCESS((access(read_only, 3, 4)))
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
-charls_jpegls_encoder_write_application_data(CHARLS_IN charls_jpegls_encoder* encoder,
-                                             int32_t application_data_id,
+charls_jpegls_encoder_write_application_data(CHARLS_IN charls_jpegls_encoder* encoder, int32_t application_data_id,
                                              CHARLS_IN_READS_BYTES(application_data_size_bytes) const void* application_data,
                                              size_t application_data_size_bytes) CHARLS_NOEXCEPT;
 
@@ -386,7 +385,8 @@ public:
     /// Size for dynamic extras like SPIFF entries and other tables are not included in this size.
     /// </remarks>
     /// <returns>The estimated size in bytes needed to hold the encoded image.</returns>
-    [[nodiscard]] size_t estimated_destination_size() const
+    [[nodiscard]]
+    size_t estimated_destination_size() const
     {
         size_t size_in_bytes;
         check_jpegls_errc(charls_jpegls_encoder_get_estimated_destination_size(encoder_.get(), &size_in_bytes));
@@ -562,7 +562,8 @@ public:
     /// Returns the size in bytes, that are written to the destination.
     /// </summary>
     /// <returns>The bytes written.</returns>
-    [[nodiscard]] size_t bytes_written() const
+    [[nodiscard]]
+    size_t bytes_written() const
     {
         size_t bytes_written;
         check_jpegls_errc(charls_jpegls_encoder_get_bytes_written(encoder_.get(), &bytes_written));
@@ -578,7 +579,8 @@ public:
     }
 
 private:
-    [[nodiscard]] static charls_jpegls_encoder* create_encoder()
+    [[nodiscard]]
+    static charls_jpegls_encoder* create_encoder()
     {
         charls_jpegls_encoder* encoder{charls_jpegls_encoder_create()};
         if (!encoder)

--- a/include/charls/jpegls_error.h
+++ b/include/charls/jpegls_error.h
@@ -18,12 +18,14 @@ CHARLS_API_IMPORT_EXPORT const char* CHARLS_API_CALLING_CONVENTION charls_get_er
 CHARLS_EXPORT
 namespace charls {
 
-[[nodiscard]] inline const std::error_category& jpegls_category() noexcept
+[[nodiscard]]
+inline const std::error_category& jpegls_category() noexcept
 {
     return *(charls_get_jpegls_category());
 }
 
-[[nodiscard]] inline std::error_code make_error_code(jpegls_errc error_value) noexcept
+[[nodiscard]]
+inline std::error_code make_error_code(jpegls_errc error_value) noexcept
 {
     return {static_cast<int>(error_value), jpegls_category()};
 }
@@ -58,7 +60,8 @@ namespace impl {
 
 // Not inlined by design, as this code path is the exceptional case.
 // It will help to allow the compiler to inline other functions.
-[[noreturn]] inline CHARLS_NO_INLINE void throw_jpegls_error(const jpegls_errc error_value)
+[[noreturn]]
+inline CHARLS_NO_INLINE void throw_jpegls_error(const jpegls_errc error_value)
 {
     throw jpegls_error(error_value);
 }

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -50,13 +50,15 @@ struct charls_jpegls_decoder final
         state_ = state::header_read;
     }
 
-    [[nodiscard]] charls::frame_info frame_info_checked() const
+    [[nodiscard]]
+    charls::frame_info frame_info_checked() const
     {
         check_operation(state_ >= state::header_read);
         return frame_info();
     }
 
-    [[nodiscard]] int32_t near_lossless(int32_t /*component*/ = 0) const
+    [[nodiscard]]
+    int32_t near_lossless(int32_t /*component*/ = 0) const
     {
         check_operation(state_ >= state::header_read);
 
@@ -64,7 +66,8 @@ struct charls_jpegls_decoder final
         return reader_.parameters().near_lossless;
     }
 
-    [[nodiscard]] charls::interleave_mode interleave_mode() const
+    [[nodiscard]]
+    charls::interleave_mode interleave_mode() const
     {
         check_operation(state_ >= state::header_read);
 
@@ -73,19 +76,22 @@ struct charls_jpegls_decoder final
         return reader_.parameters().interleave_mode;
     }
 
-    [[nodiscard]] charls::color_transformation color_transformation() const
+    [[nodiscard]]
+    charls::color_transformation color_transformation() const
     {
         check_operation(state_ >= state::header_read);
         return reader_.parameters().transformation;
     }
 
-    [[nodiscard]] const jpegls_pc_parameters& preset_coding_parameters() const
+    [[nodiscard]]
+    const jpegls_pc_parameters& preset_coding_parameters() const
     {
         check_operation(state_ >= state::header_read);
         return reader_.preset_coding_parameters();
     }
 
-    [[nodiscard]] size_t destination_size(const size_t stride) const
+    [[nodiscard]]
+    size_t destination_size(const size_t stride) const
     {
         const auto [width, height, bits_per_sample, component_count]{frame_info_checked()};
 
@@ -172,12 +178,14 @@ struct charls_jpegls_decoder final
     }
 
 private:
-    [[nodiscard]] const charls::frame_info& frame_info() const noexcept
+    [[nodiscard]]
+    const charls::frame_info& frame_info() const noexcept
     {
         return reader_.frame_info();
     }
 
-    [[nodiscard]] size_t calculate_minimum_stride() const noexcept
+    [[nodiscard]]
+    size_t calculate_minimum_stride() const noexcept
     {
         const size_t components_in_plane_count{reader_.parameters().interleave_mode == interleave_mode::none
                                                    ? 1U

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -92,7 +92,8 @@ struct charls_jpegls_encoder final
         color_transformation_ = color_transformation;
     }
 
-    [[nodiscard]] size_t estimated_destination_size() const
+    [[nodiscard]]
+    size_t estimated_destination_size() const
     {
         check_operation(is_frame_info_configured());
         return checked_mul(checked_mul(checked_mul(frame_info_.width, frame_info_.height), frame_info_.component_count),
@@ -229,7 +230,8 @@ struct charls_jpegls_encoder final
         state_ = state::completed;
     }
 
-    [[nodiscard]] size_t bytes_written() const noexcept
+    [[nodiscard]]
+    size_t bytes_written() const noexcept
     {
         return writer_.bytes_written();
     }
@@ -253,7 +255,8 @@ private:
         completed
     };
 
-    [[nodiscard]] bool is_frame_info_configured() const noexcept
+    [[nodiscard]]
+    bool is_frame_info_configured() const noexcept
     {
         return frame_info_.width != 0;
     }
@@ -271,7 +274,8 @@ private:
         writer_.seek(bytes_written);
     }
 
-    [[nodiscard]] size_t calculate_stride() const noexcept
+    [[nodiscard]]
+    size_t calculate_stride() const noexcept
     {
         const auto stride{static_cast<size_t>(frame_info_.width) * bit_to_byte_count(frame_info_.bits_per_sample)};
         if (interleave_mode_ == interleave_mode::none)
@@ -333,7 +337,8 @@ private:
         state_ = state::tables_and_miscellaneous;
     }
 
-    [[nodiscard]] bool has_option(const charls::encoding_options option_to_test) const noexcept
+    [[nodiscard]]
+    bool has_option(const charls::encoding_options option_to_test) const noexcept
     {
         return ::has_option(encoding_options_, option_to_test);
     }
@@ -571,7 +576,8 @@ charls_jpegls_encoder_write_application_data(charls_jpegls_encoder* encoder, con
                                              const void* application_data, const size_t application_data_size_bytes) noexcept
 try
 {
-    check_pointer(encoder)->write_application_data(application_data_id, {static_cast<const byte*>(application_data), application_data_size_bytes});
+    check_pointer(encoder)->write_application_data(
+        application_data_id, {static_cast<const byte*>(application_data), application_data_size_bytes});
     return jpegls_errc::success;
 }
 catch (...)

--- a/src/context_regular_mode.h
+++ b/src/context_regular_mode.h
@@ -25,12 +25,14 @@ public:
     }
 
     /// <summary>counter with prediction correction value</summary>
-    [[nodiscard]] int32_t c() const noexcept
+    [[nodiscard]]
+    int32_t c() const noexcept
     {
         return c_;
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t get_error_correction(const int32_t k) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t get_error_correction(const int32_t k) const noexcept
     {
         if (k != 0)
             return 0;
@@ -92,7 +94,8 @@ public:
     /// <summary>
     /// Computes the Golomb coding parameter using the algorithm as defined in ISO 14495-1, code segment A.10
     /// </summary>
-    [[nodiscard]] FORCE_INLINE int32_t get_golomb_coding_parameter() const
+    [[nodiscard]]
+    FORCE_INLINE int32_t get_golomb_coding_parameter() const
     {
         int32_t k{};
         for (; n_ << k < a_ && k < max_k_value; ++k)

--- a/src/context_run_mode.h
+++ b/src/context_run_mode.h
@@ -26,12 +26,14 @@ public:
     {
     }
 
-    [[nodiscard]] int32_t run_interruption_type() const noexcept
+    [[nodiscard]]
+    int32_t run_interruption_type() const noexcept
     {
         return run_interruption_type_;
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t get_golomb_code() const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t get_golomb_code() const noexcept
     {
         const int32_t temp{a_ + (n_ >> 1) * run_interruption_type_};
         int32_t n_test{n_};
@@ -65,7 +67,8 @@ public:
         ++n_;
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t compute_error_value(const int32_t temp, const int32_t k) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t compute_error_value(const int32_t temp, const int32_t k) const noexcept
     {
         const bool map = temp & 1;
         const int32_t error_value_abs{(temp + static_cast<int32_t>(map)) / 2};
@@ -81,7 +84,8 @@ public:
     }
 
     /// <summary>Code segment A.21 – Computation of map for Errval mapping.</summary>
-    [[nodiscard]] bool compute_map(const int32_t error_value, const int32_t k) const noexcept
+    [[nodiscard]]
+    bool compute_map(const int32_t error_value, const int32_t k) const noexcept
     {
         if (k == 0 && error_value > 0 && 2 * nn_ < n_)
             return true;
@@ -95,7 +99,8 @@ public:
         return false;
     }
 
-    [[nodiscard]] FORCE_INLINE bool compute_map_negative_e(const int32_t k) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE bool compute_map_negative_e(const int32_t k) const noexcept
     {
         return k != 0 || 2 * nn_ >= n_;
     }

--- a/src/default_traits.h
+++ b/src/default_traits.h
@@ -57,35 +57,41 @@ struct default_traits final
     default_traits& operator=(const default_traits&) = delete;
     default_traits& operator=(default_traits&&) = delete;
 
-    [[nodiscard]] FORCE_INLINE int32_t compute_error_value(const int32_t e) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t compute_error_value(const int32_t e) const noexcept
     {
         return modulo_range(quantize(e));
     }
 
-    [[nodiscard]] FORCE_INLINE SampleType compute_reconstructed_sample(const int32_t predicted_value,
-                                                                       const int32_t error_value) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE SampleType compute_reconstructed_sample(const int32_t predicted_value,
+                                                         const int32_t error_value) const noexcept
     {
         return fix_reconstructed_value(predicted_value + dequantize(error_value));
     }
 
-    [[nodiscard]] FORCE_INLINE bool is_near(const int32_t lhs, const int32_t rhs) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE bool is_near(const int32_t lhs, const int32_t rhs) const noexcept
     {
         return std::abs(lhs - rhs) <= near_lossless;
     }
 
-    [[nodiscard]] bool is_near(const triplet<SampleType> lhs, const triplet<SampleType> rhs) const noexcept
+    [[nodiscard]]
+    bool is_near(const triplet<SampleType> lhs, const triplet<SampleType> rhs) const noexcept
     {
         return std::abs(lhs.v1 - rhs.v1) <= near_lossless && std::abs(lhs.v2 - rhs.v2) <= near_lossless &&
                std::abs(lhs.v3 - rhs.v3) <= near_lossless;
     }
 
-    [[nodiscard]] bool is_near(const quad<SampleType> lhs, const quad<SampleType> rhs) const noexcept
+    [[nodiscard]]
+    bool is_near(const quad<SampleType> lhs, const quad<SampleType> rhs) const noexcept
     {
         return std::abs(lhs.v1 - rhs.v1) <= near_lossless && std::abs(lhs.v2 - rhs.v2) <= near_lossless &&
                std::abs(lhs.v3 - rhs.v3) <= near_lossless && std::abs(lhs.v4 - rhs.v4) <= near_lossless;
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t correct_prediction(const int32_t predicted) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t correct_prediction(const int32_t predicted) const noexcept
     {
         if ((predicted & maximum_sample_value) == predicted)
             return predicted;
@@ -97,7 +103,8 @@ struct default_traits final
     /// Returns the value of errorValue modulo RANGE. ITU.T.87, A.4.5 (code segment A.9)
     /// This ensures the error is reduced to the range (-⌊RANGE/2⌋ .. ⌈RANGE/2⌉-1)
     /// </summary>
-    [[nodiscard]] FORCE_INLINE int32_t modulo_range(int32_t error_value) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t modulo_range(int32_t error_value) const noexcept
     {
         ASSERT(std::abs(error_value) <= range);
 
@@ -116,7 +123,8 @@ struct default_traits final
     }
 
 #ifndef NDEBUG
-    [[nodiscard]] bool is_valid() const noexcept
+    [[nodiscard]]
+    bool is_valid() const noexcept
     {
         if (maximum_sample_value < 1 || maximum_sample_value > std::numeric_limits<uint16_t>::max())
             return false;
@@ -129,7 +137,8 @@ struct default_traits final
 #endif
 
 private:
-    [[nodiscard]] int32_t quantize(const int32_t error_value) const noexcept
+    [[nodiscard]]
+    int32_t quantize(const int32_t error_value) const noexcept
     {
         if (error_value > 0)
             return (error_value + near_lossless) / (2 * near_lossless + 1);
@@ -137,12 +146,14 @@ private:
         return -(near_lossless - error_value) / (2 * near_lossless + 1);
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t dequantize(const int32_t error_value) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t dequantize(const int32_t error_value) const noexcept
     {
         return error_value * (2 * near_lossless + 1);
     }
 
-    [[nodiscard]] FORCE_INLINE SampleType fix_reconstructed_value(int32_t value) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE SampleType fix_reconstructed_value(int32_t value) const noexcept
     {
         if (value < -near_lossless)
         {

--- a/src/golomb_lut.h
+++ b/src/golomb_lut.h
@@ -19,12 +19,14 @@ struct golomb_code final
     {
     }
 
-    [[nodiscard]] int32_t value() const noexcept
+    [[nodiscard]]
+    int32_t value() const noexcept
     {
         return value_;
     }
 
-    [[nodiscard]] constexpr uint32_t length() const noexcept
+    [[nodiscard]]
+    constexpr uint32_t length() const noexcept
     {
         return length_;
     }
@@ -52,7 +54,8 @@ public:
         }
     }
 
-    [[nodiscard]] FORCE_INLINE const golomb_code& get(const uint32_t value) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE const golomb_code& get(const uint32_t value) const noexcept
     {
         return types_[value];
     }
@@ -64,4 +67,4 @@ private:
 
 extern const std::array<golomb_code_table, max_k_value> golomb_lut;
 
-}
+} // namespace charls

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -30,17 +30,20 @@ public:
 
     void source(span<const std::byte> source) noexcept;
 
-    [[nodiscard]] const charls::frame_info& frame_info() const noexcept
+    [[nodiscard]]
+    const charls::frame_info& frame_info() const noexcept
     {
         return frame_info_;
     }
 
-    [[nodiscard]] const coding_parameters& parameters() const noexcept
+    [[nodiscard]]
+    const coding_parameters& parameters() const noexcept
     {
         return parameters_;
     }
 
-    [[nodiscard]] const jpegls_pc_parameters& preset_coding_parameters() const noexcept
+    [[nodiscard]]
+    const jpegls_pc_parameters& preset_coding_parameters() const noexcept
     {
         return preset_coding_parameters_;
     }
@@ -55,7 +58,8 @@ public:
         at_application_data_callback_ = at_application_data_callback;
     }
 
-    [[nodiscard]] span<const std::byte> remaining_source() const noexcept
+    [[nodiscard]]
+    span<const std::byte> remaining_source() const noexcept
     {
         ASSERT(state_ == state::bit_stream_section);
         return {position_, end_position_};
@@ -64,7 +68,8 @@ public:
     void read_header(spiff_header* header = nullptr, bool* spiff_header_found = nullptr);
     void read_next_start_of_scan();
     void read_end_of_image();
-    [[nodiscard]] jpegls_pc_parameters get_validated_preset_coding_parameters() const;
+    [[nodiscard]]
+    jpegls_pc_parameters get_validated_preset_coding_parameters() const;
 
     void advance_position(const size_t count) noexcept
     {
@@ -73,25 +78,41 @@ public:
     }
 
 private:
-    [[nodiscard]] std::byte read_byte_checked();
-    [[nodiscard]] uint16_t read_uint16_checked();
+    [[nodiscard]]
+    std::byte read_byte_checked();
 
-    [[nodiscard]] std::byte read_byte() noexcept;
+    [[nodiscard]]
+    uint16_t read_uint16_checked();
+
+    [[nodiscard]]
+    std::byte read_byte() noexcept;
     void skip_byte() noexcept;
 
-    [[nodiscard]] uint8_t read_uint8() noexcept
+    [[nodiscard]]
+    uint8_t read_uint8() noexcept
     {
         return std::to_integer<uint8_t>(read_byte());
     }
 
-    [[nodiscard]] uint16_t read_uint16() noexcept;
-    [[nodiscard]] uint32_t read_uint24() noexcept;
-    [[nodiscard]] uint32_t read_uint32() noexcept;
-    [[nodiscard]] span<const std::byte> read_bytes(size_t byte_count) noexcept;
+    [[nodiscard]]
+    uint16_t read_uint16() noexcept;
+
+    [[nodiscard]]
+    uint32_t read_uint24() noexcept;
+
+    [[nodiscard]]
+    uint32_t read_uint32() noexcept;
+
+    [[nodiscard]]
+    span<const std::byte> read_bytes(size_t byte_count) noexcept;
+
     void read_segment_size();
     void check_minimal_segment_size(size_t minimum_size) const;
     void check_segment_size(size_t expected_size) const;
-    [[nodiscard]] jpeg_marker_code read_next_marker_code();
+
+    [[nodiscard]]
+    jpeg_marker_code read_next_marker_code();
+
     void validate_marker_code(jpeg_marker_code marker_code) const;
     void read_marker_segment(jpeg_marker_code marker_code, spiff_header* header = nullptr,
                              bool* spiff_header_found = nullptr);
@@ -109,7 +130,10 @@ private:
     void try_read_hp_color_transform_segment();
     void add_component(uint8_t component_id);
     void check_interleave_mode(interleave_mode mode) const;
-    [[nodiscard]] uint32_t maximum_sample_value() const noexcept;
+
+    [[nodiscard]]
+    uint32_t maximum_sample_value() const noexcept;
+
     void skip_remaining_segment_data() noexcept;
     void check_frame_info() const;
     void frame_info_height(uint32_t height);

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -95,12 +95,14 @@ public:
 
     void write_end_of_image(bool even_destination_size);
 
-    [[nodiscard]] size_t bytes_written() const noexcept
+    [[nodiscard]]
+    size_t bytes_written() const noexcept
     {
         return byte_offset_;
     }
 
-    [[nodiscard]] span<std::byte> remaining_destination() const noexcept
+    [[nodiscard]]
+    span<std::byte> remaining_destination() const noexcept
     {
         return {destination_.data() + byte_offset_, destination_.size() - byte_offset_};
     }

--- a/src/jpegls_algorithm.h
+++ b/src/jpegls_algorithm.h
@@ -12,7 +12,8 @@ namespace charls {
 /// This is the optimized inverse algorithm of ISO/IEC 14495-1, A.5.2, Code Segment A.11 (second else branch)
 /// It will map unsigned values back to signed values.
 /// </summary>
-[[nodiscard]] constexpr int32_t unmap_error_value(const int32_t mapped_error) noexcept
+[[nodiscard]]
+constexpr int32_t unmap_error_value(const int32_t mapped_error) noexcept
 {
     const int32_t sign{static_cast<int32_t>(static_cast<uint32_t>(mapped_error) << (int32_t_bit_count - 1)) >>
                        (int32_t_bit_count - 1)};
@@ -24,7 +25,8 @@ namespace charls {
 /// This is the algorithm of ISO/IEC 14495-1, A.5.2, Code Segment A.11 (second else branch)
 /// It will map signed values to unsigned values. It has been optimized to prevent branching.
 /// </summary>
-[[nodiscard]] constexpr int32_t map_error_value(const int32_t error_value) noexcept
+[[nodiscard]]
+constexpr int32_t map_error_value(const int32_t error_value) noexcept
 {
     ASSERT(error_value <= std::numeric_limits<int32_t>::max() / 2);
 
@@ -33,19 +35,22 @@ namespace charls {
 }
 
 
-[[nodiscard]] constexpr int32_t sign(const int32_t n) noexcept
+[[nodiscard]]
+constexpr int32_t sign(const int32_t n) noexcept
 {
     return (n >> (int32_t_bit_count - 1)) | 1;
 }
 
 
-[[nodiscard]] constexpr int32_t bit_wise_sign(const int32_t i) noexcept
+[[nodiscard]]
+constexpr int32_t bit_wise_sign(const int32_t i) noexcept
 {
     return i >> (int32_t_bit_count - 1);
 }
 
 
-[[nodiscard]] constexpr int32_t apply_sign(const int32_t i, const int32_t sign) noexcept
+[[nodiscard]]
+constexpr int32_t apply_sign(const int32_t i, const int32_t sign) noexcept
 {
     return (sign ^ i) - sign;
 }
@@ -54,8 +59,8 @@ namespace charls {
 /// <summary>
 /// Computes the parameter RANGE. When NEAR = 0, RANGE = MAXVAL + 1. (see ISO/IEC 14495-1, A.2.1)
 /// </summary>
-[[nodiscard]] constexpr int32_t compute_range_parameter(const int32_t maximum_sample_value,
-                                                        const int32_t near_lossless) noexcept
+[[nodiscard]]
+constexpr int32_t compute_range_parameter(const int32_t maximum_sample_value, const int32_t near_lossless) noexcept
 {
     return (maximum_sample_value + 2 * near_lossless) / (2 * near_lossless + 1) + 1;
 }
@@ -64,13 +69,15 @@ namespace charls {
 /// <summary>
 /// Computes the parameter LIMIT. (see ISO/IEC 14495-1, A.2.1)
 /// </summary>
-[[nodiscard]] constexpr int32_t compute_limit_parameter(const int32_t bits_per_pixel)
+[[nodiscard]]
+constexpr int32_t compute_limit_parameter(const int32_t bits_per_pixel)
 {
     return 2 * (bits_per_pixel + std::max(8, bits_per_pixel));
 }
 
 
-[[nodiscard]] inline int32_t get_predicted_value(const int32_t ra, const int32_t rb, const int32_t rc) noexcept
+[[nodiscard]]
+inline int32_t get_predicted_value(const int32_t ra, const int32_t rb, const int32_t rc) noexcept
 {
     // sign trick reduces the number of if statements (branches)
     const int32_t sign{bit_wise_sign(rb - ra)};
@@ -90,15 +97,17 @@ namespace charls {
 }
 
 
-[[nodiscard]] constexpr int32_t compute_context_id(const int32_t q1, const int32_t q2, const int32_t q3) noexcept
+[[nodiscard]]
+constexpr int32_t compute_context_id(const int32_t q1, const int32_t q2, const int32_t q3) noexcept
 {
     return (q1 * 9 + q2) * 9 + q3;
 }
 
 
 // See JPEG-LS standard ISO/IEC 14495-1, A.3.3, golomb_code Segment A.4
-[[nodiscard]] constexpr int8_t quantize_gradient_org(const int32_t di, const int32_t threshold1, const int32_t threshold2,
-                                                  const int32_t threshold3, const int32_t near_lossless = 0) noexcept
+[[nodiscard]]
+constexpr int8_t quantize_gradient_org(const int32_t di, const int32_t threshold1, const int32_t threshold2,
+                                       const int32_t threshold3, const int32_t near_lossless = 0) noexcept
 {
     if (di <= -threshold3)
         return -4;

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -12,12 +12,14 @@ using std::error_category;
 class jpegls_category final : public error_category
 {
 public:
-    [[nodiscard]] const char* name() const noexcept override
+    [[nodiscard]]
+    const char* name() const noexcept override
     {
         return "charls::jpegls";
     }
 
-    [[nodiscard]] std::string message(int error_value) const override
+    [[nodiscard]]
+    std::string message(int error_value) const override
     {
         return charls_get_error_message(static_cast<jpegls_errc>(error_value));
     }

--- a/src/scan_codec.h
+++ b/src/scan_codec.h
@@ -102,8 +102,7 @@ protected:
     /// Copy frame_info and parameters to prevent 1 indirection during encoding/decoding.
     /// </remarks>
     scan_codec(const frame_info& frame_info, const coding_parameters& parameters) noexcept :
-        frame_info_{frame_info},
-        parameters_{parameters}, width_{frame_info.width}
+        frame_info_{frame_info}, parameters_{parameters}, width_{frame_info.width}
     {
         ASSERT((parameters.interleave_mode == interleave_mode::none && this->frame_info().component_count == 1) ||
                parameters.interleave_mode != interleave_mode::none);
@@ -111,22 +110,26 @@ protected:
 
     ~scan_codec() = default;
 
-    [[nodiscard]] int8_t quantize_gradient_org(const int32_t di, const int32_t near_lossless) const noexcept
+    [[nodiscard]]
+    int8_t quantize_gradient_org(const int32_t di, const int32_t near_lossless) const noexcept
     {
         return charls::quantize_gradient_org(di, t1_, t2_, t3_, near_lossless);
     }
 
-    [[nodiscard]] const coding_parameters& parameters() const noexcept
+    [[nodiscard]]
+    const coding_parameters& parameters() const noexcept
     {
         return parameters_;
     }
 
-    [[nodiscard]] const charls::frame_info& frame_info() const noexcept
+    [[nodiscard]]
+    const charls::frame_info& frame_info() const noexcept
     {
         return frame_info_;
     }
 
-    [[nodiscard]] bool is_interleaved() const noexcept
+    [[nodiscard]]
+    bool is_interleaved() const noexcept
     {
         ASSERT((parameters().interleave_mode == interleave_mode::none && frame_info().component_count == 1) ||
                parameters().interleave_mode != interleave_mode::none);

--- a/src/scan_codec_factory.cpp
+++ b/src/scan_codec_factory.cpp
@@ -18,9 +18,11 @@ using std::unique_ptr;
 namespace {
 
 /// <summary>
-/// scan_codec_factory receives the actual frame info. scan_codec expects 1 when encoding/decoding a single scan in interleave mode none.
+/// scan_codec_factory receives the actual frame info.
+/// scan_codec expects 1 when encoding/decoding a single scan in interleave mode none.
 /// </summary>
-[[nodiscard]] frame_info update_component_count(const frame_info& frame, const coding_parameters& parameters) noexcept
+[[nodiscard]]
+frame_info update_component_count(const frame_info& frame, const coding_parameters& parameters) noexcept
 {
     return {frame.width, frame.height, frame.bits_per_sample,
             parameters.interleave_mode == interleave_mode::none ? 1 : frame.component_count};

--- a/src/scan_decoder.h
+++ b/src/scan_decoder.h
@@ -84,7 +84,8 @@ protected:
             impl::throw_jpegls_error(jpegls_errc::too_much_encoded_data);
     }
 
-    [[nodiscard]] const std::byte* get_cur_byte_pos() const noexcept
+    [[nodiscard]]
+    const std::byte* get_cur_byte_pos() const noexcept
     {
         int32_t valid_bits{valid_bits_};
         const std::byte* compressed_bytes{position_};
@@ -101,7 +102,8 @@ protected:
         }
     }
 
-    [[nodiscard]] int32_t decode_value(const int32_t k, const int32_t limit, const int32_t quantized_bits_per_pixel)
+    [[nodiscard]]
+    int32_t decode_value(const int32_t k, const int32_t limit, const int32_t quantized_bits_per_pixel)
     {
         const int32_t high_bits{read_high_bits()};
 

--- a/src/scan_decoder_impl.h
+++ b/src/scan_decoder_impl.h
@@ -94,7 +94,8 @@ private:
         impl::throw_jpegls_error(jpegls_errc::bit_depth_for_transform_not_supported);
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t quantize_gradient(const int32_t di) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t quantize_gradient(const int32_t di) const noexcept
     {
         ASSERT(quantize_gradient_org(di, traits_.near_lossless) == *(quantization_ + di));
         return *(quantization_ + di);
@@ -272,7 +273,8 @@ private:
         }
     }
 
-    [[nodiscard]] int32_t decode_run_mode(const int32_t start_index)
+    [[nodiscard]]
+    int32_t decode_run_mode(const int32_t start_index)
     {
         const pixel_type ra{current_line_[start_index - 1]};
 
@@ -289,7 +291,8 @@ private:
         return end_index - start_index + 1;
     }
 
-    [[nodiscard]] FORCE_INLINE sample_type decode_regular(const int32_t qs, const int32_t predicted)
+    [[nodiscard]]
+    FORCE_INLINE sample_type decode_regular(const int32_t qs, const int32_t predicted)
     {
         const int32_t sign{bit_wise_sign(qs)};
         context_regular_mode& context{contexts_[apply_sign(qs, sign)]};
@@ -318,7 +321,8 @@ private:
         return traits_.compute_reconstructed_sample(predicted_value, error_value);
     }
 
-    [[nodiscard]] int32_t decode_run_interruption_error(context_run_mode& context)
+    [[nodiscard]]
+    int32_t decode_run_interruption_error(context_run_mode& context)
     {
         const int32_t k{context.get_golomb_code()};
         const int32_t e_mapped_error_value{
@@ -328,7 +332,8 @@ private:
         return error_value;
     }
 
-    [[nodiscard]] triplet<sample_type> decode_run_interruption_pixel(triplet<sample_type> ra, triplet<sample_type> rb)
+    [[nodiscard]]
+    triplet<sample_type> decode_run_interruption_pixel(triplet<sample_type> ra, triplet<sample_type> rb)
     {
         const int32_t error_value1{decode_run_interruption_error(context_run_mode_[0])};
         const int32_t error_value2{decode_run_interruption_error(context_run_mode_[0])};
@@ -339,7 +344,8 @@ private:
                 traits_.compute_reconstructed_sample(rb.v3, error_value3 * sign(rb.v3 - ra.v3))};
     }
 
-    [[nodiscard]] quad<sample_type> decode_run_interruption_pixel(quad<sample_type> ra, quad<sample_type> rb)
+    [[nodiscard]]
+    quad<sample_type> decode_run_interruption_pixel(quad<sample_type> ra, quad<sample_type> rb)
     {
         const int32_t error_value1{decode_run_interruption_error(context_run_mode_[0])};
         const int32_t error_value2{decode_run_interruption_error(context_run_mode_[0])};
@@ -352,7 +358,8 @@ private:
                 traits_.compute_reconstructed_sample(rb.v4, error_value4 * sign(rb.v4 - ra.v4))};
     }
 
-    [[nodiscard]] sample_type decode_run_interruption_pixel(int32_t ra, int32_t rb)
+    [[nodiscard]]
+    sample_type decode_run_interruption_pixel(int32_t ra, int32_t rb)
     {
         if (std::abs(ra - rb) <= traits_.near_lossless)
         {
@@ -364,7 +371,8 @@ private:
         return static_cast<sample_type>(traits_.compute_reconstructed_sample(rb, error_value * sign(rb - ra)));
     }
 
-    [[nodiscard]] int32_t decode_run_pixels(pixel_type ra, pixel_type* start_pos, const int32_t pixel_count)
+    [[nodiscard]]
+    int32_t decode_run_pixels(pixel_type ra, pixel_type* start_pos, const int32_t pixel_count)
     {
         int32_t index{};
         while (read_bit())

--- a/src/scan_encoder.h
+++ b/src/scan_encoder.h
@@ -146,7 +146,8 @@ protected:
         }
     }
 
-    [[nodiscard]] size_t get_length() const noexcept
+    [[nodiscard]]
+    size_t get_length() const noexcept
     {
         return bytes_written_ - (static_cast<size_t>(free_bit_count_) - 32U) / 8U;
     }

--- a/src/scan_encoder_impl.h
+++ b/src/scan_encoder_impl.h
@@ -93,7 +93,8 @@ private:
         impl::throw_jpegls_error(jpegls_errc::bit_depth_for_transform_not_supported);
     }
 
-    [[nodiscard]] FORCE_INLINE int32_t quantize_gradient(const int32_t di) const noexcept
+    [[nodiscard]]
+    FORCE_INLINE int32_t quantize_gradient(const int32_t di) const noexcept
     {
         ASSERT(quantize_gradient_org(di, traits_.near_lossless) == *(quantization_ + di));
         return *(quantization_ + di);
@@ -252,7 +253,8 @@ private:
         }
     }
 
-    [[nodiscard]] int32_t encode_run_mode(const int32_t index)
+    [[nodiscard]]
+    int32_t encode_run_mode(const int32_t index)
     {
         const int32_t count_type_remain = width_ - index;
         pixel_type* type_cur_x{current_line_ + index};
@@ -280,7 +282,8 @@ private:
         return run_length + 1;
     }
 
-    [[nodiscard]] FORCE_INLINE sample_type encode_regular(const int32_t qs, const int32_t x, const int32_t predicted)
+    [[nodiscard]]
+    FORCE_INLINE sample_type encode_regular(const int32_t qs, const int32_t x, const int32_t predicted)
     {
         const int32_t sign{bit_wise_sign(qs)};
         context_regular_mode& context{contexts_[apply_sign(qs, sign)]};
@@ -335,7 +338,8 @@ private:
         context.update_variables(error_value, e_mapped_error_value, reset_threshold_);
     }
 
-    [[nodiscard]] sample_type encode_run_interruption_pixel(const int32_t x, const int32_t ra, const int32_t rb)
+    [[nodiscard]]
+    sample_type encode_run_interruption_pixel(const int32_t x, const int32_t ra, const int32_t rb)
     {
         if (std::abs(ra - rb) <= traits_.near_lossless)
         {
@@ -349,8 +353,9 @@ private:
         return static_cast<sample_type>(traits_.compute_reconstructed_sample(rb, error_value * sign(rb - ra)));
     }
 
-    [[nodiscard]] triplet<sample_type>
-    encode_run_interruption_pixel(const triplet<sample_type> x, const triplet<sample_type> ra, const triplet<sample_type> rb)
+    [[nodiscard]]
+    triplet<sample_type> encode_run_interruption_pixel(const triplet<sample_type> x, const triplet<sample_type> ra,
+                                                       const triplet<sample_type> rb)
     {
         const int32_t error_value1{traits_.compute_error_value(sign(rb.v1 - ra.v1) * (x.v1 - rb.v1))};
         encode_run_interruption_error(context_run_mode_[0], error_value1);
@@ -366,8 +371,9 @@ private:
                 traits_.compute_reconstructed_sample(rb.v3, error_value3 * sign(rb.v3 - ra.v3))};
     }
 
-    [[nodiscard]] quad<sample_type> encode_run_interruption_pixel(const quad<sample_type> x, const quad<sample_type> ra,
-                                                                  const quad<sample_type> rb)
+    [[nodiscard]]
+    quad<sample_type> encode_run_interruption_pixel(const quad<sample_type> x, const quad<sample_type> ra,
+                                                    const quad<sample_type> rb)
     {
         const int32_t error_value1{traits_.compute_error_value(sign(rb.v1 - ra.v1) * (x.v1 - rb.v1))};
         encode_run_interruption_error(context_run_mode_[0], error_value1);

--- a/src/span.h
+++ b/src/span.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cstddef>
 #include <array>
+#include <cstddef>
 
 #include "util.h"
 
@@ -42,32 +42,38 @@ public:
     {
     }
 
-    [[nodiscard]] constexpr size_t size() const noexcept
+    [[nodiscard]]
+    constexpr size_t size() const noexcept
     {
         return size_;
     }
 
-    [[nodiscard]] constexpr pointer data() const noexcept
+    [[nodiscard]]
+    constexpr pointer data() const noexcept
     {
         return data_;
     }
 
-    [[nodiscard]] constexpr iterator begin() const noexcept
+    [[nodiscard]]
+    constexpr iterator begin() const noexcept
     {
         return data_;
     }
 
-    [[nodiscard]] constexpr iterator end() const noexcept
+    [[nodiscard]]
+    constexpr iterator end() const noexcept
     {
         return data_ + size_;
     }
 
-    [[nodiscard]] constexpr bool empty() const noexcept
+    [[nodiscard]]
+    constexpr bool empty() const noexcept
     {
         return size_ == 0;
     }
 
-    [[nodiscard]] constexpr span subspan(const size_t offset) const noexcept
+    [[nodiscard]]
+    constexpr span subspan(const size_t offset) const noexcept
     {
         ASSERT(offset <= size_);
         return {data_ + offset, size_ - offset};

--- a/src/util.h
+++ b/src/util.h
@@ -140,7 +140,9 @@ struct triplet
     SampleType v2{};
     SampleType v3{};
 
-    [[nodiscard]] friend constexpr bool operator==(const triplet& lhs, const triplet& rhs) noexcept
+    [[nodiscard]]
+    friend constexpr bool
+    operator==(const triplet& lhs, const triplet& rhs) noexcept
     {
         return lhs.v1 == rhs.v1 && lhs.v2 == rhs.v2 && lhs.v3 == rhs.v3;
     }
@@ -165,7 +167,9 @@ struct quad final
     SampleType v3{};
     SampleType v4{};
 
-    [[nodiscard]] friend constexpr bool operator==(const quad& lhs, const quad& rhs) noexcept
+    [[nodiscard]]
+    friend constexpr bool
+    operator==(const quad& lhs, const quad& rhs) noexcept
     {
         return lhs.v1 == rhs.v1 && lhs.v2 == rhs.v2 && lhs.v3 == rhs.v3 && lhs.v4 == rhs.v4;
     }
@@ -187,7 +191,8 @@ template<int BitCount, typename T>
 constexpr bool is_uint_v = sizeof(T) == BitCount / 8 && std::is_integral_v<T> && !std::is_signed_v<T>;
 
 template<typename T>
-[[nodiscard]] auto byte_swap(const T value) noexcept
+[[nodiscard]]
+auto byte_swap(const T value) noexcept
 {
     if constexpr (is_uint_v<16, T>)
     {
@@ -223,7 +228,8 @@ template<typename T>
 
 
 template<typename T>
-[[nodiscard]] T read_unaligned(const void* buffer) noexcept
+[[nodiscard]]
+T read_unaligned(const void* buffer) noexcept
 {
     // Note: MSVC, GCC and clang will replace this with a direct register read if the CPU architecture allows it
     // On x86, x64 and ARM64 this will just be 1 register load.

--- a/test/portable_anymap_file.h
+++ b/test/portable_anymap_file.h
@@ -42,22 +42,26 @@ public:
         convert_to_little_endian_if_needed();
     }
 
-    [[nodiscard]] int width() const noexcept
+    [[nodiscard]]
+    int width() const noexcept
     {
         return width_;
     }
 
-    [[nodiscard]] int height() const noexcept
+    [[nodiscard]]
+    int height() const noexcept
     {
         return height_;
     }
 
-    [[nodiscard]] int component_count() const noexcept
+    [[nodiscard]]
+    int component_count() const noexcept
     {
         return component_count_;
     }
 
-    [[nodiscard]] int bits_per_sample() const noexcept
+    [[nodiscard]]
+    int bits_per_sample() const noexcept
     {
         return bits_per_sample_;
     }
@@ -67,7 +71,8 @@ public:
         return input_buffer_;
     }
 
-    [[nodiscard]] const std::vector<std::byte>& image_data() const noexcept
+    [[nodiscard]]
+    const std::vector<std::byte>& image_data() const noexcept
     {
         return input_buffer_;
     }
@@ -100,7 +105,8 @@ private:
         return result;
     }
 
-    [[nodiscard]] static constexpr int32_t log_2(const int32_t n) noexcept
+    [[nodiscard]]
+    static constexpr int32_t log_2(const int32_t n) noexcept
     {
         int32_t x{};
         while (n > (1 << x))

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -29,7 +29,8 @@ namespace charls::test {
 
 namespace {
 
-[[nodiscard]] jpegls_decoder create_decoder(const vector<byte>& source)
+ [[nodiscard]]
+jpegls_decoder create_decoder(const vector<byte>& source)
 {
     return {source, true};
 }
@@ -1009,8 +1010,9 @@ public:
 
 private:
     // ReSharper disable CppPassValueParameterByConstReference
-    [[nodiscard]] static vector<byte>::iterator find_scan_header(const vector<byte>::iterator begin,
-                                                                 const vector<byte>::iterator end) noexcept
+    [[nodiscard]]
+    static vector<byte>::iterator find_scan_header(const vector<byte>::iterator begin,
+                                                   const vector<byte>::iterator end) noexcept
     // ReSharper restore CppPassValueParameterByConstReference
     {
         constexpr byte start_of_scan{0xDA};
@@ -1025,8 +1027,9 @@ private:
     }
 
     // ReSharper disable CppPassValueParameterByConstReference
-    [[nodiscard]] static vector<byte>::iterator find_first_restart_marker(const vector<byte>::iterator begin,
-                                                                          const vector<byte>::iterator end) noexcept
+    [[nodiscard]]
+    static vector<byte>::iterator find_first_restart_marker(const vector<byte>::iterator begin,
+                                                            const vector<byte>::iterator end) noexcept
     // ReSharper restore CppPassValueParameterByConstReference
     {
         constexpr byte first_restart_marker{0xD0};
@@ -1040,7 +1043,8 @@ private:
         return end;
     }
 
-    [[nodiscard]] static vector<byte> create_default_pc_parameters_segment()
+    [[nodiscard]]
+    static vector<byte> create_default_pc_parameters_segment()
     {
         vector<byte> segment;
 

--- a/unittest/scan_decoder_test.cpp
+++ b/unittest/scan_decoder_test.cpp
@@ -36,22 +36,26 @@ public:
         return {};
     }
 
-    [[nodiscard]] int32_t read(const int32_t length)
+    [[nodiscard]]
+    int32_t read(const int32_t length)
     {
         return read_long_value(length);
     }
 
-    [[nodiscard]] int32_t peek_byte_forward()
+    [[nodiscard]]
+    int32_t peek_byte_forward()
     {
         return peek_byte();
     }
 
-    [[nodiscard]] bool read_bit_forward()
+    [[nodiscard]]
+    bool read_bit_forward()
     {
         return read_bit();
     }
 
-    [[nodiscard]] int32_t peek_0_bits_forward()
+    [[nodiscard]]
+    int32_t peek_0_bits_forward()
     {
         return peek_0_bits();
     }

--- a/unittest/scan_encoder_tester.h
+++ b/unittest/scan_encoder_tester.h
@@ -39,7 +39,8 @@ public:
         flush();
     }
 
-    [[nodiscard]] size_t get_length_forward() const noexcept
+    [[nodiscard]]
+    size_t get_length_forward() const noexcept
     {
         return get_length();
     }

--- a/unittest/util.h
+++ b/unittest/util.h
@@ -14,17 +14,26 @@
 
 namespace charls::test {
 
-[[nodiscard]] std::vector<std::byte> read_file(const char* filename);
+[[nodiscard]]
+std::vector<std::byte> read_file(const char* filename);
 
-[[nodiscard]] charls_test::portable_anymap_file
-read_anymap_reference_file(const char* filename, interleave_mode interleave_mode, const frame_info& frame_info);
-[[nodiscard]] charls_test::portable_anymap_file read_anymap_reference_file(const char* filename,
-                                                                           interleave_mode interleave_mode);
-[[nodiscard]] std::vector<std::byte> create_test_spiff_header(uint8_t high_version = 2, uint8_t low_version = 0,
-                                                              bool end_of_directory = true, uint8_t component_count = 3);
-[[nodiscard]] std::vector<std::byte> create_noise_image_16_bit(size_t pixel_count, int bit_count, uint32_t seed);
-[[nodiscard]] bool verify_encoded_bytes(const std::vector<std::byte>& uncompressed_source,
-                                        const std::vector<std::byte>& encoded_source);
+[[nodiscard]]
+charls_test::portable_anymap_file read_anymap_reference_file(const char* filename, interleave_mode interleave_mode,
+                                                             const frame_info& frame_info);
+
+[[nodiscard]]
+charls_test::portable_anymap_file read_anymap_reference_file(const char* filename, interleave_mode interleave_mode);
+
+[[nodiscard]]
+std::vector<std::byte> create_test_spiff_header(uint8_t high_version = 2, uint8_t low_version = 0,
+                                                bool end_of_directory = true, uint8_t component_count = 3);
+
+[[nodiscard]]
+std::vector<std::byte> create_noise_image_16_bit(size_t pixel_count, int bit_count, uint32_t seed);
+
+[[nodiscard]]
+bool verify_encoded_bytes(const std::vector<std::byte>& uncompressed_source, const std::vector<std::byte>& encoded_source);
+
 void verify_decoded_bytes(interleave_mode interleave_mode, const frame_info& frame_info,
                           const std::vector<std::byte>& uncompressed_data, size_t destination_stride,
                           const char* reference_filename);
@@ -35,7 +44,8 @@ void test_compliance(const std::vector<std::byte>& encoded_source, const std::ve
 /// <summary>
 /// Computes how many bytes are needed to hold the number of bits.
 /// </summary>
-[[nodiscard]] constexpr uint32_t bit_to_byte_count(const int32_t bit_count) noexcept
+[[nodiscard]]
+constexpr uint32_t bit_to_byte_count(const int32_t bit_count) noexcept
 {
     return static_cast<uint32_t>((bit_count + 7) / 8);
 }


### PR DESCRIPTION
Follow the common cross language pattern to apply function attributes before the function definition/implementation.
This has mainly an impact on [[nodiscard]]