### PR TITLE
Update the name of golomb_code to golomb_code_match and POD conversion

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -614,6 +614,6 @@ BENCHMARK(bm_read_all_bytes_no_check64);
 // Tips to run the benchmark tests:
 
 // To run a single benchmark:
-// benchmark --benchmark_filter = bm_decode   
+// benchmark --benchmark_filter=bm_decode   
 
 BENCHMARK_MAIN();

--- a/benchmark/benchmark.vcxproj
+++ b/benchmark/benchmark.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="benchmark.cpp" />
     <ClCompile Include="context_regular_mode.cpp" />
     <ClCompile Include="decode.cpp" />
+    <ClCompile Include="golomb_lut_constexpr.cpp" />
     <ClCompile Include="log2.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/benchmark/benchmark.vcxproj.filters
+++ b/benchmark/benchmark.vcxproj.filters
@@ -23,6 +23,9 @@
     <ClCompile Include="decode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="golomb_lut_constexpr.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="context_regular_mode_v220.h">

--- a/benchmark/decode.cpp
+++ b/benchmark/decode.cpp
@@ -7,7 +7,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <vector>
 

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -53,14 +53,14 @@ struct charls_jpegls_decoder final
     [[nodiscard]]
     charls::frame_info frame_info_checked() const
     {
-        check_header_read();
+        check_state_header_read();
         return frame_info();
     }
 
     [[nodiscard]]
     int32_t near_lossless(int32_t /*component*/ = 0) const
     {
-        check_header_read();
+        check_state_header_read();
 
         // Note: The JPEG-LS standard allows to define different NEAR parameter for every scan.
         return reader_.parameters().near_lossless;
@@ -69,7 +69,7 @@ struct charls_jpegls_decoder final
     [[nodiscard]]
     charls::interleave_mode interleave_mode() const
     {
-        check_header_read();
+        check_state_header_read();
 
         // Note: The JPEG-LS standard allows to define different interleave modes for every scan.
         //       CharLS doesn't support mixed interleave modes, first scan determines the mode.
@@ -79,14 +79,14 @@ struct charls_jpegls_decoder final
     [[nodiscard]]
     charls::color_transformation color_transformation() const
     {
-        check_header_read();
+        check_state_header_read();
         return reader_.parameters().transformation;
     }
 
     [[nodiscard]]
     const jpegls_pc_parameters& preset_coding_parameters() const
     {
-        check_header_read();
+        check_state_header_read();
         return reader_.preset_coding_parameters();
     }
 
@@ -235,7 +235,7 @@ private:
         return components_in_plane_count * frame_info().width * bit_to_byte_count(frame_info().bits_per_sample);
     }
 
-    void check_header_read() const
+    void check_state_header_read() const
     {
         check_operation(state_ >= state::header_read);
     }

--- a/src/jpegls_algorithm.hpp
+++ b/src/jpegls_algorithm.hpp
@@ -153,7 +153,7 @@ constexpr int32_t compute_context_id(const int32_t q1, const int32_t q2, const i
 }
 
 
-// See JPEG-LS standard ISO/IEC 14495-1, A.3.3, golomb_code Segment A.4
+// See JPEG-LS standard ISO/IEC 14495-1, A.3.3, golomb code Segment A.4
 [[nodiscard]]
 constexpr int8_t quantize_gradient_org(const int32_t di, const int32_t threshold1, const int32_t threshold2,
                                        const int32_t threshold3, const int32_t near_lossless = 0) noexcept

--- a/src/run_mode_context.hpp
+++ b/src/run_mode_context.hpp
@@ -33,7 +33,7 @@ public:
     }
 
     [[nodiscard]]
-    FORCE_INLINE int32_t get_golomb_code() const noexcept
+    FORCE_INLINE int32_t compute_golomb_coding_parameter() const noexcept
     {
         const int32_t temp{a_ + (n_ >> 1) * run_interruption_type_};
         int32_t n_test{n_};

--- a/src/scan_encoder_impl.hpp
+++ b/src/scan_encoder_impl.hpp
@@ -273,7 +273,7 @@ private:
 
     void encode_run_interruption_error(run_mode_context& context, const int32_t error_value)
     {
-        const int32_t k{context.get_golomb_code()};
+        const int32_t k{context.compute_golomb_coding_parameter()};
         const bool map{context.compute_map(error_value, k)};
         const int32_t e_mapped_error_value{2 * std::abs(error_value) - context.run_interruption_type() -
                                            static_cast<int32_t>(map)};

--- a/unittest/charls_jpegls_encoder_test.cpp
+++ b/unittest/charls_jpegls_encoder_test.cpp
@@ -12,6 +12,8 @@
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
 using std::array;
 using std::byte;
+using std::ignore;
+using std::vector;
 
 MSVC_WARNING_SUPPRESS(6387) // '_Param_(x)' could be '0': this does not adhere to the specification for the function.
 
@@ -237,6 +239,30 @@ public:
     {
         const auto error{charls_jpegls_encoder_create_abbreviated_format(nullptr)};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
+    }
+
+    TEST_METHOD(encode_non_8_or_16_bit_with_color_transformation_throws) // NOLINT
+    {
+        constexpr frame_info frame_info{2, 1, 10, 3};
+        jpegls_encoder encoder;
+
+        vector<byte> destination(40);
+        encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
+        const vector<byte> source(20);
+        assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
+                                [&encoder, &source] { ignore = encoder.encode(source); });
+    }
+
+    TEST_METHOD(encode_non_3_components_that_is_not_supported_throws) // NOLINT
+    {
+        constexpr frame_info frame_info{2, 1, 8, 4};
+        jpegls_encoder encoder;
+
+        vector<byte> destination(40);
+        encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
+        const vector<byte> source(20);
+        assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
+                                [&encoder, &source] { ignore = encoder.encode(source); });
     }
 };
 

