### PR TITLE
Simplify enums: only define used values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Team CharLS.
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.13...3.30)
+cmake_minimum_required(VERSION 3.16...3.30)
 
 # Extract the version info from version.h
 file(READ "include/charls/version.h" version)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,20 @@ After releasing the original baseline JPEG-LS standard ISO 14495-1:1999, ISO rel
 
 ## Supported platforms
 
-The code is regularly compiled/tested on Windows and 64 bit Linux. Additionally, the code has been successfully tested on Linux Intel/AMD 32/64 bit (slackware, debian, gentoo), Solaris SPARC systems, Intel based Macs and Windows CE (ARM CPU, emulated), where the less common compilers may require minor code edits. It leverages C++ language features (templates, traits) to create optimized code, which generally perform best with recent compilers. If you compile with GCC, 64 bit code performs substantially better.
+The code is regularly compiled/tested on Windows and 64 bit Linux. Additionally, the code has been successfully tested on Linux Intel/AMD 32/64 bit (slackware, debian, gentoo), Solaris SPARC systems, Intel based Macs and Windows CE (ARM CPU, emulated), where the less common compilers may require minor code edits. It leverages C++ language features (templates, traits) to create optimized code, which generally perform best with recent compilers.
+
+### Support Matrix
+
+| Dimension     | Supported Version      |
+|---------------|------------------------|
+| C Version     | >= 17                  |
+| C++ Version   | >= 17                  |
+| CMake         | >= 3.16                |
+| GCC           | >= 9.1                 |
+| Clang         | >= 7.0.0               |
+| MSVC          | >= 2019                |
+| Apple Clang   | >= 12                  |
+
 
 ## Getting Started
 

