### PR TITLE
Add support for DNL segments with lines > 2^16 (#59)

### DIFF
--- a/src/jpeg_stream_reader.hpp
+++ b/src/jpeg_stream_reader.hpp
@@ -158,7 +158,7 @@ private:
     void read_start_of_scan_segment();
     void read_comment_segment();
     void read_application_data_segment(jpeg_marker_code marker_code);
-    void read_define_number_of_lines_segment();
+    uint32_t read_define_number_of_lines_segment();
     void read_preset_parameters_segment();
     void read_preset_coding_parameters();
     void read_oversize_image_dimension();

--- a/unittest/jpeg_test_stream_writer.hpp
+++ b/unittest/jpeg_test_stream_writer.hpp
@@ -192,8 +192,9 @@ public:
         write_segment(jpeg_marker_code::start_of_scan, segment.data(), segment.size());
     }
 
-    void write_define_restart_interval(const uint32_t restart_interval, const int size)
+    void write_define_restart_interval(const uint32_t restart_interval, const int32_t size)
     {
+        // Segment is documented in ISO/IEC 14495-1, C.2.5
         std::vector<std::byte> segment;
         switch (size)
         {
@@ -217,10 +218,35 @@ public:
         write_segment(jpeg_marker_code::define_restart_interval, segment.data(), segment.size());
     }
 
-    void write_define_number_of_lines(const int height)
+    void write_define_number_of_lines(const uint32_t height, const int32_t size)
     {
+        // Segment is documented in ISO/IEC 14495-1, C.2.6
         std::vector<std::byte> segment;
-        push_back(segment, static_cast<uint16_t>(height));
+        switch (size)
+        {
+        case 2:
+            push_back(segment, static_cast<uint16_t>(height));
+            break;
+
+        case 3:
+            push_back_uint24(segment, height);
+            break;
+
+        case 4:
+            push_back(segment, height);
+            break;
+
+        case 5:
+            push_back(segment, height);
+            // This will make the segment non-conforming.
+            segment.push_back({});
+            break;
+
+        default:
+            assert(false);
+            break;
+        }
+
         write_segment(jpeg_marker_code::define_number_of_lines, segment.data(), segment.size());
     }
 

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -463,7 +463,7 @@ public:
         Assert::AreEqual(1024U, header.horizontal_resolution);
     }
 
-    TEST_METHOD(read_spiff_header_from_temporary_object) // NOLINT
+    TEST_METHOD(read_spiff_header_from_temporary_decoder) // NOLINT
     {
         const spiff_header header{create_decoder(create_test_spiff_header()).spiff_header()};
 


### PR DESCRIPTION
Section ISO/IEC 14495-1, C.2.6 specifies that JPEG-LS allows DNL segments with a length between 4 and 6 bytes. Update the code to handle these DNL segments.