--- a/unittest/color_transform_test.cpp
+++ b/unittest/color_transform_test.cpp
@@ -7,16 +7,7 @@
 
 #include "../src/color_transform.hpp"
 
-#include <charls/jpegls_decoder.hpp>
-#include <charls/jpegls_encoder.hpp>
-
-#include <tuple>
-#include <vector>
-
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;
-using std::byte;
-using std::vector;
-using std::ignore;
 
 namespace charls::test {
 
@@ -42,9 +33,10 @@ public:
 
                     const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
 
-                    Assert::AreEqual(static_cast<uint8_t>(red), round_trip.v1);
-                    Assert::AreEqual(static_cast<uint8_t>(green), round_trip.v2);
-                    Assert::AreEqual(static_cast<uint8_t>(blue), round_trip.v3);
+                    // Note: Is True is 1000 times faster then AreEqual
+                    Assert::IsTrue(static_cast<uint8_t>(red) == round_trip.v1);
+                    Assert::IsTrue(static_cast<uint8_t>(green) == round_trip.v2);
+                    Assert::IsTrue(static_cast<uint8_t>(blue) == round_trip.v3);
                 }
             }
         }
@@ -69,9 +61,10 @@ public:
 
                     const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
 
-                    Assert::AreEqual(static_cast<uint8_t>(red), round_trip.v1);
-                    Assert::AreEqual(static_cast<uint8_t>(green), round_trip.v2);
-                    Assert::AreEqual(static_cast<uint8_t>(blue), round_trip.v3);
+                    // Note: Is True is 1000 times faster then AreEqual
+                    Assert::IsTrue(static_cast<uint8_t>(red) == round_trip.v1);
+                    Assert::IsTrue(static_cast<uint8_t>(green) == round_trip.v2);
+                    Assert::IsTrue(static_cast<uint8_t>(blue) == round_trip.v3);
                 }
             }
         }
@@ -95,46 +88,13 @@ public:
                     constexpr transform_hp3<uint8_t>::inverse inverse{};
                     const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
 
-                    Assert::AreEqual(static_cast<uint8_t>(red), round_trip.v1);
-                    Assert::AreEqual(static_cast<uint8_t>(green), round_trip.v2);
-                    Assert::AreEqual(static_cast<uint8_t>(blue), round_trip.v3);
+                    // Note: Is True is 1000 times faster then AreEqual
+                    Assert::IsTrue(static_cast<uint8_t>(red) == round_trip.v1);
+                    Assert::IsTrue(static_cast<uint8_t>(green) == round_trip.v2);
+                    Assert::IsTrue(static_cast<uint8_t>(blue) == round_trip.v3);
                 }
             }
         }
-    }
-
-    TEST_METHOD(decode_non_8_or_16_bit_that_is_not_supported_throws) // NOLINT
-    {
-        const auto jpegls_data{read_file("land10-10bit-rgb-hp3-invalid.jls")};
-
-        jpegls_decoder decoder{jpegls_data, false};
-
-        assert_expect_exception(jpegls_errc::invalid_parameter_color_transformation,
-                                [&decoder] { decoder.read_header(); });
-    }
-
-    TEST_METHOD(encode_non_8_or_16_bit_that_is_not_supported_throws) // NOLINT
-    {
-        constexpr frame_info frame_info{2, 1, 10, 3};
-        jpegls_encoder encoder;
-
-        vector<byte> destination(40);
-        encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
-        const vector<byte> source(20);
-        assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
-                                [&encoder, &source] { ignore = encoder.encode(source); });
-    }
-
-    TEST_METHOD(encode_non_3_components_that_is_not_supported_throws) // NOLINT
-    {
-        constexpr frame_info frame_info{2, 1, 8, 4};
-        jpegls_encoder encoder;
-
-        vector<byte> destination(40);
-        encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
-        const vector<byte> source(20);
-        assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
-                                [&encoder, &source] { ignore = encoder.encode(source); });
     }
 };
 

