### PR TITLE
Add method charls_decoder_get_compressed_data_format

### DIFF
--- a/CharLS.sln.DotSettings
+++ b/CharLS.sln.DotSettings
@@ -19,6 +19,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyModernizeLoopConvert/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyModernizeUseDefaultMemberInit/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyModernizeUseNullptr/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyPerformanceEnumSize/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyPerformanceNoexceptMoveConstructor/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyReadabilityMagicNumbers/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyReadabilityStaticAccessedThroughInstance/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -107,6 +108,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRRGGGBBB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Runmode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=strcpy/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subsampled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subspan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Undefine/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unittest/@EntryIndexedValue">True</s:Boolean>

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -210,6 +210,22 @@ charls_jpegls_decoder_at_application_data(CHARLS_IN charls_jpegls_decoder* decod
                                           charls_at_application_data_handler handler, void* user_context) CHARLS_NOEXCEPT
     CHARLS_ATTRIBUTE((nonnull(1)));
 
+
+/// <summary>
+/// Returns the compressed data format of the JPEG-LS data stream.
+/// </summary>
+/// <remarks>
+/// Function can be called after reading the header or after processing the complete JPEG-LS stream.
+/// After reading the header the method may report unknown or abbreviated_table_specification.
+/// </remarks>
+/// <param name="decoder">Reference to the decoder instance.</param>
+/// <param name="compressed_data_format">Current .</param>
+/// <returns>The result of the operation: success or a failure code.</returns>
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_decoder_get_compressed_data_format(CHARLS_IN const charls_jpegls_decoder* decoder,
+                                          CHARLS_OUT charls_compressed_data_format* compressed_data_format) CHARLS_NOEXCEPT
+    CHARLS_ATTRIBUTE((nonnull));
+
 /// <summary>
 /// Returns the mapping table ID referenced by the component or 0 when no mapping table is used.
 /// </summary>
@@ -237,7 +253,7 @@ charls_decoder_get_mapping_table_id(CHARLS_IN const charls_jpegls_decoder* decod
 /// <returns>The result of the operation: success or a failure code.</returns>
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
 charls_decoder_find_mapping_table_index(CHARLS_IN const charls_jpegls_decoder* decoder, int32_t mapping_table_id,
-                                       CHARLS_OUT int32_t* index) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull));
+                                        CHARLS_OUT int32_t* index) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull));
 
 /// <summary>
 /// Returns the count of mapping tables present in the JPEG-LS stream.
@@ -277,7 +293,9 @@ charls_decoder_get_mapping_table_info(CHARLS_IN const charls_jpegls_decoder* dec
 /// </remarks>
 /// <param name="decoder">Reference to the decoder instance.</param>
 /// <param name="mapping_table_index">Index of the requested mapping table.</param>
-/// <param name="mapping_table_data">Output argument, will hold the data of the mapping table when the function returns.</param>
+/// <param name="mapping_table_data">
+/// Output argument, will hold the data of the mapping table when the function returns.
+/// </param>
 /// <param name="mapping_table_size_bytes">Length of the mapping table buffer in bytes.</param>
 /// <returns>The result of the operation: success or a failure code.</returns>
 CHARLS_ATTRIBUTE_ACCESS((access(write_only, 3, 4)))

--- a/include/charls/jpegls_decoder.hpp
+++ b/include/charls/jpegls_decoder.hpp
@@ -392,6 +392,22 @@ public:
     }
 
     /// <summary>
+    /// Returns the compressed data format of the JPEG-LS data stream.
+    /// </summary>
+    /// <remarks>
+    /// Function can be called after reading the header or after processing the complete JPEG-LS stream.
+    /// After reading the header the method may report unknown or abbreviated_table_specification.
+    /// </remarks>
+    /// <returns>The compressed data format.</returns>
+    [[nodiscard]]
+    charls::compressed_data_format compressed_data_format() const
+    {
+        charls::compressed_data_format format;
+        check_jpegls_errc(charls_decoder_get_compressed_data_format(decoder(), &format));
+        return format;
+    }
+
+    /// <summary>
     /// Returns the mapping table ID referenced by the component or 0 when no mapping table is used.
     /// </summary>
     /// <remarks>

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -92,6 +92,14 @@ enum charls_interleave_mode
     CHARLS_INTERLEAVE_MODE_SAMPLE = 2
 };
 
+enum charls_compressed_data_format
+{
+    CHARLS_COMPRESSED_DATA_FORMAT_UNKNOWN = 0,
+    CHARLS_COMPRESSED_DATA_FORMAT_INTERCHANGE = 1,
+    CHARLS_COMPRESSED_DATA_FORMAT_ABBREVIATED_IMAGE_DATA = 2,
+    CHARLS_COMPRESSED_DATA_FORMAT_ABBREVIATED_TABLE_SPECIFICATION = 3
+};
+
 enum charls_encoding_options
 {
     CHARLS_ENCODING_OPTIONS_NONE = 0,
@@ -472,6 +480,34 @@ enum class interleave_mode
 };
 
 
