### PR TITLE
Re-order the failure values of the enum jpegls_errc (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - BREAKING: Updated the minimal required C++ language version to C++17.
 - BREAKING: encoding_options::include_pc_parameters_jai is not enabled by default anymore.
 - BREAKING: charls::jpegls_decoder and charls::jpegls_encoder follow the same const pattern as the C API.
+- BREAKING: the failure values of the enum charls::jpegls_errc are now divided in 2 groups: runtime failures and logic.
 
 ### Removed
 
@@ -30,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- Fixed [#221](https://github.com/team-charls/charls/issues/221), jpegls_errc::destination_buffer_too_small incorrectly thrown for 8 bit 2*2 image with stride = 4 during decoding.
+- Fixed [#221](https://github.com/team-charls/charls/issues/221), jpegls_errc::destination_too_small incorrectly thrown for 8 bit 2*2 image with stride = 4 during decoding.
 
 ## [2.4.0] - 2022-12-29
 

--- a/include/charls/charls.h
+++ b/include/charls/charls.h
@@ -9,7 +9,8 @@
 #include "version.h"
 
 
-// Undefine CHARLS macros to prevent global macro namespace pollution
+// Undefine CHARLS macros to prevent global macro namespace pollution and usage by client code.
+// The macros are not part of the official API.
 #if !defined(CHARLS_LIBRARY_BUILD)
 
 #undef CHARLS_API_IMPORT_EXPORT
@@ -17,6 +18,7 @@
 #undef CHARLS_NOEXCEPT
 #undef CHARLS_ATTRIBUTE
 #undef CHARLS_C_VOID
+#undef CHARLS_NO_INLINE
 #undef CHARLS_IN
 #undef CHARLS_IN_OPT
 #undef CHARLS_IN_Z

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -111,15 +111,15 @@ charls_jpegls_encoder_set_color_transformation(CHARLS_IN charls_jpegls_encoder* 
     CHARLS_ATTRIBUTE((nonnull));
 
 /// <summary>
-/// Configures the table ID the encoder should reference when encoding a component.
-/// The referenced table can be included in the stream or provided in another JPEG-LS abbreviated format stream.
+/// Configures the mapping table ID the encoder should reference when encoding a component.
+/// The referenced mapping table can be included in the stream or provided in another JPEG-LS abbreviated format stream.
 /// </summary>
 /// <param name="encoder">Reference to the encoder instance.</param>
 /// <param name="component_index">Index of the component. Component 0 is the start index.</param>
-/// <param name="table_id">Table ID that will be referenced by this component.</param>
+/// <param name="table_id">Mapping table ID that will be referenced by this component.</param>
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
-charls_jpegls_encoder_set_table_id(CHARLS_IN charls_jpegls_encoder* encoder, int32_t component_index,
-                                   int32_t table_id) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull));
+charls_jpegls_encoder_set_mapping_table_id(CHARLS_IN charls_jpegls_encoder* encoder, int32_t component_index,
+                                           int32_t table_id) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull));
 
 /// <summary>
 /// Returns the size in bytes, that the encoder expects are needed to hold the encoded image.
@@ -252,7 +252,7 @@ charls_jpegls_encoder_write_application_data(CHARLS_IN charls_jpegls_encoder* en
 /// During decoding the active maximum value determines the required size of the table.
 /// </remarks>
 /// <param name="encoder">Reference to the encoder instance.</param>
-/// <param name="table_id">Table ID. Unique identifier of the mapping table in the range [1..255]</param>
+/// <param name="table_id">Mapping table ID. Unique identifier of the mapping table in the range [1..255]</param>
 /// <param name="entry_size">Size in bytes of a single table entry.</param>
 /// <param name="table_data">Byte array that holds the mapping table.</param>
 /// <param name="table_data_size_bytes">The size in bytes of the table data.</param>
@@ -424,14 +424,14 @@ public:
     }
 
     /// <summary>
-    /// Configures the table ID the encoder should reference when encoding a component.
-    /// The referenced table can be included in the stream or provided in another JPEG-LS abbreviated format stream.
+    /// Configures the mapping table ID the encoder should reference when encoding a component.
+    /// The referenced mapping table can be included in the stream or provided in another JPEG-LS abbreviated format stream.
     /// </summary>
     /// <param name="component_index">Index of the component. Component 0 is the start index.</param>
-    /// <param name="table_id">Table ID that will be referenced by this component.</param>
-    jpegls_encoder& set_table_id(const int32_t component_index, const int32_t table_id)
+    /// <param name="table_id">Mapping table ID that will be referenced by this component.</param>
+    jpegls_encoder& set_mapping_table_id(const int32_t component_index, const int32_t table_id)
     {
-        check_jpegls_errc(charls_jpegls_encoder_set_table_id(encoder(), component_index, table_id));
+        check_jpegls_errc(charls_jpegls_encoder_set_mapping_table_id(encoder(), component_index, table_id));
         return *this;
     }
 
@@ -589,7 +589,7 @@ public:
     /// <remarks>
     /// No validation is performed if the table ID is unique and if the table size matches the required size.
     /// </remarks>
-    /// <param name="table_id">Table ID. Unique identifier of the mapping table in the range [1..255]</param>
+    /// <param name="table_id">Mapping table ID. Unique identifier of the mapping table in the range [1..255]</param>
     /// <param name="entry_size">Size in bytes of a single table entry.</param>
     /// <param name="table_data">Byte buffer that holds the mapping table.</param>
     /// <param name="size">The size of the buffer in bytes.</param>

--- a/include/charls/jpegls_error.h
+++ b/include/charls/jpegls_error.h
@@ -66,8 +66,6 @@ inline CHARLS_NO_INLINE void throw_jpegls_error(const jpegls_errc error_value)
     throw jpegls_error(error_value);
 }
 
