### PR TITLE
Fix charls-template.pc

### DIFF
--- a/src/charls-template.pc
+++ b/src/charls-template.pc
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/charls
 
 Name: CharLS
 Description: JPEG-LS (ISO/IEC 14495-1 / ITU-T.87) library implementation.


### PR DESCRIPTION
The pkg-config points to the wrong include dir.

Compare

https://github.com/team-charls/charls/blob/f2ff4448c2bd90fb15a1abe0e5d1702da1f8532b/src/CMakeLists.txt#L154