### PR TITLE
Update jpegls_decoder and jpegls_encoder to follow same const pattern as C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - BREAKING: Updated the minimal required C++ language version to C++17.
 - BREAKING: encoding_options::include_pc_parameters_jai is not enabled by default anymore.
+- BREAKING: charls::jpegls_decoder and charls::jpegls_encoder follow the same const pattern as the C API.
 
 ### Removed
 

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -389,7 +389,7 @@ public:
     jpegls_decoder& source(CHARLS_IN_READS_BYTES(source_size_bytes) const void* source_buffer,
                            const size_t source_size_bytes)
     {
-        check_jpegls_errc(charls_jpegls_decoder_set_source_buffer(decoder_.get(), source_buffer, source_size_bytes));
+        check_jpegls_errc(charls_jpegls_decoder_set_source_buffer(decoder(), source_buffer, source_size_bytes));
         return *this;
     }
 
@@ -434,7 +434,7 @@ public:
     bool read_spiff_header(std::error_code& ec) noexcept
     {
         int32_t found;
-        ec = charls_jpegls_decoder_read_spiff_header(decoder_.get(), &spiff_header_, &found);
+        ec = charls_jpegls_decoder_read_spiff_header(decoder(), &spiff_header_, &found);
         spiff_header_has_value_ = found != 0;
         return spiff_header_has_value_;
     }
@@ -460,10 +460,10 @@ public:
     /// <param name="ec">The out-parameter for error reporting.</param>
     jpegls_decoder& read_header(CHARLS_OUT std::error_code& ec) noexcept
     {
-        ec = charls_jpegls_decoder_read_header(decoder_.get());
+        ec = charls_jpegls_decoder_read_header(decoder());
         if (ec == jpegls_errc::success)
         {
-            ec = charls_jpegls_decoder_get_frame_info(decoder_.get(), &frame_info_);
+            ec = charls_jpegls_decoder_get_frame_info(decoder(), &frame_info_);
             if (ec == jpegls_errc::success && spiff_header_has_value_)
             {
                 ec = charls_validate_spiff_header(&spiff_header_, &frame_info_);
@@ -536,7 +536,7 @@ public:
     int32_t near_lossless(const int32_t component = 0) const
     {
         int32_t near_lossless;
-        check_jpegls_errc(charls_jpegls_decoder_get_near_lossless(decoder_.get(), component, &near_lossless));
+        check_jpegls_errc(charls_jpegls_decoder_get_near_lossless(decoder(), component, &near_lossless));
         return near_lossless;
     }
 
@@ -549,7 +549,7 @@ public:
     charls::interleave_mode interleave_mode() const
     {
         charls::interleave_mode interleave_mode;
-        check_jpegls_errc(charls_jpegls_decoder_get_interleave_mode(decoder_.get(), &interleave_mode));
+        check_jpegls_errc(charls_jpegls_decoder_get_interleave_mode(decoder(), &interleave_mode));
         return interleave_mode;
     }
 
@@ -562,7 +562,7 @@ public:
     jpegls_pc_parameters preset_coding_parameters() const
     {
         jpegls_pc_parameters preset_coding_parameters;
-        check_jpegls_errc(charls_jpegls_decoder_get_preset_coding_parameters(decoder_.get(), 0, &preset_coding_parameters));
+        check_jpegls_errc(charls_jpegls_decoder_get_preset_coding_parameters(decoder(), 0, &preset_coding_parameters));
         return preset_coding_parameters;
     }
 
@@ -575,7 +575,7 @@ public:
     charls::color_transformation color_transformation() const
     {
         charls::color_transformation color_transformation;
-        check_jpegls_errc(charls_jpegls_decoder_get_color_transformation(decoder_.get(), &color_transformation));
+        check_jpegls_errc(charls_jpegls_decoder_get_color_transformation(decoder(), &color_transformation));
         return color_transformation;
     }
 
@@ -590,7 +590,7 @@ public:
     size_t destination_size(const uint32_t stride = 0) const
     {
         size_t size_in_bytes;
-        check_jpegls_errc(charls_jpegls_decoder_get_destination_size(decoder_.get(), stride, &size_in_bytes));
+        check_jpegls_errc(charls_jpegls_decoder_get_destination_size(decoder(), stride, &size_in_bytes));
         return size_in_bytes;
     }
 
@@ -603,10 +603,10 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     CHARLS_ATTRIBUTE_ACCESS((access(write_only, 2, 3)))
     void decode(CHARLS_OUT_WRITES_BYTES(destination_size_bytes) void* destination_buffer,
-                const size_t destination_size_bytes, const uint32_t stride = 0) const
+                const size_t destination_size_bytes, const uint32_t stride = 0)
     {
         check_jpegls_errc(
-            charls_jpegls_decoder_decode_to_buffer(decoder_.get(), destination_buffer, destination_size_bytes, stride));
+            charls_jpegls_decoder_decode_to_buffer(decoder(), destination_buffer, destination_size_bytes, stride));
     }
 
     /// <summary>
@@ -618,7 +618,7 @@ public:
     /// <param name="stride">Number of bytes to the next line in the buffer, when zero, decoder will compute it.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     template<typename Container, typename ContainerValueType = typename Container::value_type>
-    void decode(CHARLS_OUT Container& destination_container, const uint32_t stride = 0) const
+    void decode(CHARLS_OUT Container& destination_container, const uint32_t stride = 0)
     {
         decode(destination_container.data(), destination_container.size() * sizeof(ContainerValueType), stride);
     }
@@ -631,7 +631,7 @@ public:
     /// <returns>Container with the decoded data.</returns>
     template<typename Container, typename ContainerValueType = typename Container::value_type>
     [[nodiscard]]
-    Container decode(const uint32_t stride = 0) const
+    Container decode(const uint32_t stride = 0)
     {
         Container destination(destination_size() / sizeof(ContainerValueType));
 
@@ -653,7 +653,7 @@ public:
     {
         comment_handler_ = std::move(comment_handler);
         check_jpegls_errc(
-            charls_jpegls_decoder_at_comment(decoder_.get(), comment_handler_ ? &at_comment_callback : nullptr, this));
+            charls_jpegls_decoder_at_comment(decoder(), comment_handler_ ? &at_comment_callback : nullptr, this));
         return *this;
     }
 
@@ -672,7 +672,7 @@ public:
     {
         application_data_handler_ = std::move(application_data_handler);
         check_jpegls_errc(charls_jpegls_decoder_at_application_data(
-            decoder_.get(), application_data_handler_ ? &at_application_data_callback : nullptr, this));
+            decoder(), application_data_handler_ ? &at_application_data_callback : nullptr, this));
         return *this;
     }
 