-#undef CHARLS_NO_INLINE
-
 } // namespace impl
 
 inline void check_jpegls_errc(const jpegls_errc error_value)

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -28,57 +28,61 @@ CHARLS_RETURN_TYPE_SUCCESS(return == 0)
 enum charls_jpegls_errc
 {
     CHARLS_JPEGLS_ERRC_SUCCESS = 0,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT = 1,
-    CHARLS_JPEGLS_ERRC_PARAMETER_VALUE_NOT_SUPPORTED = 2,
-    CHARLS_JPEGLS_ERRC_DESTINATION_BUFFER_TOO_SMALL = 3,
-    CHARLS_JPEGLS_ERRC_SOURCE_BUFFER_TOO_SMALL = 4,
-    CHARLS_JPEGLS_ERRC_INVALID_ENCODED_DATA = 5,
-    CHARLS_JPEGLS_ERRC_TOO_MUCH_ENCODED_DATA = 6,
-    CHARLS_JPEGLS_ERRC_INVALID_OPERATION = 7,
-    CHARLS_JPEGLS_ERRC_COLOR_TRANSFORM_NOT_SUPPORTED = 9,
-    CHARLS_JPEGLS_ERRC_ENCODING_NOT_SUPPORTED = 10,
-    CHARLS_JPEGLS_ERRC_UNKNOWN_JPEG_MARKER_FOUND = 11,
-    CHARLS_JPEGLS_ERRC_JPEG_MARKER_START_BYTE_NOT_FOUND = 12,
-    CHARLS_JPEGLS_ERRC_NOT_ENOUGH_MEMORY = 13,
-    CHARLS_JPEGLS_ERRC_UNEXPECTED_FAILURE = 14,
-    CHARLS_JPEGLS_ERRC_START_OF_IMAGE_MARKER_NOT_FOUND = 15,
-    CHARLS_JPEGLS_ERRC_UNEXPECTED_MARKER_FOUND = 16,
-    CHARLS_JPEGLS_ERRC_INVALID_MARKER_SEGMENT_SIZE = 17,
-    CHARLS_JPEGLS_ERRC_DUPLICATE_START_OF_IMAGE_MARKER = 18,
-    CHARLS_JPEGLS_ERRC_DUPLICATE_START_OF_FRAME_MARKER = 19,
-    CHARLS_JPEGLS_ERRC_DUPLICATE_COMPONENT_ID_IN_SOF_SEGMENT = 20,
-    CHARLS_JPEGLS_ERRC_UNEXPECTED_END_OF_IMAGE_MARKER = 21,
-    CHARLS_JPEGLS_ERRC_INVALID_JPEGLS_PRESET_PARAMETER_TYPE = 22,
-    CHARLS_JPEGLS_ERRC_JPEGLS_PRESET_EXTENDED_PARAMETER_TYPE_NOT_SUPPORTED = 23,
-    CHARLS_JPEGLS_ERRC_MISSING_END_OF_SPIFF_DIRECTORY = 24,
-    CHARLS_JPEGLS_ERRC_UNEXPECTED_RESTART_MARKER = 25,
-    CHARLS_JPEGLS_ERRC_RESTART_MARKER_NOT_FOUND = 26,
-    CHARLS_JPEGLS_ERRC_CALLBACK_FAILED = 27,
-    CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND = 28,
-    CHARLS_JPEGLS_ERRC_INVALID_SPIFF_HEADER = 29,
-    CHARLS_JPEGLS_ERRC_UNKNOWN_COMPONENT_ID = 30,
-    CHARLS_JPEGLS_ERRC_MAPPING_TABLES_AND_SPIFF_HEADER = 31,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_WIDTH = 100,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_HEIGHT = 101,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COMPONENT_COUNT = 102,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_BITS_PER_SAMPLE = 103,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_INTERLEAVE_MODE = 104,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_NEAR_LOSSLESS = 105,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_JPEGLS_PC_PARAMETERS = 106,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COLOR_TRANSFORMATION = 107,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_SIZE = 108,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_STRIDE = 109,
-    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_ENCODING_OPTIONS = 110,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_WIDTH = 200,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_HEIGHT = 201,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COMPONENT_COUNT = 202,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_BITS_PER_SAMPLE = 203,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_INTERLEAVE_MODE = 204,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_NEAR_LOSSLESS = 205,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PRESET_PARAMETERS = 206,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COLOR_TRANSFORMATION = 207,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_ID = 208,
-    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_CONTINUATION = 209
+
+    // Runtime errors:
+
+    CHARLS_JPEGLS_ERRC_NOT_ENOUGH_MEMORY = 1,
+    CHARLS_JPEGLS_ERRC_CALLBACK_FAILED = 2,
+    CHARLS_JPEGLS_ERRC_DESTINATION_TOO_SMALL = 3,
+    CHARLS_JPEGLS_ERRC_NEED_MORE_DATA = 4,
+    CHARLS_JPEGLS_ERRC_INVALID_DATA = 5,
+    CHARLS_JPEGLS_ERRC_ENCODING_NOT_SUPPORTED = 6,
+    CHARLS_JPEGLS_ERRC_PARAMETER_VALUE_NOT_SUPPORTED = 7,
+    CHARLS_JPEGLS_ERRC_COLOR_TRANSFORM_NOT_SUPPORTED = 8,
+    CHARLS_JPEGLS_ERRC_JPEGLS_PRESET_EXTENDED_PARAMETER_TYPE_NOT_SUPPORTED = 9,
+    CHARLS_JPEGLS_ERRC_JPEG_MARKER_START_BYTE_NOT_FOUND = 10,
+    CHARLS_JPEGLS_ERRC_START_OF_IMAGE_MARKER_NOT_FOUND = 11,
+    CHARLS_JPEGLS_ERRC_INVALID_SPIFF_HEADER = 12,
+    CHARLS_JPEGLS_ERRC_UNKNOWN_JPEG_MARKER_FOUND = 13,
+    CHARLS_JPEGLS_ERRC_UNEXPECTED_MARKER_FOUND = 14,
+    CHARLS_JPEGLS_ERRC_INVALID_MARKER_SEGMENT_SIZE = 15,
+    CHARLS_JPEGLS_ERRC_DUPLICATE_START_OF_IMAGE_MARKER = 16,
+    CHARLS_JPEGLS_ERRC_DUPLICATE_START_OF_FRAME_MARKER = 17,
+    CHARLS_JPEGLS_ERRC_DUPLICATE_COMPONENT_ID_IN_SOF_SEGMENT = 18,
+    CHARLS_JPEGLS_ERRC_UNEXPECTED_END_OF_IMAGE_MARKER = 19,
+    CHARLS_JPEGLS_ERRC_INVALID_JPEGLS_PRESET_PARAMETER_TYPE = 20,
+    CHARLS_JPEGLS_ERRC_MISSING_END_OF_SPIFF_DIRECTORY = 21,
+    CHARLS_JPEGLS_ERRC_UNEXPECTED_RESTART_MARKER = 22,
+    CHARLS_JPEGLS_ERRC_RESTART_MARKER_NOT_FOUND = 23,
+    CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND = 24,
+    CHARLS_JPEGLS_ERRC_UNKNOWN_COMPONENT_ID = 25,
+    CHARLS_JPEGLS_ERRC_ABBREVIATED_FORMAT_AND_SPIFF_HEADER = 26,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_WIDTH = 27,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_HEIGHT = 28,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_BITS_PER_SAMPLE = 29,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COMPONENT_COUNT = 30,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_INTERLEAVE_MODE = 31,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_NEAR_LOSSLESS = 32,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PRESET_PARAMETERS = 33,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COLOR_TRANSFORMATION = 34,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_ID = 35,
+    CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_CONTINUATION = 36,
+
+    // Logic errors:
+
+    CHARLS_JPEGLS_ERRC_INVALID_OPERATION = 100,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT = 101,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_WIDTH = 102,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_HEIGHT = 103,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_BITS_PER_SAMPLE = 104,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COMPONENT_COUNT = 105,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_INTERLEAVE_MODE = 106,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_NEAR_LOSSLESS = 107,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_JPEGLS_PC_PARAMETERS = 108,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COLOR_TRANSFORMATION = 109,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_SIZE = 110,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_STRIDE = 111,
+    CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_ENCODING_OPTIONS = 112,
 };
 
 enum charls_interleave_mode
@@ -189,60 +193,7 @@ enum class [[nodiscard]] jpegls_errc
     /// </summary>
     success = impl::CHARLS_JPEGLS_ERRC_SUCCESS,
 