--- a/unittest/golomb_table_test.cpp
+++ b/unittest/golomb_table_test.cpp
@@ -17,18 +17,18 @@ TEST_CLASS(golomb_table_test)
 public:
     TEST_METHOD(golomb_table_create) // NOLINT
     {
-#if _MSC_VER >= 1920 // VS 2019
-        constexpr golomb_code_table golomb_table;
-#else
-        const golomb_code_table golomb_table;
-#endif
+        const golomb_code_match_table golomb_table(0);
 
-        for (uint32_t i{}; i != 256U; ++i)
-        {
-            Assert::AreEqual(0U, golomb_table.get(i).length());
-            Assert::AreEqual(0, golomb_table.get(i).value());
-        }
+        Assert::AreEqual(0U, golomb_table.get(0).bit_count);
+        Assert::AreEqual(0, golomb_table.get(0).error_value);
+        Assert::AreEqual(1U, golomb_table.get(255).bit_count);
+        Assert::AreEqual(0, golomb_table.get(255).error_value);
     }
 };
+
+// The Windows x64 ABI has strict requirements when it is allowed to return a struct in a register.
+static_assert(std::is_standard_layout_v<golomb_code_match>);
+static_assert(std::is_trivial_v<golomb_code_match>);
+
 
 } // namespace charls::test

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -1304,6 +1304,15 @@ public:
                                 [&decoder, &table] { decoder.get_mapping_table_data(0, table); });
     }
 
+    TEST_METHOD(read_header_non_8_or_16_bit_with_color_transformation_throws) // NOLINT
+    {
+        const auto jpegls_data{read_file("land10-10bit-rgb-hp3-invalid.jls")};
+
+        jpegls_decoder decoder{jpegls_data, false};
+
+        assert_expect_exception(jpegls_errc::invalid_parameter_color_transformation, [&decoder] { decoder.read_header(); });
+    }
+
 private:
     // ReSharper disable CppPassValueParameterByConstReference
     [[nodiscard]]

--- a/unittest/run_mode_context_test.cpp
+++ b/unittest/run_mode_context_test.cpp
@@ -19,7 +19,7 @@ public:
 
         context.update_variables(3, 27, 0);
 
-        Assert::AreEqual(3, context.get_golomb_code());
+        Assert::AreEqual(3, context.compute_golomb_coding_parameter());
     }
 };
 

--- a/unittest/scan_decoder_test.cpp
+++ b/unittest/scan_decoder_test.cpp
@@ -39,13 +39,13 @@ public:
     }
 
     [[nodiscard]]
-    int32_t peek_byte_forward()
+    size_t peek_byte_forward()
     {
         return peek_byte();
     }
 
     [[nodiscard]]
-    bool read_bit_forward()
+    uintptr_t read_bit_forward()
     {
         return read_bit();
     }
@@ -107,7 +107,7 @@ public:
 
         scan_decoder_tester scan_decoder(frame_info, parameters, buffer.data(), buffer.size());
 
-        Assert::AreEqual(7, scan_decoder.peek_byte_forward());
+        Assert::AreEqual(size_t{7}, scan_decoder.peek_byte_forward());
     }
 
     TEST_METHOD(read_bit) // NOLINT
@@ -119,14 +119,14 @@ public:
 
         scan_decoder_tester scan_decoder(frame_info, parameters, buffer.data(), buffer.size());
 
-        Assert::IsTrue(scan_decoder.read_bit_forward());
-        Assert::IsFalse(scan_decoder.read_bit_forward());
-        Assert::IsTrue(scan_decoder.read_bit_forward());
-        Assert::IsFalse(scan_decoder.read_bit_forward());
-        Assert::IsTrue(scan_decoder.read_bit_forward());
-        Assert::IsFalse(scan_decoder.read_bit_forward());
-        Assert::IsTrue(scan_decoder.read_bit_forward());
-        Assert::IsFalse(scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(1), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(0), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(1), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(0), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(1), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(0), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(1), scan_decoder.read_bit_forward());
+        Assert::AreEqual(static_cast<uintptr_t>(0), scan_decoder.read_bit_forward());
     }
 
     TEST_METHOD(peek_0_bits) // NOLINT


### PR DESCRIPTION
The main purpose of golomb_code_match is to see if there is a precomputed match which allows to just skip the bytes. Rename the struct to make it clear it is not the actual glomb code itself. Update the golomb_code_match struct back into a POD. The Windows x64 ABI cannot return non-POD structs in a single register even when the would fit.