@@ -689,7 +689,7 @@ public:
     int32_t mapping_table_id(const int32_t component_index) const
     {
         int32_t table_id;
-        check_jpegls_errc(charls_decoder_get_mapping_table_id(decoder_.get(), component_index, &table_id));
+        check_jpegls_errc(charls_decoder_get_mapping_table_id(decoder(), component_index, &table_id));
         return table_id;
     }
 
@@ -708,7 +708,7 @@ public:
     std::optional<int32_t> mapping_table_index(const int32_t table_id) const
     {
         int32_t index;
-        check_jpegls_errc(charls_decoder_get_mapping_table_index(decoder_.get(), table_id, &index));
+        check_jpegls_errc(charls_decoder_get_mapping_table_index(decoder(), table_id, &index));
         return index == mapping_table_missing ? std::optional<int32_t>{} : index;
     }
 
@@ -724,7 +724,7 @@ public:
     int32_t mapping_table_count() const
     {
         int32_t count;
-        check_jpegls_errc(charls_decoder_get_mapping_table_count(decoder_.get(), &count));
+        check_jpegls_errc(charls_decoder_get_mapping_table_count(decoder(), &count));
         return count;
     }
 
@@ -741,7 +741,7 @@ public:
     table_info mapping_table_info(const int32_t index) const
     {
         table_info info;
-        check_jpegls_errc(charls_decoder_get_mapping_table_info(decoder_.get(), index, &info));
+        check_jpegls_errc(charls_decoder_get_mapping_table_info(decoder(), index, &info));
         return info;
     }
 