-    /// <summary>
-    /// This error is returned when one of the passed arguments is invalid.
-    /// </summary>
-    invalid_argument = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT,
-
-    /// <summary>
-    /// This error is returned when the JPEG stream contains a parameter value that is not supported by this implementation.
-    /// </summary>
-    parameter_value_not_supported = impl::CHARLS_JPEGLS_ERRC_PARAMETER_VALUE_NOT_SUPPORTED,
-
-    /// <summary>
-    /// The destination buffer is too small to hold all the output.
-    /// </summary>
-    destination_buffer_too_small = impl::CHARLS_JPEGLS_ERRC_DESTINATION_BUFFER_TOO_SMALL,
-
-    /// <summary>
-    /// The source buffer is too small, more input data was expected.
-    /// </summary>
-    source_buffer_too_small = impl::CHARLS_JPEGLS_ERRC_SOURCE_BUFFER_TOO_SMALL,
-
-    /// <summary>
-    /// This error is returned when the encoded bit stream contains a general structural problem.
-    /// </summary>
-    invalid_encoded_data = impl::CHARLS_JPEGLS_ERRC_INVALID_ENCODED_DATA,
-
-    /// <summary>
-    /// Too much compressed data.The decoding process is ready but the input buffer still contains encoded data.
-    /// </summary>
-    too_much_encoded_data = impl::CHARLS_JPEGLS_ERRC_TOO_MUCH_ENCODED_DATA,
-
-    /// <summary>
-    /// This error is returned when a method call is invalid for the current state.
-    /// </summary>
-    invalid_operation = impl::CHARLS_JPEGLS_ERRC_INVALID_OPERATION,
-
-    /// <summary>
-    /// The color transform is not supported.
-    /// </summary>
-    color_transform_not_supported = impl::CHARLS_JPEGLS_ERRC_COLOR_TRANSFORM_NOT_SUPPORTED,
-
-    /// <summary>
-    /// This error is returned when an encoded frame is found that is not encoded with the JPEG-LS algorithm.
-    /// </summary>
-    encoding_not_supported = impl::CHARLS_JPEGLS_ERRC_ENCODING_NOT_SUPPORTED,
-
-    /// <summary>
-    /// This error is returned when an unknown JPEG marker code is found in the encoded bit stream.
-    /// </summary>
-    unknown_jpeg_marker_found = impl::CHARLS_JPEGLS_ERRC_UNKNOWN_JPEG_MARKER_FOUND,
-
-    /// <summary>
-    /// This error is returned when the algorithm expect a 0xFF code (indicates start of a JPEG marker) but none was found.
-    /// </summary>
-    jpeg_marker_start_byte_not_found = impl::CHARLS_JPEGLS_ERRC_JPEG_MARKER_START_BYTE_NOT_FOUND,
+    // Runtime errors:
 
     /// <summary>
     /// This error is returned when the implementation could not allocate memory for its internal buffers.
@@ -250,15 +201,65 @@ enum class [[nodiscard]] jpegls_errc
     not_enough_memory = impl::CHARLS_JPEGLS_ERRC_NOT_ENOUGH_MEMORY,
 
     /// <summary>
-    /// This error is returned when the implementation encountered a failure it did not expect. No guarantees can be given
-    /// for the state after this error.
+    /// This error is returned when a callback function returns a nonzero value.
     /// </summary>
-    unexpected_failure = impl::CHARLS_JPEGLS_ERRC_UNEXPECTED_FAILURE,
+    callback_failed = impl::CHARLS_JPEGLS_ERRC_CALLBACK_FAILED,
+
+    /// <summary>
+    /// The destination buffer is too small to hold all the output.
+    /// </summary>
+    destination_too_small = impl::CHARLS_JPEGLS_ERRC_DESTINATION_TOO_SMALL,
+
+    /// <summary>
+    /// The source buffer is too small, more input data was expected.
+    /// </summary>
+    need_more_data = impl::CHARLS_JPEGLS_ERRC_NEED_MORE_DATA,
+
+    /// <summary>
+    /// This error is returned when the encoded bit stream contains a general structural problem.
+    /// </summary>
+    invalid_data = impl::CHARLS_JPEGLS_ERRC_INVALID_DATA,
+
+    /// <summary>
+    /// This error is returned when an encoded frame is found that is not encoded with the JPEG-LS algorithm.
+    /// </summary>
+    encoding_not_supported = impl::CHARLS_JPEGLS_ERRC_ENCODING_NOT_SUPPORTED,
+
+    /// <summary>
+    /// This error is returned when the JPEG stream contains a parameter value that is not supported by this implementation.
+    /// </summary>
+    parameter_value_not_supported = impl::CHARLS_JPEGLS_ERRC_PARAMETER_VALUE_NOT_SUPPORTED,
+
+    /// <summary>
+    /// The color transform is not supported.
+    /// </summary>
+    color_transform_not_supported = impl::CHARLS_JPEGLS_ERRC_COLOR_TRANSFORM_NOT_SUPPORTED,
+
+    /// <summary>
+    /// This error is returned when the stream contains an unsupported type parameter in the JPEG-LS segment.
+    /// </summary>
+    jpegls_preset_extended_parameter_type_not_supported =
+        impl::CHARLS_JPEGLS_ERRC_JPEGLS_PRESET_EXTENDED_PARAMETER_TYPE_NOT_SUPPORTED,
+
+    /// <summary>
+    /// This error is returned when the algorithm expect a 0xFF code (indicates start of a JPEG marker) but none was found.
+    /// </summary>
+    jpeg_marker_start_byte_not_found = impl::CHARLS_JPEGLS_ERRC_JPEG_MARKER_START_BYTE_NOT_FOUND,
 
     /// <summary>
     /// This error is returned when the first JPEG marker is not the SOI marker.
     /// </summary>
     start_of_image_marker_not_found = impl::CHARLS_JPEGLS_ERRC_START_OF_IMAGE_MARKER_NOT_FOUND,
+
+    /// <summary>
+    /// This error is returned when the SPIFF header is invalid.
+    /// </summary>
+    invalid_spiff_header = impl::CHARLS_JPEGLS_ERRC_INVALID_SPIFF_HEADER,
+
+    /// <summary>
+    /// This error is returned when an unknown JPEG marker code is found in the encoded bit stream.
+    /// </summary>
+    unknown_jpeg_marker_found = impl::CHARLS_JPEGLS_ERRC_UNKNOWN_JPEG_MARKER_FOUND,
 
     /// <summary>
     /// This error is returned when a JPEG marker is found that is not valid for the current state.
@@ -296,12 +297,6 @@ enum class [[nodiscard]] jpegls_errc
     invalid_jpegls_preset_parameter_type = impl::CHARLS_JPEGLS_ERRC_INVALID_JPEGLS_PRESET_PARAMETER_TYPE,
 
     /// <summary>
-    /// This error is returned when the stream contains an unsupported type parameter in the JPEG-LS segment.
-    /// </summary>
-    jpegls_preset_extended_parameter_type_not_supported =
-        impl::CHARLS_JPEGLS_ERRC_JPEGLS_PRESET_EXTENDED_PARAMETER_TYPE_NOT_SUPPORTED,
-
-    /// <summary>
     /// This error is returned when the stream contains a SPIFF header but not an SPIFF end-of-directory entry.
     /// </summary>
     missing_end_of_spiff_directory = impl::CHARLS_JPEGLS_ERRC_MISSING_END_OF_SPIFF_DIRECTORY,
@@ -318,19 +313,9 @@ enum class [[nodiscard]] jpegls_errc
     restart_marker_not_found = impl::CHARLS_JPEGLS_ERRC_RESTART_MARKER_NOT_FOUND,
 
     /// <summary>
-    /// This error is returned when a callback function returns a nonzero value.
-    /// </summary>
-    callback_failed = impl::CHARLS_JPEGLS_ERRC_CALLBACK_FAILED,
-
-    /// <summary>
     /// This error is returned when the End of Image (EOI) marker could not be found.
     /// </summary>
     end_of_image_marker_not_found = impl::CHARLS_JPEGLS_ERRC_END_OF_IMAGE_MARKER_NOT_FOUND,
-
-    /// <summary>
-    /// This error is returned when the SPIFF header is invalid.
-    /// </summary>
-    invalid_spiff_header = impl::CHARLS_JPEGLS_ERRC_INVALID_SPIFF_HEADER,
 
     /// <summary>
     /// This error is returned when an unknown component ID in a scan is detected.
@@ -340,7 +325,72 @@ enum class [[nodiscard]] jpegls_errc
     /// <summary>
     /// This error is returned for stream with only mapping tables and a spiff header.
     /// </summary>
