### PR TITLE
Move processing of restart marker to base class + reset_threshold

### DIFF
--- a/src/default_traits.hpp
+++ b/src/default_traits.hpp
@@ -46,20 +46,15 @@ struct default_traits final
     // ISO 14495-1 LIMIT symbol: the value of glimit for a sample encoded in regular mode.
     int32_t limit;
 
-    // ISO 14495-1 RESET symbol: threshold value at which A, B, and N are halved.
-    int32_t reset_threshold;
-
     int32_t quantization_range;
 
-    default_traits(const int32_t arg_maximum_sample_value, const int32_t arg_near_lossless,
-                   const int32_t reset = default_reset_threshold) noexcept :
+    default_traits(const int32_t arg_maximum_sample_value, const int32_t arg_near_lossless) noexcept :
         maximum_sample_value{arg_maximum_sample_value},
         near_lossless{arg_near_lossless},
         range{compute_range_parameter(maximum_sample_value, near_lossless)},
         quantized_bits_per_sample{log2_ceiling(range)},
         bits_per_sample{log2_ceiling(maximum_sample_value)},
         limit{compute_limit_parameter(bits_per_sample)},
-        reset_threshold{reset},
         quantization_range{1 << bits_per_sample}
     {
         ASSERT(sizeof(SampleType) * 8 >= static_cast<size_t>(bits_per_sample));

--- a/src/lossless_traits.hpp
+++ b/src/lossless_traits.hpp
@@ -39,9 +39,6 @@ struct lossless_traits_impl
     // ISO 14495-1 LIMIT symbol: the value of glimit for a sample encoded in regular mode.
     static constexpr int32_t limit{compute_limit_parameter(BitsPerSample)};
 
-    // ISO 14495-1 RESET symbol: threshold value at which A, B, and N are halved.
-    static constexpr int32_t reset_threshold{default_reset_threshold};
-
     static constexpr int32_t quantization_range{1 << BitsPerSample};
 
     static_assert(sizeof(SampleType) * 8 >= BitsPerSample);

--- a/src/make_scan_codec.cpp
+++ b/src/make_scan_codec.cpp
@@ -139,30 +139,25 @@ unique_ptr<ScanProcess> try_make_optimized_codec(const frame_info& frame, const 
 
 template<typename ScanProcess>
 unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame, const jpegls_pc_parameters& pc_parameters,
-                                        const coding_parameters& parameters)
+                                        const coding_parameters& c_parameters)
 {
-    unique_ptr<ScanProcess> codec;
-
-    if (pc_parameters.reset_value == default_reset_threshold)
-    {
-        codec = try_make_optimized_codec<ScanProcess>(frame, pc_parameters, parameters);
-    }
+    unique_ptr<ScanProcess> codec{try_make_optimized_codec<ScanProcess>(frame, pc_parameters, c_parameters)};
 
     if (!codec)
     {
         if (frame.bits_per_sample <= 8)
         {
             default_traits<uint8_t, uint8_t> traits(calculate_maximum_sample_value(frame.bits_per_sample),
-                                                    parameters.near_lossless, pc_parameters.reset_value);
+                                                    c_parameters.near_lossless);
             traits.maximum_sample_value = pc_parameters.maximum_sample_value;
-            codec = make_codec<ScanProcess, default_traits<uint8_t, uint8_t>>(frame, pc_parameters, parameters, traits);
+            codec = make_codec<ScanProcess, default_traits<uint8_t, uint8_t>>(frame, pc_parameters, c_parameters, traits);
         }
         else
         {
             default_traits<uint16_t, uint16_t> traits(calculate_maximum_sample_value(frame.bits_per_sample),
-                                                      parameters.near_lossless, pc_parameters.reset_value);
+                                                      c_parameters.near_lossless);
             traits.maximum_sample_value = pc_parameters.maximum_sample_value;
-            codec = make_codec<ScanProcess, default_traits<uint16_t, uint16_t>>(frame, pc_parameters, parameters, traits);
+            codec = make_codec<ScanProcess, default_traits<uint16_t, uint16_t>>(frame, pc_parameters, c_parameters, traits);
         }
     }
 

--- a/src/make_scan_codec.hpp
+++ b/src/make_scan_codec.hpp
@@ -13,7 +13,7 @@ namespace charls {
 template<typename ScanProcess>
 [[nodiscard]]
 std::unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame,
-                                             const jpegls_pc_parameters& pc_parameters, const coding_parameters& parameters);
+                                             const jpegls_pc_parameters& pc_parameters, const coding_parameters& c_parameters);
 
 
 extern template std::unique_ptr<class scan_decoder>