@@ -759,7 +759,7 @@ public:
     void mapping_table(const int32_t index, CHARLS_OUT_WRITES_BYTES(table_size_bytes) void* table_data,
                        const size_t table_size_bytes) const
     {
-        check_jpegls_errc(charls_decoder_get_mapping_table(decoder_.get(), index, table_data, table_size_bytes));
+        check_jpegls_errc(charls_decoder_get_mapping_table(decoder(), index, table_data, table_size_bytes));
     }
 
     /// <summary>
@@ -778,6 +778,18 @@ public:
     }
 
 private:
+    [[nodiscard]]
+    charls_jpegls_decoder* decoder() noexcept
+    {
+        return decoder_.get();
+    }
+
+    [[nodiscard]]
+    const charls_jpegls_decoder* decoder() const noexcept
+    {
+        return decoder_.get();
+    }
+
     [[nodiscard]]
     static charls_jpegls_decoder* create_decoder()
     {

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -355,7 +355,7 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& frame_info(const frame_info& frame_info)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_frame_info(encoder_.get(), &frame_info));
+        check_jpegls_errc(charls_jpegls_encoder_set_frame_info(encoder(), &frame_info));
         return *this;
     }
 
@@ -366,7 +366,7 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& near_lossless(const int32_t near_lossless)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_near_lossless(encoder_.get(), near_lossless));
+        check_jpegls_errc(charls_jpegls_encoder_set_near_lossless(encoder(), near_lossless));
         return *this;
     }
 
@@ -378,7 +378,7 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& interleave_mode(const interleave_mode interleave_mode)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_interleave_mode(encoder_.get(), interleave_mode));
+        check_jpegls_errc(charls_jpegls_encoder_set_interleave_mode(encoder(), interleave_mode));
         return *this;
     }
 
@@ -389,7 +389,7 @@ public:
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     jpegls_encoder& encoding_options(const encoding_options encoding_options)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_encoding_options(encoder_.get(), encoding_options));
+        check_jpegls_errc(charls_jpegls_encoder_set_encoding_options(encoder(), encoding_options));
         return *this;
     }
 
@@ -402,7 +402,7 @@ public:
     /// <param name="preset_coding_parameters">Reference to the preset coding parameters.</param>
     jpegls_encoder& preset_coding_parameters(const jpegls_pc_parameters& preset_coding_parameters)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_preset_coding_parameters(encoder_.get(), &preset_coding_parameters));
+        check_jpegls_errc(charls_jpegls_encoder_set_preset_coding_parameters(encoder(), &preset_coding_parameters));
         return *this;
     }
 
@@ -415,7 +415,7 @@ public:
     /// <param name="color_transformation">The color transformation parameters.</param>
     jpegls_encoder& color_transformation(const color_transformation color_transformation)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_color_transformation(encoder_.get(), color_transformation));
+        check_jpegls_errc(charls_jpegls_encoder_set_color_transformation(encoder(), color_transformation));
         return *this;
     }
 
@@ -427,7 +427,7 @@ public:
     /// <param name="table_id">Table ID that will be referenced by this component.</param>
     jpegls_encoder& set_table_id(const int32_t component_index, const int32_t table_id)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_table_id(encoder_.get(), component_index, table_id));
+        check_jpegls_errc(charls_jpegls_encoder_set_table_id(encoder(), component_index, table_id));
         return *this;
     }
 
@@ -442,7 +442,7 @@ public:
     size_t estimated_destination_size() const
     {
         size_t size_in_bytes;
-        check_jpegls_errc(charls_jpegls_encoder_get_estimated_destination_size(encoder_.get(), &size_in_bytes));
+        check_jpegls_errc(charls_jpegls_encoder_get_estimated_destination_size(encoder(), &size_in_bytes));
         return size_in_bytes;
     }
 
@@ -457,7 +457,7 @@ public:
                                 const size_t destination_size_bytes)
     {
         check_jpegls_errc(
-            charls_jpegls_encoder_set_destination_buffer(encoder_.get(), destination_buffer, destination_size_bytes));
+            charls_jpegls_encoder_set_destination_buffer(encoder(), destination_buffer, destination_size_bytes));
         return *this;
     }
 