-    mapping_tables_and_spiff_header = impl::CHARLS_JPEGLS_ERRC_MAPPING_TABLES_AND_SPIFF_HEADER,
+    abbreviated_format_and_spiff_header = impl::CHARLS_JPEGLS_ERRC_ABBREVIATED_FORMAT_AND_SPIFF_HEADER,
+
+    /// <summary>
+    /// This error is returned when the stream contains a width parameter defined more than once or in an incompatible way.
+    /// </summary>
+    invalid_parameter_width = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_WIDTH,
+
+    /// <summary>
+    /// This error is returned when the stream contains a height parameter defined more than once in an incompatible way.
+    /// </summary>
+    invalid_parameter_height = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_HEIGHT,
+
+    /// <summary>
+    /// This error is returned when the stream contains a bits per sample (sample precision) parameter outside the range
+    /// [2,16]
+    /// </summary>
+    invalid_parameter_bits_per_sample = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_BITS_PER_SAMPLE,
+
+    /// <summary>
+    /// This error is returned when the stream contains a component count parameter outside the range [1,255] for SOF or
+    /// [1,4] for SOS.
+    /// </summary>
+    invalid_parameter_component_count = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COMPONENT_COUNT,
+
+    /// <summary>
+    /// This error is returned when the stream contains an interleave mode (ILV) parameter outside the range [0, 2]
+    /// </summary>
+    invalid_parameter_interleave_mode = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_INTERLEAVE_MODE,
+
+    /// <summary>
+    /// This error is returned when the stream contains a near-lossless (NEAR)
+    /// parameter outside the range [0, min(255, MAXVAL/2)]
+    /// </summary>
+    invalid_parameter_near_lossless = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_NEAR_LOSSLESS,
+
+    /// <summary>
+    /// This error is returned when the stream contains an invalid JPEG-LS preset parameters segment.
+    /// </summary>
+    invalid_parameter_jpegls_preset_parameters = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PRESET_PARAMETERS,
+
+    /// <summary>
+    /// This error is returned when the stream contains an invalid color transformation segment or one that doesn't match with frame info.
+    /// </summary>
+    invalid_parameter_color_transformation = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COLOR_TRANSFORMATION,
+
+    /// <summary>
+    /// This error is returned when the stream contains a mapping table with an invalid ID.
+    /// </summary>
+    invalid_parameter_mapping_table_id = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_ID,
+
+    /// <summary>
+    /// This error is returned when the stream contains an invalid mapping table continuation.
+    /// </summary>
+    invalid_parameter_mapping_table_continuation = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_CONTINUATION,
+
+    // Logic errors:
+
+    /// <summary>
+    /// This error is returned when a method call is invalid for the current state.
+    /// </summary>
+    invalid_operation = impl::CHARLS_JPEGLS_ERRC_INVALID_OPERATION,
+
+    /// <summary>
+    /// This error is returned when one of the passed arguments is invalid.
+    /// </summary>
+    invalid_argument = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT,
 
     /// <summary>
     /// The argument for the width parameter is outside the range [1, 65535].
@@ -353,14 +403,14 @@ enum class [[nodiscard]] jpegls_errc
     invalid_argument_height = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_HEIGHT,
 
     /// <summary>
-    /// The argument for the component count parameter is outside the range [1, 255].
-    /// </summary>
-    invalid_argument_component_count = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COMPONENT_COUNT,
-
-    /// <summary>
     /// The argument for the bit per sample parameter is outside the range [2, 16].
     /// </summary>
     invalid_argument_bits_per_sample = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_BITS_PER_SAMPLE,
+
+    /// <summary>
+    /// The argument for the component count parameter is outside the range [1, 255].
+    /// </summary>
+    invalid_argument_component_count = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_COMPONENT_COUNT,
 
     /// <summary>
     /// The argument for the interleave mode is not (None, Sample, Line) or invalid in combination with component count.
@@ -368,7 +418,7 @@ enum class [[nodiscard]] jpegls_errc
     invalid_argument_interleave_mode = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_INTERLEAVE_MODE,
 
     /// <summary>
-    /// The argument for the near lossless parameter is outside the range [0, 255].
+    /// The argument for the near lossless parameter is outside the range [0, min(255, MAXVAL/2)].
     /// </summary>
     invalid_argument_near_lossless = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_NEAR_LOSSLESS,
 
@@ -397,59 +447,6 @@ enum class [[nodiscard]] jpegls_errc
     /// The encoding options argument has an invalid value.
     /// </summary>
     invalid_argument_encoding_options = impl::CHARLS_JPEGLS_ERRC_INVALID_ARGUMENT_ENCODING_OPTIONS,
-
-    /// <summary>
-    /// This error is returned when the stream contains a width parameter defined more than once or in an incompatible way.
-    /// </summary>
-    invalid_parameter_width = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_WIDTH,
-
-    /// <summary>
-    /// This error is returned when the stream contains a height parameter defined more than once in an incompatible way.
-    /// </summary>
-    invalid_parameter_height = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_HEIGHT,
-
-    /// <summary>
-    /// This error is returned when the stream contains a component count parameter outside the range [1,255] for SOF or
-    /// [1,4] for SOS.
-    /// </summary>
-    invalid_parameter_component_count = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COMPONENT_COUNT,
-
-    /// <summary>
-    /// This error is returned when the stream contains a bits per sample (sample precision) parameter outside the range
-    /// [2,16]
-    /// </summary>
-    invalid_parameter_bits_per_sample = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_BITS_PER_SAMPLE,
-
-    /// <summary>
-    /// This error is returned when the stream contains an interleave mode (ILV) parameter outside the range [0, 2]
-    /// </summary>
-    invalid_parameter_interleave_mode = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_INTERLEAVE_MODE,
-
-    /// <summary>
-    /// This error is returned when the stream contains a near-lossless (NEAR) parameter outside the range [0, min(255,
-    /// MAXVAL/2)]
-    /// </summary>
-    invalid_parameter_near_lossless = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_NEAR_LOSSLESS,
-
-    /// <summary>
-    /// This error is returned when the stream contains an invalid JPEG-LS preset parameters segment.
-    /// </summary>
-    invalid_parameter_jpegls_preset_parameters = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_JPEGLS_PRESET_PARAMETERS,
-
-    /// <summary>
-    /// This error is returned when the stream contains an invalid color transformation segment or one that doesn't match with frame info.
-    /// </summary>
-    invalid_parameter_color_transformation = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_COLOR_TRANSFORMATION,
-
-    /// <summary>
-    /// This error is returned when the stream contains a mapping table with an invalid ID.
-    /// </summary>
-    invalid_parameter_mapping_table_id = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_ID,
-
-    /// <summary>
-    /// This error is returned when the stream contains an invalid mapping table continuation.
-    /// </summary>
-    invalid_parameter_mapping_table_continuation = impl::CHARLS_JPEGLS_ERRC_INVALID_PARAMETER_MAPPING_TABLE_CONTINUATION
 };
 
 

--- a/spelling.dic
+++ b/spelling.dic
@@ -15,3 +15,6 @@ cppcoreguidelines
 mrfx
 subspan
 cppcoreguidelines
+uint
+json
+intrinsics

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -191,7 +191,7 @@ struct charls_jpegls_decoder final
                                                                                                : 1U};
         if (const size_t minimum_destination_size = bytes_per_plane * plane_count - (stride - minimum_stride);
             UNLIKELY(destination.size() < minimum_destination_size))
-            throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
+            throw_jpegls_error(jpegls_errc::destination_too_small);
 
         for (size_t plane{};;)
         {

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -90,12 +90,12 @@ struct charls_jpegls_encoder final
         color_transformation_ = color_transformation;
     }
 
-    void set_table_id(const int32_t component_index, const int32_t table_id)
+    void set_mapping_table_id(const int32_t component_index, const int32_t table_id)
     {
         check_argument_range(minimum_component_index, maximum_component_index, component_index);
         check_argument_range(0, maximum_table_id, table_id);
 
-        writer_.set_table_id(static_cast<size_t>(component_index), table_id);
+        writer_.set_mapping_table_id(static_cast<size_t>(component_index), table_id);
     }
 
     [[nodiscard]]
@@ -223,7 +223,7 @@ struct charls_jpegls_encoder final
         write_end_of_image();
     }
 
-    void create_tables_only()
+    void create_abbreviated_format()
     {
         check_operation(state_ == state::tables_and_miscellaneous);
         write_end_of_image();
@@ -507,11 +507,11 @@ catch (...)
 }
 
 
