### PR TITLE
Replace set_presets with extra constructor parameter

### DIFF
--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -159,7 +159,7 @@ struct charls_jpegls_decoder final
         for (size_t plane{};;)
         {
             const auto decoder{make_scan_codec<scan_decoder>(
-                frame_info(), reader_.parameters(), reader_.get_validated_preset_coding_parameters())};
+                frame_info(), reader_.get_validated_preset_coding_parameters(), reader_.parameters())};
             const size_t bytes_read{decoder->decode_scan(reader_.remaining_source(), destination.data(), stride)};
             reader_.advance_position(bytes_read);
 

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -267,7 +267,7 @@ private:
                                             component_count};
 
         const auto encoder{make_scan_codec<scan_encoder>(
-            frame_info, {near_lossless_, 0, interleave_mode_, color_transformation_}, preset_coding_parameters_)};
+            frame_info, preset_coding_parameters_, {near_lossless_, 0, interleave_mode_, color_transformation_})};
         const size_t bytes_written{encoder->encode_scan(source, stride, writer_.remaining_destination())};
 
         // Synchronize the destination encapsulated in the writer (encode_scan works on a local copy)

--- a/src/make_scan_codec.h
+++ b/src/make_scan_codec.h
@@ -12,13 +12,13 @@ namespace charls {
 
 template<typename ScanProcess>
 [[nodiscard]]
-std::unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame, const coding_parameters& parameters,
-                                             const jpegls_pc_parameters& preset_coding_parameters);
+std::unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame,
+                                             const jpegls_pc_parameters& pc_parameters, const coding_parameters& parameters);
 
 
 extern template std::unique_ptr<class scan_decoder>
-make_scan_codec<scan_decoder>(const frame_info&, const coding_parameters&, const jpegls_pc_parameters&);
+make_scan_codec<scan_decoder>(const frame_info&, const jpegls_pc_parameters& , const coding_parameters&);
 extern template std::unique_ptr<class scan_encoder>
-make_scan_codec<scan_encoder>(const frame_info&, const coding_parameters&, const jpegls_pc_parameters&);
+make_scan_codec<scan_encoder>(const frame_info&, const jpegls_pc_parameters&, const coding_parameters&);
 
 } // namespace charls

--- a/src/scan_codec.h
+++ b/src/scan_codec.h
@@ -101,8 +101,15 @@ protected:
     /// <remarks>
     /// Copy frame_info and parameters to prevent 1 indirection during encoding/decoding.
     /// </remarks>
-    scan_codec(const frame_info& frame_info, const coding_parameters& parameters) noexcept :
-        frame_info_{frame_info}, parameters_{parameters}, width_{frame_info.width}
+    scan_codec(const frame_info& frame_info, const jpegls_pc_parameters& pc_parameters,
+               const coding_parameters& parameters) noexcept :
+        frame_info_{frame_info},
+        parameters_{parameters},
+        t1_{pc_parameters.threshold1},
+        t2_{pc_parameters.threshold2},
+        t3_{pc_parameters.threshold3},
+        width_{frame_info.width},
+        reset_value_{static_cast<uint8_t>(pc_parameters.reset_value)}
     {
         ASSERT((parameters.interleave_mode == interleave_mode::none && this->frame_info().component_count == 1) ||
                parameters.interleave_mode != interleave_mode::none);
@@ -169,7 +176,7 @@ protected:
     std::array<context_regular_mode, 365> contexts_;
     std::array<context_run_mode, 2> context_run_mode_;
     uint32_t width_;
-    uint8_t reset_threshold_{};
+    uint8_t reset_value_{};
 
     // Quantization lookup table
     const int8_t* quantization_{};

--- a/src/scan_decoder.h
+++ b/src/scan_decoder.h
@@ -30,7 +30,6 @@ public:
     scan_decoder& operator=(const scan_decoder&) = delete;
     scan_decoder& operator=(scan_decoder&&) = delete;
 
-    virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters) = 0;
     virtual size_t decode_scan(span<const std::byte> source, std::byte* destination, size_t stride) = 0;
 
 protected:

--- a/src/scan_encoder.h
+++ b/src/scan_encoder.h
@@ -27,7 +27,6 @@ public:
     scan_encoder& operator=(const scan_encoder&) = delete;
     scan_encoder& operator=(scan_encoder&&) = delete;
 
-    virtual void set_presets(const jpegls_pc_parameters& preset_coding_parameters) = 0;
     virtual size_t encode_scan(const std::byte* source, size_t stride, span<std::byte> destination) = 0;
 
 protected:

--- a/unittest/scan_decoder_test.cpp
+++ b/unittest/scan_decoder_test.cpp
@@ -22,13 +22,9 @@ class scan_decoder_tester final : public scan_decoder
 public:
     scan_decoder_tester(const charls::frame_info& frame_info, const coding_parameters& parameters, byte* const destination,
                         const size_t count) :
-        scan_decoder(frame_info, parameters)
+        scan_decoder(frame_info, {}, parameters)
     {
         initialize({destination, count});
-    }
-
-    void set_presets(const jpegls_pc_parameters& /*preset_coding_parameters*/) noexcept(false) override
-    {
     }
 
     size_t decode_scan(span<const byte> /*source*/, byte* /*destination*/, size_t /*stride*/) noexcept(false) override

--- a/unittest/scan_encoder_tester.h
+++ b/unittest/scan_encoder_tester.h
@@ -11,11 +11,7 @@ class scan_encoder_tester final : scan_encoder
 {
 public:
     explicit scan_encoder_tester(const charls::frame_info& frame_info, const coding_parameters& parameters) noexcept :
-        scan_encoder(frame_info, parameters)
-    {
-    }
-
-    void set_presets(const jpegls_pc_parameters&) noexcept(false) override
+        scan_encoder(frame_info, {}, parameters)
     {
     }
 


### PR DESCRIPTION
set_presets was used as a second constructor. Pass the pc_parameter to the base constructor to get rid of this method.