@@ -490,7 +490,7 @@ public:
                                 const spiff_resolution_units resolution_units = spiff_resolution_units::aspect_ratio,
                                 const uint32_t vertical_resolution = 1, const uint32_t horizontal_resolution = 1)
     {
-        check_jpegls_errc(charls_jpegls_encoder_write_standard_spiff_header(encoder_.get(), color_space, resolution_units,
+        check_jpegls_errc(charls_jpegls_encoder_write_standard_spiff_header(encoder(), color_space, resolution_units,
                                                                             vertical_resolution, horizontal_resolution));
         return *this;
     }
@@ -501,7 +501,7 @@ public:
     /// <param name="header">Reference to a SPIFF header that will be written to the destination.</param>
     jpegls_encoder& write_spiff_header(const spiff_header& header)
     {
-        check_jpegls_errc(charls_jpegls_encoder_write_spiff_header(encoder_.get(), &header));
+        check_jpegls_errc(charls_jpegls_encoder_write_spiff_header(encoder(), &header));
         return *this;
     }
 
@@ -517,7 +517,7 @@ public:
                                       CHARLS_IN_READS_BYTES(entry_data_size_bytes) const void* entry_data,
                                       const size_t entry_data_size_bytes)
     {
-        check_jpegls_errc(charls_jpegls_encoder_write_spiff_entry(encoder_.get(), static_cast<uint32_t>(entry_tag),
+        check_jpegls_errc(charls_jpegls_encoder_write_spiff_entry(encoder(), static_cast<uint32_t>(entry_tag),
                                                                   entry_data, entry_data_size_bytes));
         return *this;
     }
@@ -532,7 +532,7 @@ public:
     /// </remarks>
     jpegls_encoder& write_spiff_end_of_directory_entry()
     {
-        check_jpegls_errc(charls_jpegls_encoder_write_spiff_end_of_directory_entry(encoder_.get()));
+        check_jpegls_errc(charls_jpegls_encoder_write_spiff_end_of_directory_entry(encoder()));
         return *this;
     }
 
@@ -558,7 +558,7 @@ public:
     CHARLS_ATTRIBUTE_ACCESS((access(read_only, 2, 3)))
     jpegls_encoder& write_comment(CHARLS_IN_READS_BYTES(size) const void* comment, const size_t size)
     {
-        check_jpegls_errc(charls_jpegls_encoder_write_comment(encoder_.get(), comment, size));
+        check_jpegls_errc(charls_jpegls_encoder_write_comment(encoder(), comment, size));
         return *this;
     }
 
@@ -573,7 +573,7 @@ public:
                                            CHARLS_IN_READS_BYTES(size) const void* application_data, const size_t size)
     {
         check_jpegls_errc(
-            charls_jpegls_encoder_write_application_data(encoder_.get(), application_data_id, application_data, size));
+            charls_jpegls_encoder_write_application_data(encoder(), application_data_id, application_data, size));
         return *this;
     }
 
@@ -591,7 +591,7 @@ public:
     jpegls_encoder& write_table(const int32_t table_id, const int32_t entry_size, CHARLS_IN const void* table_data,
                                 const size_t size)
     {
-        check_jpegls_errc(charls_jpegls_encoder_write_table(encoder_.get(), table_id, entry_size, table_data, size));
+        check_jpegls_errc(charls_jpegls_encoder_write_table(encoder(), table_id, entry_size, table_data, size));
         return *this;
     }
 
@@ -623,10 +623,10 @@ public:
     /// <returns>The number of bytes written to the destination.</returns>
     CHARLS_ATTRIBUTE_ACCESS((access(read_only, 2, 3)))
     size_t encode(CHARLS_IN_READS_BYTES(source_size_bytes) const void* source_buffer, const size_t source_size_bytes,
-                  const uint32_t stride = 0) const
+                  const uint32_t stride = 0)
     {
         check_jpegls_errc(
-            charls_jpegls_encoder_encode_from_buffer(encoder_.get(), source_buffer, source_size_bytes, stride));
+            charls_jpegls_encoder_encode_from_buffer(encoder(), source_buffer, source_size_bytes, stride));
         return bytes_written();
     }
 
@@ -640,7 +640,7 @@ public:
     /// </param>
     /// <returns>The number of bytes written to the destination.</returns>
     template<typename Container, typename ContainerValueType = typename Container::value_type>