--- a/src/run_mode_context.hpp
+++ b/src/run_mode_context.hpp
@@ -48,7 +48,7 @@ public:
 
     /// <summary>Code segment A.23 – Update of variables for run interruption sample.</summary>
     void update_variables(const int32_t error_value, const int32_t e_mapped_error_value,
-                          const uint8_t reset_threshold) noexcept
+                          const int32_t reset_threshold) noexcept
     {
         if (error_value < 0)
         {
@@ -60,8 +60,8 @@ public:
         if (n_ == reset_threshold)
         {
             a_ >>= 1;
-            n_ = static_cast<uint8_t>(n_ >> 1);
-            nn_ = static_cast<uint8_t>(nn_ >> 1);
+            n_ >>= 1;
+            nn_ >>= 1;
         }
 
         ++n_;
@@ -103,8 +103,8 @@ private:
     // Initialize with the default values as defined in ISO 14495-1, A.8, step 1.d and 1.f.
     int32_t run_interruption_type_{};
     int32_t a_{};
-    uint8_t n_{1};
-    uint8_t nn_{};
+    int32_t n_{1};
+    int32_t nn_{};
 };
 
 } // namespace charls

--- a/src/scan_codec.hpp
+++ b/src/scan_codec.hpp
@@ -118,7 +118,7 @@ protected:
         t2_{pc_parameters.threshold2},
         t3_{pc_parameters.threshold3},
         width_{frame_info.width},
-        reset_value_{static_cast<uint8_t>(pc_parameters.reset_value)}
+        reset_threshold_{static_cast<uint8_t>(pc_parameters.reset_value)}
     {
         ASSERT((parameters.interleave_mode == interleave_mode::none && this->frame_info().component_count == 1) ||
                parameters.interleave_mode != interleave_mode::none);
@@ -144,7 +144,7 @@ protected:
         return frame_info_;
     }
 
-    void reset_parameters(const int32_t range) noexcept
+    void initialize_parameters(const int32_t range) noexcept
     {
         const regular_mode_context context_initial_value(range);
         for (auto& context : regular_mode_contexts_)
@@ -184,7 +184,9 @@ protected:
     std::array<regular_mode_context, 365> regular_mode_contexts_;
     std::array<run_mode_context, 2> run_mode_contexts_;
     uint32_t width_;
-    uint8_t reset_value_{};
+
+    // ISO 14495-1 RESET symbol: threshold value at which A, B, and N are halved.
+    int32_t reset_threshold_{};
 
     // Quantization lookup table
     const int8_t* quantization_{};

--- a/src/scan_encoder_impl.hpp
+++ b/src/scan_encoder_impl.hpp
@@ -26,7 +26,7 @@ public:
         ASSERT(traits_.is_valid());
 
         quantization_ = initialize_quantization_lut(traits_, t1_, t2_, t3_, quantization_lut_);
-        reset_parameters(traits_.range);
+        initialize_parameters(traits_.range);
     }
 
     size_t encode_scan(const std::byte* source, const size_t stride, const span<std::byte> destination) override
@@ -238,7 +238,7 @@ private:
 
         encode_mapped_value(k, map_error_value(context.get_error_correction(k | traits_.near_lossless) ^ error_value),
                             traits_.limit);
-        context.update_variables_and_bias(error_value, traits_.near_lossless, traits_.reset_threshold);
+        context.update_variables_and_bias(error_value, traits_.near_lossless, reset_threshold_);
         ASSERT(traits_.is_near(traits_.compute_reconstructed_sample(predicted_value, apply_sign(error_value, sign)), x));
         return static_cast<sample_type>(
             traits_.compute_reconstructed_sample(predicted_value, apply_sign(error_value, sign)));
@@ -280,7 +280,7 @@ private:
 
         ASSERT(error_value == context.compute_error_value(e_mapped_error_value + context.run_interruption_type(), k));
         encode_mapped_value(k, e_mapped_error_value, traits_.limit - J[run_index_] - 1);
-        context.update_variables(error_value, e_mapped_error_value, reset_value_);
+        context.update_variables(error_value, e_mapped_error_value, reset_threshold_);
     }
 
     [[nodiscard]]

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -132,7 +132,6 @@ void test_traits16_bit()
 
     assert::is_true(traits1.limit == lossless_traits::limit);
     assert::is_true(traits1.maximum_sample_value == lossless_traits::maximum_sample_value);
-    assert::is_true(traits1.reset_threshold == lossless_traits::reset_threshold);
     assert::is_true(traits1.bits_per_sample == lossless_traits::bits_per_sample);
     assert::is_true(traits1.quantized_bits_per_sample == lossless_traits::quantized_bits_per_sample);
 
@@ -157,7 +156,6 @@ void test_traits8_bit()
 
     assert::is_true(traits1.limit == lossless_traits::limit);
     assert::is_true(traits1.maximum_sample_value == lossless_traits::maximum_sample_value);
-    assert::is_true(traits1.reset_threshold == lossless_traits::reset_threshold);
     assert::is_true(traits1.bits_per_sample == lossless_traits::bits_per_sample);
     assert::is_true(traits1.quantized_bits_per_sample == lossless_traits::quantized_bits_per_sample);
 