-USE_DECL_ANNOTATIONS jpegls_errc CHARLS_API_CALLING_CONVENTION charls_jpegls_encoder_set_table_id(
+USE_DECL_ANNOTATIONS jpegls_errc CHARLS_API_CALLING_CONVENTION charls_jpegls_encoder_set_mapping_table_id(
     charls_jpegls_encoder* encoder, const int32_t component_index, const int32_t table_id) noexcept
 try
 {
-    check_pointer(encoder)->set_table_id(component_index, table_id);
+    check_pointer(encoder)->set_mapping_table_id(component_index, table_id);
     return jpegls_errc::success;
 }
 catch (...)
@@ -650,7 +650,7 @@ USE_DECL_ANNOTATIONS charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
 charls_jpegls_encoder_create_abbreviated_format(charls_jpegls_encoder* encoder) noexcept
 try
 {
-    check_pointer(encoder)->create_tables_only();
+    check_pointer(encoder)->create_abbreviated_format();
     return jpegls_errc::success;
 }
 catch (...)

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -283,7 +283,7 @@ void jpeg_stream_reader::get_mapping_table_data(const size_t index, const span<b
 {
     const auto& mapping_table{mapping_tables_[index]};
     if (mapping_table.data_size() > table.size())
-        throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
+        throw_jpegls_error(jpegls_errc::destination_too_small);
 
     mapping_table.copy(table.data());
 }
@@ -581,7 +581,7 @@ void jpeg_stream_reader::read_start_of_scan_segment()
 byte jpeg_stream_reader::read_byte_checked()
 {
     if (UNLIKELY(position_ == end_position_))
-        throw_jpegls_error(jpegls_errc::source_buffer_too_small);
+        throw_jpegls_error(jpegls_errc::need_more_data);
 
     return read_byte();
 }
@@ -590,7 +590,7 @@ byte jpeg_stream_reader::read_byte_checked()
 uint16_t jpeg_stream_reader::read_uint16_checked()
 {
     if (UNLIKELY(position_ + sizeof(uint16_t) > end_position_))
-        throw_jpegls_error(jpegls_errc::source_buffer_too_small);
+        throw_jpegls_error(jpegls_errc::need_more_data);
 
     return read_uint16();
 }

--- a/src/jpeg_stream_reader.h
+++ b/src/jpeg_stream_reader.h
@@ -184,7 +184,7 @@ private:
         {
             if (state_ == state::frame_section)
             {
-                impl::throw_jpegls_error(jpegls_errc::mapping_tables_and_spiff_header);
+                impl::throw_jpegls_error(jpegls_errc::abbreviated_format_and_spiff_header);
             }
 
             // ISO/IEC 14495-1, Annex C defines 3 data formats.

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -234,7 +234,7 @@ void jpeg_stream_writer::write_segment_header(const jpeg_marker_code marker_code
     constexpr size_t marker_code_size{2};
     if (const size_t total_segment_size{marker_code_size + segment_length_size + data_size};
         UNLIKELY(byte_offset_ + total_segment_size > destination_.size()))
-        impl::throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
+        impl::throw_jpegls_error(jpegls_errc::destination_too_small);
 
     write_marker(marker_code);
     write_uint16(static_cast<uint16_t>(segment_length_size + data_size));

--- a/src/jpeg_stream_writer.h
+++ b/src/jpeg_stream_writer.h
@@ -131,7 +131,7 @@ public:
         component_index_ = 0;
     }
 
-    void set_table_id(const size_t component_index, const int32_t table_id)
+    void set_mapping_table_id(const size_t component_index, const int32_t table_id)
     {
         ASSERT(component_index < maximum_component_count);
         ASSERT(0 <= table_id && table_id <= maximum_table_id);
@@ -153,7 +153,7 @@ private:
     void write_segment_without_data(const jpeg_marker_code marker_code)
     {
         if (UNLIKELY(byte_offset_ + 2 > destination_.size()))
-            impl::throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
+            impl::throw_jpegls_error(jpegls_errc::destination_too_small);
 
         write_marker(marker_code);
     }

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -42,45 +42,47 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
     case jpegls_errc::success:
         return "Success";
 
-    case jpegls_errc::invalid_argument:
-        return "Invalid argument";
+        // Runtime errors:
 
-    case jpegls_errc::invalid_argument_width:
-        return "The width argument is outside the supported range [1, 4294967295]";
+    case jpegls_errc::not_enough_memory:
+        return "No memory could be allocated for an internal buffer";
 
-    case jpegls_errc::invalid_argument_height:
-        return "The height argument is outside the supported range [1, 4294967295]";
+    case jpegls_errc::callback_failed:
+        return "Callback function returned a failure";
 
-    case jpegls_errc::invalid_argument_component_count:
-        return "The component count argument is outside the range [1, 255]";
+    case jpegls_errc::destination_too_small:
+        return "The destination buffer is too small to hold all the output";
 
-    case jpegls_errc::invalid_argument_bits_per_sample:
-        return "The bit per sample argument is outside the range [2, 16]";
+    case jpegls_errc::need_more_data:
+        return "The source buffer is too small, more input data was expected";
 
-    case jpegls_errc::invalid_argument_interleave_mode:
-        return "The interleave mode is not None, Sample, Line) or invalid in combination with component count";
+    case jpegls_errc::invalid_data:
+        return "Invalid JPEG-LS stream, the encoded bit stream contains a general structural problem";
 
-    case jpegls_errc::invalid_argument_near_lossless:
-        return "The near lossless argument is outside the range [0, 255]";
+    case jpegls_errc::encoding_not_supported:
+        return "Invalid JPEG-LS stream: the JPEG stream is not encoded with the JPEG-LS algorithm";
 
-    case jpegls_errc::invalid_argument_size:
-        return "The passed size is outside the valid range";
+    case jpegls_errc::parameter_value_not_supported:
+        return "The JPEG-LS stream is encoded with a parameter value that is not supported by the CharLS decoder";
 
-    case jpegls_errc::invalid_argument_color_transformation:
-        return "The argument for the color component is not (None, Hp1, Hp2, Hp3) or invalid in combination with component "
-               "count";
+    case jpegls_errc::color_transform_not_supported:
+        return "The color transform is not supported";
 
-    case jpegls_errc::invalid_argument_jpegls_pc_parameters:
-        return "The argument for the JPEG-LS preset coding parameters is not valid";
+    case jpegls_errc::jpegls_preset_extended_parameter_type_not_supported:
+        return "Unsupported JPEG-LS stream: JPEG-LS preset parameters segment contains a JPEG-LS Extended (ISO/IEC "
+               "14495-2) type";
 
-    case jpegls_errc::invalid_argument_stride:
-        return "The stride argument does not match with the frame info and buffer size";
-
-    case jpegls_errc::invalid_argument_encoding_options:
-        return "The encoding options argument has an invalid value";
+    case jpegls_errc::jpeg_marker_start_byte_not_found:
+        return "Invalid JPEG-LS stream: the leading start byte (0xFF) for a JPEG marker was not found";
 
     case jpegls_errc::start_of_image_marker_not_found:
         return "Invalid JPEG-LS stream: first JPEG marker is not a Start Of Image (SOI) marker";
+
+    case jpegls_errc::invalid_spiff_header:
+        return "Invalid JPEG-LS stream: invalid SPIFF header";
+
+    case jpegls_errc::unknown_jpeg_marker_found:
+        return "Invalid JPEG-LS stream: an unknown JPEG marker code was found";
 
     case jpegls_errc::unexpected_marker_found:
         return "Invalid JPEG-LS stream: unexpected marker found";
@@ -103,10 +105,6 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
     case jpegls_errc::invalid_jpegls_preset_parameter_type:
         return "Invalid JPEG-LS stream: JPEG-LS preset parameters segment contains an invalid type";
 
-    case jpegls_errc::jpegls_preset_extended_parameter_type_not_supported:
-        return "Unsupported JPEG-LS stream: JPEG-LS preset parameters segment contains a JPEG-LS Extended (ISO/IEC "
-               "14495-2) type";
-
     case jpegls_errc::missing_end_of_spiff_directory:
         return "Invalid JPEG-LS stream: SPIFF header without End Of Directory (EOD) entry";
 
@@ -116,65 +114,23 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
     case jpegls_errc::restart_marker_not_found:
         return "Invalid JPEG-LS stream: missing expected restart (RTSm) marker";
 
-    case jpegls_errc::callback_failed:
-        return "Callback function returned a failure";
-
     case jpegls_errc::end_of_image_marker_not_found:
         return "Invalid JPEG-LS stream: missing End Of Image (EOI) marker";
-
-    case jpegls_errc::invalid_spiff_header:
-        return "Invalid JPEG-LS stream: invalid SPIFF header";
 
     case jpegls_errc::unknown_component_id:
         return "Invalid JPEG-LS stream: unknown component ID in scan segment";
 
-    case jpegls_errc::mapping_tables_and_spiff_header:
+    case jpegls_errc::abbreviated_format_and_spiff_header:
         return "Invalid JPEG-LS stream: mapping tables without SOF but with spiff header";
-
-    case jpegls_errc::invalid_parameter_bits_per_sample:
-        return "Invalid JPEG-LS stream: the bit per sample (sample precision) parameter is not in the range [2, 16]";
-
-    case jpegls_errc::parameter_value_not_supported:
-        return "The JPEG-LS stream is encoded with a parameter value that is not supported by the CharLS decoder";
-
-    case jpegls_errc::destination_buffer_too_small:
-        return "The destination buffer is too small to hold all the output";
-
-    case jpegls_errc::source_buffer_too_small:
-        return "The source buffer is too small, more input data was expected";
-
-    case jpegls_errc::invalid_encoded_data:
-        return "Invalid JPEG-LS stream, the encoded bit stream contains a general structural problem";
-
-    case jpegls_errc::too_much_encoded_data:
-        return "Invalid JPEG-LS stream, the decoding process is ready but the source buffer still contains encoded data";
-
-    case jpegls_errc::invalid_operation:
-        return "Method call is invalid for the current state";
-
-    case jpegls_errc::color_transform_not_supported:
-        return "The color transform is not supported";
-
-    case jpegls_errc::encoding_not_supported:
-        return "Invalid JPEG-LS stream: the JPEG stream is not encoded with the JPEG-LS algorithm";
-
-    case jpegls_errc::unknown_jpeg_marker_found:
-        return "Invalid JPEG-LS stream: an unknown JPEG marker code was found";
-
-    case jpegls_errc::jpeg_marker_start_byte_not_found:
-        return "Invalid JPEG-LS stream: the leading start byte (0xFF) for a JPEG marker was not found";
-
-    case jpegls_errc::not_enough_memory:
-        return "No memory could be allocated for an internal buffer";
-
-    case jpegls_errc::unexpected_failure:
-        return "An unexpected internal failure occurred";
 
     case jpegls_errc::invalid_parameter_width:
         return "Invalid JPEG-LS stream: the width (Number of samples per line) is already defined";
 
     case jpegls_errc::invalid_parameter_height:
         return "Invalid JPEG-LS stream: the height (Number of lines) is already defined";
+
+    case jpegls_errc::invalid_parameter_bits_per_sample:
+        return "Invalid JPEG-LS stream: the bit per sample (sample precision) parameter is not in the range [2, 16]";
 
     case jpegls_errc::invalid_parameter_component_count:
         return "Invalid JPEG-LS stream: component count in the SOF segment is outside the range [1, 255]";
@@ -189,13 +145,56 @@ const char* CHARLS_API_CALLING_CONVENTION charls_get_error_message(const charls_
         return "Invalid JPEG-LS stream: JPEG-LS preset parameters segment contains invalid values";
 
     case jpegls_errc::invalid_parameter_color_transformation:
-        return "Invalid JPEG-LS stream: Color transformation segment contains invalid values or doesn't match with frame info";
+        return "Invalid JPEG-LS stream: Color transformation segment contains invalid values or doesn't match with frame "
+               "info";
 
     case jpegls_errc::invalid_parameter_mapping_table_id:
         return "Invalid JPEG-LS stream: mapping table ID outside valid range or duplicate";
 
     case jpegls_errc::invalid_parameter_mapping_table_continuation:
         return "Invalid JPEG-LS stream: mapping table continuation without matching mapping table specification";
+
+        // Logic errors:
+
+    case jpegls_errc::invalid_operation:
+        return "Method call is invalid for the current state";
+
+    case jpegls_errc::invalid_argument:
+        return "Invalid argument";
+
+    case jpegls_errc::invalid_argument_width:
+        return "The width argument is outside the supported range [1, 4294967295]";
+
+    case jpegls_errc::invalid_argument_height:
+        return "The height argument is outside the supported range [1, 4294967295]";
+
+    case jpegls_errc::invalid_argument_bits_per_sample:
+        return "The bit per sample argument is outside the range [2, 16]";
+
+    case jpegls_errc::invalid_argument_component_count:
+        return "The component count argument is outside the range [1, 255]";
+
+    case jpegls_errc::invalid_argument_interleave_mode:
+        return "The interleave mode is not None, Sample, Line) or invalid in combination with component count";
+
+    case jpegls_errc::invalid_argument_near_lossless:
+        return "The near lossless argument is outside the range [0, min(255, MAXVAL/2)]";
+
+    case jpegls_errc::invalid_argument_size:
+        return "The passed size is outside the valid range";
+
+    case jpegls_errc::invalid_argument_jpegls_pc_parameters:
+        return "The argument for the JPEG-LS preset coding parameters is not valid";
+
+    case jpegls_errc::invalid_argument_color_transformation:
+        return "The argument for the color component is not (None, Hp1, Hp2, Hp3) or invalid in combination with component "
+               "count";
+
+    case jpegls_errc::invalid_argument_stride:
+        return "The stride argument does not match with the frame info and buffer size";
+
+    case jpegls_errc::invalid_argument_encoding_options:
+        return "The encoding options argument has an invalid value";
     }
 
     return "Unknown";

--- a/src/regular_mode_context.h
+++ b/src/regular_mode_context.h
@@ -50,7 +50,7 @@ public:
         b_ += error_value * (2 * near_lossless + 1);
 
         if (constexpr int limit{65536 * 256}; UNLIKELY(a_ >= limit || std::abs(b_) >= limit))
-            impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+            impl::throw_jpegls_error(jpegls_errc::invalid_data);
 
         if (n_ == reset_threshold)
         {
@@ -104,7 +104,7 @@ public:
         }
 
         if (UNLIKELY(k == max_k_value))
-            impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+            impl::throw_jpegls_error(jpegls_errc::invalid_data);
 
         return k;
     }

--- a/src/scan_decoder.h
+++ b/src/scan_decoder.h
@@ -70,21 +70,21 @@ protected:
     void end_scan()
     {
         if (UNLIKELY(position_ >= end_position_))
-            impl::throw_jpegls_error(jpegls_errc::source_buffer_too_small);
+            impl::throw_jpegls_error(jpegls_errc::need_more_data);
 
         if (*position_ != jpeg_marker_start_byte)
         {
             read_bit();
 
             if (UNLIKELY(position_ >= end_position_))
-                impl::throw_jpegls_error(jpegls_errc::source_buffer_too_small);
+                impl::throw_jpegls_error(jpegls_errc::need_more_data);
 
             if (UNLIKELY(*position_ != jpeg_marker_start_byte))
-                impl::throw_jpegls_error(jpegls_errc::too_much_encoded_data);
+                impl::throw_jpegls_error(jpegls_errc::invalid_data);
         }
 
         if (UNLIKELY(read_cache_ != 0))
-            impl::throw_jpegls_error(jpegls_errc::too_much_encoded_data);
+            impl::throw_jpegls_error(jpegls_errc::invalid_data);
     }
 
     [[nodiscard]]
@@ -127,7 +127,7 @@ protected:
         {
             fill_read_cache();
             if (UNLIKELY(valid_bits_ < bit_count))
-                impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+                impl::throw_jpegls_error(jpegls_errc::invalid_data);
         }
 
         ASSERT(bit_count <= valid_bits_);
@@ -209,7 +209,7 @@ protected:
     std::byte read_byte()
     {
         if (UNLIKELY(position_ == end_position_))
-            impl::throw_jpegls_error(jpegls_errc::source_buffer_too_small);
+            impl::throw_jpegls_error(jpegls_errc::need_more_data);
 
         const std::byte value = *position_;
         ++position_;
@@ -251,7 +251,7 @@ private:
                 if (UNLIKELY(valid_bits_ == 0))
                 {
                     // Decoding process expects at least some bits to be added to the cache.
-                    impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+                    impl::throw_jpegls_error(jpegls_errc::invalid_data);
                 }
 
                 return;
@@ -266,7 +266,7 @@ private:
                 if (UNLIKELY(valid_bits_ <= 0))
                 {
                     // Decoding process expects at least some bits to be added to the cache.
-                    impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+                    impl::throw_jpegls_error(jpegls_errc::invalid_data);
                 }
 
                 // End of buffer or marker detected. Typical found markers are EOI, SOS (next scan) or RSTm.

--- a/src/scan_decoder_impl.h
+++ b/src/scan_decoder_impl.h
@@ -291,7 +291,7 @@ private:
         {
             error_value = unmap_error_value(decode_value(k, traits_.limit, traits_.quantized_bits_per_sample));
             if (UNLIKELY(std::abs(error_value) > 65535))
-                impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+                impl::throw_jpegls_error(jpegls_errc::invalid_data);
         }
 
         if (k == 0)
@@ -380,7 +380,7 @@ private:
         }
 
         if (UNLIKELY(index > pixel_count))
-            impl::throw_jpegls_error(jpegls_errc::invalid_encoded_data);
+            impl::throw_jpegls_error(jpegls_errc::invalid_data);
 
         for (int32_t i{}; i < index; ++i)
         {

--- a/src/scan_encoder.h
+++ b/src/scan_encoder.h
@@ -113,7 +113,7 @@ protected:
     void flush()
     {
         if (UNLIKELY(compressed_length_ < 4))
-            impl::throw_jpegls_error(jpegls_errc::destination_buffer_too_small);
+            impl::throw_jpegls_error(jpegls_errc::destination_too_small);
 
         for (int i{}; i < 4; ++i)
         {

--- a/src/util.h
+++ b/src/util.h
@@ -86,7 +86,7 @@
 
 namespace charls {
 
-inline jpegls_errc to_jpegls_errc() noexcept
+inline CHARLS_NO_INLINE jpegls_errc to_jpegls_errc() noexcept
 {
     try
     {
@@ -101,10 +101,8 @@ inline jpegls_errc to_jpegls_errc() noexcept
     {
         return jpegls_errc::not_enough_memory;
     }
-    catch (...)
-    {
-        return jpegls_errc::unexpected_failure;
-    }
+
+    // Don't catch exceptions that are not expected: it is safer to terminate then continue in an unknown state.
 }
 
 

--- a/test/bitstreamdamage.cpp
+++ b/test/bitstreamdamage.cpp
@@ -35,7 +35,7 @@ void test_damaged_bit_stream1()
         error = e.code();
     }
 
-    assert::is_true(error == jpegls_errc::invalid_encoded_data);
+    assert::is_true(error == jpegls_errc::invalid_data);
 }
 
 
@@ -58,7 +58,7 @@ void test_damaged_bit_stream2()
         error = e.code();
     }
 
-    assert::is_true(error == jpegls_errc::invalid_encoded_data);
+    assert::is_true(error == jpegls_errc::invalid_data);
 }
 
 
@@ -81,7 +81,7 @@ void test_damaged_bit_stream3()
         error = e.code();
     }
 
-    assert::is_true(error == jpegls_errc::invalid_encoded_data);
+    assert::is_true(error == jpegls_errc::invalid_data);
 }
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -254,7 +254,7 @@ void test_fail_on_too_small_output_buffer()
     }
     catch (const jpegls_error& e)
     {
-        assert::is_true(e.code() == jpegls_errc::destination_buffer_too_small);
+        assert::is_true(e.code() == jpegls_errc::destination_too_small);
     }
 
     // Trigger a "destination buffer too small" when writing the encoded pixel bytes.
@@ -269,7 +269,7 @@ void test_fail_on_too_small_output_buffer()
     }
     catch (const jpegls_error& e)
     {
-        assert::is_true(e.code() == jpegls_errc::destination_buffer_too_small);
+        assert::is_true(e.code() == jpegls_errc::destination_too_small);
     }
 }
 