-    size_t encode(const Container& source_container, const uint32_t stride = 0) const
+    size_t encode(const Container& source_container, const uint32_t stride = 0)
     {
         return encode(source_container.data(), source_container.size() * sizeof(ContainerValueType), stride);
     }
@@ -650,9 +650,9 @@ public:
     /// These tables should have been written to the stream first with the method write_table.
     /// </summary>
     /// <returns>The number of bytes written to the destination.</returns>
-    size_t create_tables_only() const
+    size_t create_tables_only()
     {
-        check_jpegls_errc(charls_jpegls_encoder_create_tables_only(encoder_.get()));
+        check_jpegls_errc(charls_jpegls_encoder_create_tables_only(encoder()));
         return bytes_written();
     }
 
@@ -664,19 +664,31 @@ public:
     size_t bytes_written() const
     {
         size_t bytes_written;
-        check_jpegls_errc(charls_jpegls_encoder_get_bytes_written(encoder_.get(), &bytes_written));
+        check_jpegls_errc(charls_jpegls_encoder_get_bytes_written(encoder(), &bytes_written));
         return bytes_written;
     }
 
     /// <summary>
     /// Resets the write position of the destination buffer to the beginning.
     /// </summary>
-    void rewind() const
+    void rewind()
     {
-        check_jpegls_errc(charls_jpegls_encoder_rewind(encoder_.get()));
+        check_jpegls_errc(charls_jpegls_encoder_rewind(encoder()));
     }
 
 private:
+    [[nodiscard]]
+    charls_jpegls_encoder* encoder() noexcept
+    {
+        return encoder_.get();
+    }
+
+    [[nodiscard]]
+    const charls_jpegls_encoder* encoder() const noexcept
+    {
+        return encoder_.get();
+    }
+
     [[nodiscard]]
     static charls_jpegls_encoder* create_encoder()
     {

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -23,12 +23,14 @@ using std::optional;
 
 namespace {
 
+[[nodiscard]]
 constexpr bool is_restart_marker_code(const jpeg_marker_code marker_code) noexcept
 {
     return static_cast<uint8_t>(marker_code) >= jpeg_restart_marker_base &&
            static_cast<uint8_t>(marker_code) < jpeg_restart_marker_base + jpeg_restart_marker_range;
 }
 
+[[nodiscard]]
 constexpr int32_t to_application_data_id(const jpeg_marker_code marker_code) noexcept
 {
     return static_cast<int32_t>(marker_code) - static_cast<int32_t>(jpeg_marker_code::application_data0);

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -104,7 +104,7 @@ void decode_performance_tests(const int loop_count)
         const auto start{steady_clock::now()};
         for (int i{}; i != loop_count; ++i)
         {
-            const jpegls_decoder decoder{encoded_source, true};
+            jpegls_decoder decoder{encoded_source, true};
 
             decoder.decode(destination);
         }

--- a/unittest/documentation_test.cpp
+++ b/unittest/documentation_test.cpp
@@ -35,7 +35,7 @@ std::vector<std::byte> decode_simple_8_bit_monochrome(const std::vector<std::byt
 
 std::vector<std::byte> decode_advanced(const std::vector<std::byte>& source)
 {
-    const jpegls_decoder decoder{source, true};
+    jpegls_decoder decoder{source, true};
 
     // Standalone JPEG-LS files may have a SPIFF header (color space info, etc.)
     if (decoder.spiff_header_has_value() && decoder.spiff_header().color_space != spiff_color_space::grayscale)

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -237,7 +237,7 @@ public:
     TEST_METHOD(destination_size_for_small_image_with_custom_stride) // NOLINT
     {
         const auto source{read_file("8bit-monochrome-2x2.jls")};
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
 
         constexpr uint32_t stride{4};
         const size_t destination_size{decoder.destination_size(stride)};
@@ -250,7 +250,7 @@ public:
     TEST_METHOD(decode_reference_file_from_buffer) // NOLINT
     {
         const auto source{read_file("DataFiles/t8c0e0.jls")};
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
 
         vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
@@ -270,7 +270,7 @@ public:
         auto source{read_file("DataFiles/t8c0e0.jls")};
         insert_pc_parameters_segments(source, 3);
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
 
         vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
@@ -294,7 +294,7 @@ public:
         writer.write_byte(byte{0x80});
         writer.write_start_of_scan_segment(1, 2, 0, interleave_mode::sample);
 
-        const jpegls_decoder decoder(writer.buffer, true);
+        jpegls_decoder decoder(writer.buffer, true);
         std::vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::parameter_value_not_supported,
@@ -304,7 +304,7 @@ public:
     TEST_METHOD(decode_with_destination_as_return) // NOLINT
     {
         const auto source{read_file("DataFiles/t8c0e0.jls")};
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         const auto destination{decoder.decode<vector<byte>>()};
 
         portable_anymap_file reference_file{
@@ -320,7 +320,7 @@ public:
     TEST_METHOD(decode_with_16_bit_destination_as_return) // NOLINT
     {
         const auto source{read_file("DataFiles/t8c0e0.jls")};
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         const auto destination{decoder.decode<vector<uint16_t>>()};
 
         portable_anymap_file reference_file{
@@ -336,7 +336,7 @@ public:
 
     TEST_METHOD(decode_without_reading_header_throws) // NOLINT
     {
-        const jpegls_decoder decoder;
+        jpegls_decoder decoder;
 
         vector<byte> buffer(1000);
         assert_expect_exception(jpegls_errc::invalid_operation, [&decoder, &buffer] { decoder.decode(buffer); });
@@ -366,7 +366,7 @@ public:
     {
         const auto source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size());
 
         constexpr uint32_t correct_stride{256};
@@ -379,7 +379,7 @@ public:
     {
         const auto source{read_file("DataFiles/t8c2e0.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size());
 
         constexpr uint32_t correct_stride{256 * 3};
@@ -392,7 +392,7 @@ public:
     {
         const auto source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size());
         const uint32_t standard_stride{decoder.frame_info().width};
         decoder.decode(destination, standard_stride);
@@ -405,7 +405,7 @@ public:
     {
         const auto source{read_file("DataFiles/t8c2e0.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size());
         const uint32_t standard_stride{decoder.frame_info().width * 3};
         decoder.decode(destination, standard_stride);
@@ -419,7 +419,7 @@ public:
         constexpr uint32_t custom_stride{256 + 1};
         const auto source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size(custom_stride));
         decoder.decode(destination, custom_stride);
 
@@ -432,7 +432,7 @@ public:
         constexpr uint32_t custom_stride{256 * 3 + 1};
         const auto source{read_file("DataFiles/t8c2e0.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size(custom_stride));
         decoder.decode(destination, custom_stride);
 
@@ -543,7 +543,7 @@ public:
 
         const auto encoded{jpegls_encoder::encode(source_to_encode, frame_info)};
 
-        const jpegls_decoder decoder{encoded, true};
+        jpegls_decoder decoder{encoded, true};
         vector<byte> destination(decoder.destination_size());
         decoder.decode(destination);
 
@@ -588,7 +588,7 @@ public:
     {
         const auto source{read_file("ff_in_entropy_data.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
 
         const auto& frame_info{decoder.frame_info()};
         Assert::AreEqual(1, frame_info.component_count);
@@ -614,7 +614,7 @@ public:
             // that can be checked with address sanitizer.
             const vector source(encoded.cbegin(), encoded.cend() - 1);
 
-            const jpegls_decoder decoder{source, true};
+            jpegls_decoder decoder{source, true};
             vector<byte> destination(decoder.destination_size());
             assert_expect_exception(jpegls_errc::source_buffer_too_small,
                                     [&decoder, &destination] { decoder.decode(destination); });
@@ -622,7 +622,7 @@ public:
 
         {
             const vector source(encoded.cbegin(), encoded.cend() - 2);
-            const jpegls_decoder decoder{source, true};
+            jpegls_decoder decoder{source, true};
             vector<byte> destination(decoder.destination_size());
 
             assert_expect_exception(jpegls_errc::source_buffer_too_small,
@@ -632,7 +632,7 @@ public:
         {
             auto source(encoded);
             source[source.size() - 1] = byte{0x33};
-            const jpegls_decoder decoder{source, true};
+            jpegls_decoder decoder{source, true};
             vector<byte> destination(decoder.destination_size());
 
             assert_expect_exception(jpegls_errc::end_of_image_marker_not_found,
@@ -644,7 +644,7 @@ public:
     {
         const auto source{read_file("fuzzy_input_golomb_16.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
 
         const auto& frame_info{decoder.frame_info()};
         Assert::AreEqual(3, frame_info.component_count);
@@ -662,7 +662,7 @@ public:
     {
         const auto source{read_file("DataFiles/no_start_byte_after_encoded_scan.jls")};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
 
         const auto& frame_info{decoder.frame_info()};
         Assert::AreEqual(3, frame_info.component_count);
@@ -686,7 +686,7 @@ public:
         const auto it{source.begin() + 2};
         source.insert(it, stream_writer.buffer.cbegin(), stream_writer.buffer.cend());
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::restart_marker_not_found,
@@ -703,7 +703,7 @@ public:
         ++it;
         *it = byte{0xD1};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::restart_marker_not_found,
@@ -739,7 +739,7 @@ public:
         // that can be checked with address sanitizer.
         const vector too_small_source(source.begin(), it);
 
-        const jpegls_decoder decoder{too_small_source, true};
+        jpegls_decoder decoder{too_small_source, true};
         vector<byte> destination(decoder.destination_size());
 
         assert_expect_exception(jpegls_errc::source_buffer_too_small,
@@ -1159,7 +1159,7 @@ public:
     {
         const auto encoded_source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder(encoded_source, true);
+        jpegls_decoder decoder(encoded_source, true);
         vector<byte> decoded_destination(decoder.destination_size());
 
         decoder.decode(decoded_destination);
@@ -1173,7 +1173,7 @@ public:
     {
         const auto encoded_source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder(encoded_source, true);
+        jpegls_decoder decoder(encoded_source, true);
         vector<byte> decoded_destination(decoder.destination_size());
 
         decoder.decode(decoded_destination);
@@ -1203,7 +1203,7 @@ public:
     {
         const auto encoded_source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder(encoded_source, true);
+        jpegls_decoder decoder(encoded_source, true);
         vector<byte> decoded_destination(decoder.destination_size());
         decoder.decode(decoded_destination);
 
@@ -1244,7 +1244,7 @@ public:
     {
         const auto encoded_source{read_file("DataFiles/t8c0e0.jls")};
 
-        const jpegls_decoder decoder(encoded_source, true);
+        jpegls_decoder decoder(encoded_source, true);
         vector<byte> decoded_destination(decoder.destination_size());
         decoder.decode(decoded_destination);
         vector<byte> table(1000);
@@ -1339,7 +1339,7 @@ private:
     {
         const auto source{read_file(image_filename)};
 
-        const jpegls_decoder decoder{source, true};
+        jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size(stride) - 1);
 
         assert_expect_exception(jpegls_errc::destination_buffer_too_small,

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -1091,7 +1091,7 @@ public:
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
-        const jpegls_decoder decoder(destination, true);
+        jpegls_decoder decoder(destination, true);
         vector<byte> destination_decoded(decoder.destination_size());
         decoder.decode(destination_decoded);
         Assert::AreEqual(1, decoder.mapping_table_id(0));
@@ -1111,7 +1111,7 @@ public:
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
-        const jpegls_decoder decoder(destination, true);
+        jpegls_decoder decoder(destination, true);
         vector<byte> destination_decoded(decoder.destination_size());
         decoder.decode(destination_decoded);
         Assert::AreEqual(0, decoder.mapping_table_id(0));

--- a/unittest/util.cpp
+++ b/unittest/util.cpp
@@ -234,15 +234,14 @@ void verify_decoded_bytes(const interleave_mode interleave_mode, const frame_inf
 
 void test_compliance(const vector<byte>& encoded_source, const vector<byte>& uncompressed_source, const bool check_encode)
 {
-    const jpegls_decoder decoder{encoded_source, true};
+    jpegls_decoder decoder{encoded_source, true};
 
     if (check_encode)
     {
         Assert::IsTrue(verify_encoded_bytes(uncompressed_source, encoded_source));
     }
 
-    vector<byte> destination(decoder.destination_size());
-    decoder.decode(destination);
+    const auto destination{decoder.decode<vector<byte>>()};
 
     if (decoder.near_lossless() == 0)
     {


### PR DESCRIPTION
Use helper methods to ensure const is correctly forwarded to the C API.