--- a/src/jpeg_marker_code.h
+++ b/src/jpeg_marker_code.h
@@ -22,6 +22,8 @@ constexpr uint32_t jpeg_restart_marker_range{8};
 
 enum class jpeg_marker_code : uint8_t
 {
+    // The following markers are defined in ISO/IEC 10918-1 | ITU T.81 (general JPEG standard).
+
     /// <summary>SOI: Marks the start of an image.</summary>
     start_of_image = 0xD8,
 
@@ -36,51 +38,6 @@ enum class jpeg_marker_code : uint8_t
 
     /// <summary>DRI: Defines the restart interval used in succeeding scans.</summary>
     define_restart_interval = 0xDD,
-
-
-    // The following markers are defined in ISO/IEC 10918-1 | ITU T.81 (general JPEG standard).
-
-    /// <summary>SOF_0: Marks the start of a baseline jpeg encoded frame.</summary>
-    start_of_frame_baseline_jpeg = 0xC0,
-
-    /// <summary>SOF_1: Marks the start of an extended sequential Huffman encoded frame.</summary>
-    start_of_frame_extended_sequential = 0xC1,
-
-    /// <summary>SOF_2: Marks the start of a progressive Huffman encoded frame.</summary>
-    start_of_frame_progressive = 0xC2, //
-
-    /// <summary>SOF_3: Marks the start of a lossless Huffman encoded frame.</summary>
-    start_of_frame_lossless = 0xC3,
-
-    /// <summary>SOF_5: Marks the start of a differential sequential Huffman encoded frame.</summary>
-    start_of_frame_differential_sequential = 0xC5,
-
-    /// <summary>SOF_6: Marks the start of a differential progressive Huffman encoded frame.</summary>
-    start_of_frame_differential_progressive = 0xC6,
-
-    /// <summary>SOF_7: Marks the start of a differential lossless Huffman encoded frame.</summary>
-    start_of_frame_differential_lossless = 0xC7,
-
-    /// <summary>SOF_9: Marks the start of an extended sequential arithmetic encoded frame.</summary>
-    start_of_frame_extended_arithmetic = 0xC9,
-
-    /// <summary>SOF_10: Marks the start of a progressive arithmetic encoded frame.</summary>
-    start_of_frame_progressive_arithmetic = 0xCA,
-
-    /// <summary>SOF_11: Marks the start of a lossless arithmetic encoded frame.</summary>
-    start_of_frame_lossless_arithmetic = 0xCB,
-
-
-    // The following markers are defined in ISO/IEC 14495-1 | ITU T.87. (JPEG-LS standard)
-
-    /// <summary>SOF_55: Marks the start of a JPEG-LS encoded frame.</summary>
-    start_of_frame_jpegls = 0xF7,
-
-    /// <summary>LSE: Marks the start of a JPEG-LS preset parameters segment.</summary>
-    jpegls_preset_parameters = 0xF8,
-
-    /// <summary>SOF_57: Marks the start of a JPEG-LS extended (ISO/IEC 14495-2) encoded frame.</summary>
-    start_of_frame_jpegls_extended = 0xF9,
 
     /// <summary>APP0: Application data 0: used for JFIF header.</summary>
     application_data0 = 0xE0,
@@ -131,7 +88,15 @@ enum class jpeg_marker_code : uint8_t
     application_data15 = 0xEF,
 
     /// <summary>COM: Comment block.</summary>
-    comment = 0xFE
+    comment = 0xFE,
+
+    // The following markers are defined in ISO/IEC 14495-1 | ITU T.87. (JPEG-LS standard)
+
+    /// <summary>SOF_55: Marks the start of a JPEG-LS encoded frame.</summary>
+    start_of_frame_jpegls = 0xF7,
+
+    /// <summary>LSE: Marks the start of a JPEG-LS preset parameters segment.</summary>
+    jpegls_preset_parameters = 0xF8
 };
 
 } // namespace charls

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -75,7 +75,7 @@ void jpeg_stream_writer::write_spiff_end_of_directory_entry()
 {
     // Note: ISO/IEC 10918-3, Annex F.2.2.3 documents that the EOD entry segment should have a length of 8
     // but only 6 data bytes. This approach allows to wrap existing bit streams\encoders with a SPIFF header.
-    // In this implementation the SOI marker is added as data bytes to simplify the design.
+    // In this implementation the SOI marker is added as data bytes to simplify the stream writer design.
     static constexpr array spiff_end_of_directory{byte{0},    byte{0},
                                                   byte{0},    byte{spiff_end_of_directory_entry_type},
                                                   byte{0xFF}, byte{to_underlying_type(jpeg_marker_code::start_of_image)}};

--- a/src/jpegls_preset_parameters_type.h
+++ b/src/jpegls_preset_parameters_type.h
@@ -28,48 +28,6 @@ enum class jpegls_preset_parameters_type : uint8_t
     /// JPEG-LS Baseline (ISO/IEC 14495-1): X and Y parameters are defined (defined in C.2.4.1.4).
     /// </summary>
     oversize_image_dimension = 0x4,
-
-    // The values below are from JPEG-LS Extended (ISO/IEC 14495-2) standard and defined only for better error reporting.
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): Coding method specification.
-    /// </summary>
-    coding_method_specification = 0x5,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): NEAR value re-specification.
-    /// </summary>
-    near_lossless_error_re_specification = 0x6,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): Visually oriented quantization specification.
-    /// </summary>
-    visually_oriented_quantization_specification = 0x7,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): Extended prediction specification.
-    /// </summary>
-    extended_prediction_specification = 0x8,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): Specification of the start of fixed length coding.
-    /// </summary>
-    start_of_fixed_length_coding = 0x9,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): Specification of the end of fixed length coding.
-    /// </summary>
-    end_of_fixed_length_coding = 0xA,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): JPEG-LS preset coding parameters.
-    /// </summary>
-    extended_preset_coding_parameters = 0xC,
-
-    /// <summary>
-    /// JPEG-LS Extended (ISO/IEC 14495-2): inverse color transform specification.
-    /// </summary>
-    inverse_color_transform_specification = 0xD
 };
 
 } // namespace charls


### PR DESCRIPTION
Remove values from the enum that are only needed for slightly better error reporting (handle this locally)

Also add support matrix to readme