@@ -292,7 +292,7 @@ void test_too_small_output_buffer()
         error = e.code();
     }
 
-    assert::is_true(error == jpegls_errc::destination_buffer_too_small);
+    assert::is_true(error == jpegls_errc::destination_too_small);
 }
 
 

--- a/unittest/charls_jpegls_decoder_test.cpp
+++ b/unittest/charls_jpegls_decoder_test.cpp
@@ -160,7 +160,7 @@ public:
         Assert::AreEqual(jpegls_errc::success, error);
 
         error = charls_jpegls_decoder_read_header(decoder);
-        Assert::AreEqual(jpegls_errc::source_buffer_too_small, error);
+        Assert::AreEqual(jpegls_errc::need_more_data, error);
 
         charls_jpegls_decoder_destroy(decoder);
     }
@@ -170,7 +170,7 @@ public:
         auto decoder{get_initialized_decoder()};
 
         const auto error{charls_jpegls_decoder_decode_to_buffer(decoder.get(), nullptr, 0, 0)};
-        Assert::AreEqual(jpegls_errc::destination_buffer_too_small, error);
+        Assert::AreEqual(jpegls_errc::destination_too_small, error);
     }
 
     TEST_METHOD(at_comment_nullptr) // NOLINT

--- a/unittest/charls_jpegls_encoder_test.cpp
+++ b/unittest/charls_jpegls_encoder_test.cpp
@@ -89,7 +89,7 @@ public:
 
     TEST_METHOD(charls_jpegls_encoder_set_table_id_nullptr) // NOLINT
     {
-        const auto error{charls_jpegls_encoder_set_table_id(nullptr, 0, 0)};
+        const auto error{charls_jpegls_encoder_set_mapping_table_id(nullptr, 0, 0)};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
 
@@ -210,7 +210,7 @@ public:
 
         constexpr array<byte, 10> buffer{};
         error = charls_jpegls_encoder_encode_from_buffer(encoder, buffer.data(), buffer.size(), 0);
-        Assert::AreEqual(jpegls_errc::destination_buffer_too_small, error);
+        Assert::AreEqual(jpegls_errc::destination_too_small, error);
 
         charls_jpegls_encoder_destroy(encoder);
     }