+/// <summary>
+/// JPEG-LS defines 3 compressed data formats. (see Annex C).
+/// </summary>
+enum class compressed_data_format
+{
+    /// <summary>
+    /// Not enough information has been decoded to determine the data format.
+    /// </summary>
+    unknown = impl::CHARLS_COMPRESSED_DATA_FORMAT_UNKNOWN,
+
+    /// <summary>
+    /// All data to decode the image is contained in the file. This is the typical format.
+    /// </summary>
+    interchange = impl::CHARLS_COMPRESSED_DATA_FORMAT_INTERCHANGE,
+
+    /// <summary>
+    /// The file has references to mapping tables that need to be provided by
+    /// the application environment.
+    /// </summary>
+    abbreviated_image_data = impl::CHARLS_COMPRESSED_DATA_FORMAT_ABBREVIATED_IMAGE_DATA,
+
+    /// <summary>
+    /// The file only contains mapping tables, no image is present.
+    /// </summary>
+    abbreviated_table_specification = impl::CHARLS_COMPRESSED_DATA_FORMAT_ABBREVIATED_TABLE_SPECIFICATION
+};
+
+
 namespace encoding_options_private {
 
 /// <summary>
@@ -841,6 +877,7 @@ struct std::is_error_code_enum<charls::jpegls_errc> final : std::true_type
 
 using charls_jpegls_errc = charls::jpegls_errc;
 using charls_interleave_mode = charls::interleave_mode;
+using charls_compressed_data_format = charls::compressed_data_format;
 using charls_encoding_options = charls::encoding_options;
 using charls_color_transformation = charls::color_transformation;
 
@@ -854,6 +891,7 @@ using charls_spiff_entry_tag = charls::spiff_entry_tag;
 
 typedef enum charls_jpegls_errc charls_jpegls_errc;
 typedef enum charls_interleave_mode charls_interleave_mode;
+typedef enum charls_compressed_data_format charls_compressed_data_format;
 typedef enum charls_encoding_options charls_encoding_options;
 typedef enum charls_color_transformation charls_color_transformation;
 
@@ -895,8 +933,8 @@ struct charls_spiff_header CHARLS_FINAL
 /// Defines the information that can be stored in a JPEG-LS Frame marker segment that applies to all scans.
 /// </summary>
 /// <remark>
-/// The JPEG-LS also allow to store sub-sampling information in a JPEG-LS Frame marker segment.
-/// CharLS does not support JPEG-LS images that contain sub-sampled scans.
+/// The JPEG-LS also allow to store subsampling information in a JPEG-LS Frame marker segment.
+/// CharLS does not support JPEG-LS images that contain subsampled scans.
 /// </remark>
 struct charls_frame_info CHARLS_FINAL
 {

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -130,6 +130,12 @@ struct charls_jpegls_decoder final
     }
 
     [[nodiscard]]
+    charls::compressed_data_format compressed_data_format() const noexcept
+    {
+        return reader_.compressed_data_format();
+    }
+
+    [[nodiscard]]
     int32_t get_mapping_table_id(const size_t component_index) const
     {
         check_state_completed();
@@ -441,6 +447,19 @@ USE_DECL_ANNOTATIONS jpegls_errc CHARLS_API_CALLING_CONVENTION charls_jpegls_dec
 try
 {
     check_pointer(decoder)->at_application_data({handler, user_context});
+    return jpegls_errc::success;
+}
+catch (...)
+{
+    return to_jpegls_errc();
+}
+
+
+USE_DECL_ANNOTATIONS charls_jpegls_errc CHARLS_API_CALLING_CONVENTION charls_decoder_get_compressed_data_format(
+    const charls_jpegls_decoder* decoder, charls_compressed_data_format* compressed_data_format) noexcept
+try
+{
+    *check_pointer(compressed_data_format) = check_pointer(decoder)->compressed_data_format();
     return jpegls_errc::success;
 }
 catch (...)

--- a/src/jpeg_stream_reader.hpp
+++ b/src/jpeg_stream_reader.hpp
@@ -86,6 +86,12 @@ public:
     }
 
     [[nodiscard]]
+    charls::compressed_data_format compressed_data_format() const noexcept
+    {
+        return compressed_data_format_;
+    }
+
+    [[nodiscard]]
     int32_t get_mapping_table_id(size_t component_index) const noexcept;
 
     [[nodiscard]]
@@ -176,6 +182,9 @@ private:
     void add_mapping_table(uint8_t table_id, uint8_t entry_size, span<const std::byte> table_data);
     void extend_mapping_table(uint8_t table_id, uint8_t entry_size, span<const std::byte> table_data);
     void store_mapping_table_id(uint8_t component_id, uint8_t table_id);
+
+    [[nodiscard]]
+    bool has_external_mapping_table_ids() const noexcept;
 
     /// <summary>
     /// ISO/IEC 14495-1, Annex C defines 3 data formats.
@@ -275,6 +284,7 @@ private:
     std::vector<scan_info> scan_infos_;
     std::vector<mapping_table_entry> mapping_tables_;
     state state_{};
+    charls::compressed_data_format compressed_data_format_{};
     callback_function<at_comment_handler> at_comment_callback_{};
     callback_function<at_application_data_handler> at_application_data_callback_{};
 };

--- a/unittest/util.hpp
+++ b/unittest/util.hpp
@@ -91,6 +91,13 @@ Microsoft::VisualStudio::CppUnitTestFramework::ToString<charls::interleave_mode>
 }
 
 template<>
+inline std::wstring Microsoft::VisualStudio::CppUnitTestFramework::ToString<charls::compressed_data_format>(
+    const charls::compressed_data_format& q)
+{
+    RETURN_WIDE_STRING(static_cast<int>(q));
+}
+
+template<>
 inline std::wstring Microsoft::VisualStudio::CppUnitTestFramework::ToString<std::byte>(const std::byte& q)
 {
     RETURN_WIDE_STRING(static_cast<int>(q));


### PR DESCRIPTION
The JPEG-LS standard defines 3 compressed data formats. Only the interchange format (the most common) can normally be decoded. Add a method to allow application code to retrieve the data format of the JPEG-LS stream. This allows an application to decide if it want to display the image or process it differently.