--- a/unittest/default_traits_test.cpp
+++ b/unittest/default_traits_test.cpp
@@ -22,7 +22,6 @@ public:
         Assert::AreEqual(8, traits.quantized_bits_per_sample);
         Assert::AreEqual(8, traits.bits_per_sample);
         Assert::AreEqual(32, traits.limit);
-        Assert::AreEqual(64, traits.reset_threshold);
     }
 
     TEST_METHOD(modulo_range) // NOLINT

--- a/unittest/lossless_traits_test.cpp
+++ b/unittest/lossless_traits_test.cpp
@@ -20,7 +20,6 @@ public:
 
         Assert::IsTrue(traits1.limit == lossless_traits::limit);
         Assert::IsTrue(traits1.maximum_sample_value == lossless_traits::maximum_sample_value);
-        Assert::IsTrue(traits1.reset_threshold == lossless_traits::reset_threshold);
         Assert::IsTrue(traits1.bits_per_sample == lossless_traits::bits_per_sample);
         Assert::IsTrue(traits1.quantized_bits_per_sample == lossless_traits::quantized_bits_per_sample);
 
@@ -44,7 +43,6 @@ public:
 
         Assert::IsTrue(traits1.limit == lossless_traits::limit);
         Assert::IsTrue(traits1.maximum_sample_value == lossless_traits::maximum_sample_value);
-        Assert::IsTrue(traits1.reset_threshold == lossless_traits::reset_threshold);
         Assert::IsTrue(traits1.bits_per_sample == lossless_traits::bits_per_sample);
         Assert::IsTrue(traits1.quantized_bits_per_sample == lossless_traits::quantized_bits_per_sample);
 

--- a/unittest/run_mode_context_test.cpp
+++ b/unittest/run_mode_context_test.cpp
@@ -15,7 +15,7 @@ TEST_CLASS(run_mode_context_test)
 public:
     TEST_METHOD(update_variable) // NOLINT
     {
-        run_mode_context context;
+        run_mode_context context{0, 4};
 
         context.update_variables(3, 27, 0);
 

--- a/unittest/scan_encoder_test.cpp
+++ b/unittest/scan_encoder_test.cpp
@@ -22,14 +22,15 @@ public:
         constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
-        scan_encoder_tester strategy(frame_info, parameters);
+        scan_encoder_tester scan_encoder(frame_info, parameters);
 
         array<byte, 1024> data{};
 
-        strategy.initialize_forward({data.data(), data.size()});
+        scan_encoder.initialize_forward({data.data(), data.size()});
 
-        strategy.append_to_bit_stream_forward(0, 0);
-        strategy.flush_forward();
+        scan_encoder.append_to_bit_stream_forward(0, 0);
+        scan_encoder.flush_forward();
+        Assert::AreEqual({}, data[0]);
     }
 
     TEST_METHOD(append_to_bit_stream_ff_pattern) // NOLINT
@@ -37,28 +38,28 @@ public:
         constexpr frame_info frame_info{1, 1, 8, 1};
         constexpr coding_parameters parameters{};
 
-        scan_encoder_tester strategy(frame_info, parameters);
+        scan_encoder_tester scan_encoder(frame_info, parameters);
 
         array<byte, 1024> destination{};
         destination[13] = byte{0x77}; // marker byte to detect overruns.
 
-        strategy.initialize_forward({destination.data(), destination.size()});
+        scan_encoder.initialize_forward({destination.data(), destination.size()});
 
         // We want _isFFWritten == true.
-        strategy.append_to_bit_stream_forward(0, 24);
-        strategy.append_to_bit_stream_forward(0xff, 8);
+        scan_encoder.append_to_bit_stream_forward(0, 24);
+        scan_encoder.append_to_bit_stream_forward(0xff, 8);
 
         // We need the buffer filled with set bits.
-        strategy.append_to_bit_stream_forward(0xffff, 16);
-        strategy.append_to_bit_stream_forward(0xffff, 16);
+        scan_encoder.append_to_bit_stream_forward(0xffff, 16);
+        scan_encoder.append_to_bit_stream_forward(0xffff, 16);
 
         // Buffer is full of FFs and _isFFWritten = true: Flush can only write 30 date bits.
-        strategy.append_to_bit_stream_forward(0x3, 31);
+        scan_encoder.append_to_bit_stream_forward(0x3, 31);
 
-        strategy.flush_forward();
+        scan_encoder.flush_forward();
 
         // Verify output.
-        Assert::AreEqual(size_t{13}, strategy.get_length_forward());
+        Assert::AreEqual(size_t{13}, scan_encoder.get_length_forward());
         Assert::AreEqual({}, destination[0]);
         Assert::AreEqual({}, destination[1]);
         Assert::AreEqual({}, destination[2]);


### PR DESCRIPTION
reset_threshold is just a parameter. Remove it from the traits class to have more flexibility.