@@ -228,7 +228,7 @@ public:
         Assert::AreEqual(jpegls_errc::success, error);
 
         error = charls_jpegls_encoder_encode_from_buffer(encoder, nullptr, 0, 0);
-        Assert::AreEqual(jpegls_errc::destination_buffer_too_small, error);
+        Assert::AreEqual(jpegls_errc::destination_too_small, error);
 
         charls_jpegls_encoder_destroy(encoder);
     }

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -30,7 +30,7 @@ public:
         jpeg_stream_reader reader;
         reader.source({buffer.data(), 0});
 
-        assert_expect_exception(jpegls_errc::source_buffer_too_small, [&reader] { reader.read_header(); });
+        assert_expect_exception(jpegls_errc::need_more_data, [&reader] { reader.read_header(); });
     }
 
     TEST_METHOD(read_header_from_buffer_preceded_with_fill_bytes) // NOLINT
@@ -589,7 +589,7 @@ public:
                            },
                            &called});
 
-        assert_expect_exception(jpegls_errc::source_buffer_too_small, [&reader] { reader.read_header(); });
+        assert_expect_exception(jpegls_errc::need_more_data, [&reader] { reader.read_header(); });
         Assert::IsFalse(called);
     }
 
@@ -682,7 +682,7 @@ public:
                                     },
                                     &called});
 
