### PR TITLE
Add namespace charls to frame_info to prevent false GCC warning [-Wer…

### DIFF
--- a/src/color_transform.h
+++ b/src/color_transform.h
@@ -7,9 +7,9 @@
 
 namespace charls {
 
-inline bool color_transformation_possible(const frame_info& frame_info) noexcept
+inline bool color_transformation_possible(const frame_info& frame) noexcept
 {
-    return frame_info.component_count == 3 && (frame_info.bits_per_sample == 8 || frame_info.bits_per_sample == 16);
+    return frame.component_count == 3 && (frame.bits_per_sample == 8 || frame.bits_per_sample == 16);
 }
 
 // This file defines simple classes that define (lossless) color transforms.

--- a/src/process_encoded_line.h
+++ b/src/process_encoded_line.h
@@ -154,10 +154,10 @@ void transform_quad_to_line(const quad<PixelType>* source, const size_t pixel_st
     {
         const quad<PixelType>& color{source[i]};
 
-        destination[i] = color.v1 & mask;
-        destination[i + pixel_stride] = color.v2 & mask;
-        destination[i + 2 * pixel_stride] = color.v3 & mask;
-        destination[i + 3 * pixel_stride] = color.v4 & mask;
+        destination[i] = static_cast<PixelType>(color.v1 & mask);
+        destination[i + pixel_stride] = static_cast<PixelType>(color.v2 & mask);
+        destination[i + 2 * pixel_stride] = static_cast<PixelType>(color.v3 & mask);
+        destination[i + 3 * pixel_stride] = static_cast<PixelType>(color.v4 & mask);
     }
 }
 


### PR DESCRIPTION
…ror=shadow]