-        assert_expect_exception(jpegls_errc::source_buffer_too_small, [&reader] { reader.read_header(); });
+        assert_expect_exception(jpegls_errc::need_more_data, [&reader] { reader.read_header(); });
         Assert::IsFalse(called);
     }
 
@@ -734,7 +734,7 @@ public:
         reader.source({source.data(), source.size()});
         reader.read_header();
 
-        assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&reader] {
+        assert_expect_exception(jpegls_errc::destination_too_small, [&reader] {
             vector<byte> table_data(1);
             reader.get_mapping_table_data(0, {table_data.data(), table_data.size()});
         });

--- a/unittest/jpeg_stream_writer_test.cpp
+++ b/unittest/jpeg_stream_writer_test.cpp
@@ -48,7 +48,7 @@ public:
         jpeg_stream_writer writer;
         writer.destination({buffer.data(), buffer.size()});
 
-        assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&writer] { writer.write_start_of_image(); });
+        assert_expect_exception(jpegls_errc::destination_too_small, [&writer] { writer.write_start_of_image(); });
         Assert::AreEqual(size_t{}, writer.bytes_written());
     }
 
@@ -127,7 +127,7 @@ public:
         jpeg_stream_writer writer;
         writer.destination({buffer.data(), buffer.size()});
 
-        assert_expect_exception(jpegls_errc::destination_buffer_too_small, [&writer] { writer.write_end_of_image(false); });
+        assert_expect_exception(jpegls_errc::destination_too_small, [&writer] { writer.write_end_of_image(false); });
         Assert::AreEqual(size_t{}, writer.bytes_written());
     }
 
@@ -220,7 +220,7 @@ public:
                             96,
                             1024};
 
-        assert_expect_exception(jpegls_errc::destination_buffer_too_small,
+        assert_expect_exception(jpegls_errc::destination_too_small,
                                 [&writer, &header] { writer.write_spiff_header_segment(header); });
         Assert::AreEqual(size_t{}, writer.bytes_written());
     }
@@ -537,7 +537,7 @@ public:
         array<byte, 10> buffer{};
         jpeg_stream_writer writer;
         writer.destination({buffer.data(), buffer.size()});
-        writer.set_table_id(0, 77);
+        writer.set_mapping_table_id(0, 77);
 
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);
 
@@ -555,7 +555,7 @@ public:
         array<byte, 10> buffer{};
         jpeg_stream_writer writer;
         writer.destination({buffer.data(), buffer.size()});
-        writer.set_table_id(0, 77);
+        writer.set_mapping_table_id(0, 77);
         writer.rewind();
 
         writer.write_start_of_scan_segment(1, 2, interleave_mode::none);

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -598,7 +598,7 @@ public:
 
         vector<byte> destination(decoder.destination_size());
 
-        assert_expect_exception(jpegls_errc::invalid_encoded_data,
+        assert_expect_exception(jpegls_errc::invalid_data,
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
@@ -616,7 +616,7 @@ public:
 
             jpegls_decoder decoder{source, true};
             vector<byte> destination(decoder.destination_size());
-            assert_expect_exception(jpegls_errc::source_buffer_too_small,
+            assert_expect_exception(jpegls_errc::need_more_data,
                                     [&decoder, &destination] { decoder.decode(destination); });
         }
 
@@ -625,7 +625,7 @@ public:
             jpegls_decoder decoder{source, true};
             vector<byte> destination(decoder.destination_size());
 
-            assert_expect_exception(jpegls_errc::source_buffer_too_small,
+            assert_expect_exception(jpegls_errc::need_more_data,
                                     [&decoder, &destination] { decoder.decode(destination); });
         }
 
@@ -654,7 +654,7 @@ public:
 
         vector<byte> destination(decoder.destination_size());
 
-        assert_expect_exception(jpegls_errc::invalid_encoded_data,
+        assert_expect_exception(jpegls_errc::invalid_data,
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
@@ -672,7 +672,7 @@ public:
 
         vector<byte> destination(decoder.destination_size());
 
-        assert_expect_exception(jpegls_errc::source_buffer_too_small,
+        assert_expect_exception(jpegls_errc::need_more_data,
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
@@ -742,7 +742,7 @@ public:
         jpegls_decoder decoder{too_small_source, true};
         vector<byte> destination(decoder.destination_size());
 
-        assert_expect_exception(jpegls_errc::source_buffer_too_small,
+        assert_expect_exception(jpegls_errc::need_more_data,
                                 [&decoder, &destination] { decoder.decode(destination); });
     }
 
@@ -1050,7 +1050,7 @@ public:
         decoder.source(writer.buffer);
         decoder.read_spiff_header();
 
-        assert_expect_exception(jpegls_errc::mapping_tables_and_spiff_header,
+        assert_expect_exception(jpegls_errc::abbreviated_format_and_spiff_header,
                                 [&decoder] { ignore = decoder.read_header(); });
     }
 
@@ -1342,7 +1342,7 @@ private:
         jpegls_decoder decoder{source, true};
         vector<byte> destination(decoder.destination_size(stride) - 1);
 
-        assert_expect_exception(jpegls_errc::destination_buffer_too_small,
+        assert_expect_exception(jpegls_errc::destination_too_small,
                                 [&decoder, &destination, &stride] { decoder.decode(destination, stride); });
     }
 };

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -1052,7 +1052,7 @@ public:
         Assert::AreEqual(static_cast<byte>(jpeg_marker_code::end_of_image), destination[11]);
     }
 
-    TEST_METHOD(create_tables_only_with_no_tables_throws) // NOLINT
+    TEST_METHOD(create_abbreviated_format_with_no_tables_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
@@ -1117,7 +1117,7 @@ public:
         vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
-        encoder.set_table_id(0, 1);
+        encoder.set_mapping_table_id(0, 1);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
@@ -1136,8 +1136,8 @@ public:
         vector<byte> destination(encoder.estimated_destination_size());
         encoder.destination(destination);
 
-        encoder.set_table_id(0, 1);
-        encoder.set_table_id(0, 0);
+        encoder.set_mapping_table_id(0, 1);
+        encoder.set_mapping_table_id(0, 0);
 
         const size_t bytes_written{encoder.encode(source)};
         destination.resize(bytes_written);
@@ -1151,14 +1151,14 @@ public:
     {
         jpegls_encoder encoder;
 
-        assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] { encoder.set_table_id(-1, 0); });
+        assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] { encoder.set_mapping_table_id(-1, 0); });
     }
 
     TEST_METHOD(set_table_id_bad_id_throws) // NOLINT
     {
         jpegls_encoder encoder;
 
-        assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] { encoder.set_table_id(0, -1); });
+        assert_expect_exception(jpegls_errc::invalid_argument, [&encoder] { encoder.set_mapping_table_id(0, -1); });
     }
 
     TEST_METHOD(encode_without_destination_throws) // NOLINT


### PR DESCRIPTION
Group the error IDs in errors that cannot be prevented and can be reported at runtime and in a set of errors that can be prevented.

Note 1: the error destination_too_small is considerd a runtime failure, but can in many cases be prevented.
Note 2: unexpected exceptions will now trigger a call to std::terminate (improved crash dumps)