### PR TITLE
Add support to encode and decode 2 components by line and sample

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@
 # -clang-diagnostic-unused-macros => Rationale: Macros defined in header are reported as problem
 # -clang-diagnostic-sign-conversion => Rationale: warning will be enabled in additional steps
 # -clang-diagnostic-switch-enum => Rationale: options are handled by default case
+# -clang-diagnostic-global-constructors => Rationale: Acceptable construction
 # -clang-diagnostic-exit-time-destructors => Rationale: Acceptable construction
 # -clang-diagnostic-pragma-once-outside-header => Rationale: Generates false warnings for usage in header files
 # -clang-diagnostic-unused-const-variable => Rationale: false warnings for constexpr in .h files
@@ -74,6 +75,7 @@ Checks:          '*,
                   -clang-diagnostic-unused-macros,
                   -clang-diagnostic-sign-conversion,
                   -clang-diagnostic-switch-enum,
+                  -clang-diagnostic-global-constructors,
                   -clang-diagnostic-exit-time-destructors,
                   -clang-diagnostic-pragma-once-outside-header,
                   -clang-diagnostic-unused-const-variable,

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -177,7 +177,6 @@ struct charls_jpegls_decoder final
     {
         check_argument(destination.data() || destination.empty());
         check_operation(state_ == state::header_read);
-        check_parameter_coherent();
 
         // Compute the stride for the uncompressed destination buffer.
         const size_t minimum_stride{calculate_minimum_stride()};
@@ -248,21 +247,6 @@ private:
     void check_mapping_table_index(const int32_t mapping_table_index) const
     {
         check_argument_range(0, mapping_table_count() - 1, mapping_table_index);
-    }
-
-    void check_parameter_coherent() const
-    {
-        switch (frame_info().component_count)
-        {
-        case 4:
-        case 3:
-            break;
-        default:
-            if (UNLIKELY(reader_.parameters().interleave_mode != interleave_mode::none))
-                throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
-
-            break;
-        }
     }
 
     enum class state

--- a/src/default_traits.hpp
+++ b/src/default_traits.hpp
@@ -87,6 +87,12 @@ struct default_traits final
     }
 
     [[nodiscard]]
+    bool is_near(const pair<SampleType> lhs, const pair<SampleType> rhs) const noexcept
+    {
+        return std::abs(lhs.v1 - rhs.v1) <= near_lossless && std::abs(lhs.v2 - rhs.v2) <= near_lossless;
+    }
+
+    [[nodiscard]]
     bool is_near(const triplet<SampleType> lhs, const triplet<SampleType> rhs) const noexcept
     {
         return std::abs(lhs.v1 - rhs.v1) <= near_lossless && std::abs(lhs.v2 - rhs.v2) <= near_lossless &&

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -882,7 +882,7 @@ void jpeg_stream_reader::call_application_data_callback(const jpeg_marker_code m
 
 void jpeg_stream_reader::find_and_read_define_number_of_lines_segment()
 {
-    for (auto position{position_}; position < end_position_ - 1; ++position)
+    for (const byte* position{position_}; position < end_position_ - 1; ++position)
     {
         if (*position != jpeg_marker_start_byte)
             continue;
@@ -895,7 +895,7 @@ void jpeg_stream_reader::find_and_read_define_number_of_lines_segment()
         if (static_cast<jpeg_marker_code>(optional_marker_code) != jpeg_marker_code::define_number_of_lines)
             break;
 
-        const auto current_position{position_};
+        const byte* current_position{position_};
         position_ = position + 2;
         read_segment_size();
         frame_info_height(read_define_number_of_lines_segment(), true);

--- a/src/lossless_traits.hpp
+++ b/src/lossless_traits.hpp
@@ -136,6 +136,29 @@ struct lossless_traits<uint16_t, 16> final : lossless_traits_impl<uint16_t, 16>
 
 
 template<typename SampleType, int32_t BitsPerSample>
+struct lossless_traits<pair<SampleType>, BitsPerSample> final : lossless_traits_impl<SampleType, BitsPerSample>
+{
+    using pixel_type = pair<SampleType>;
+
+    FORCE_INLINE constexpr static bool is_near(const int32_t lhs, const int32_t rhs) noexcept
+    {
+        return lhs == rhs;
+    }
+
+    FORCE_INLINE constexpr static bool is_near(const pixel_type lhs, const pixel_type rhs) noexcept
+    {
+        return lhs == rhs;
+    }
+
+    FORCE_INLINE static SampleType compute_reconstructed_sample(const int32_t predicted_value,
+                                                                const int32_t error_value) noexcept
+    {
+        return static_cast<SampleType>(predicted_value + error_value);
+    }
+};
+
+
+template<typename SampleType, int32_t BitsPerSample>
 struct lossless_traits<triplet<SampleType>, BitsPerSample> final : lossless_traits_impl<SampleType, BitsPerSample>
 {
     using pixel_type = triplet<SampleType>;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -107,6 +107,21 @@ inline CHARLS_NO_INLINE jpegls_errc to_jpegls_errc() noexcept
 
 
 template<typename T>
+struct pair final
+{
+    T v1{};
+    T v2{};
+
+    [[nodiscard]]
+    friend constexpr bool
+    operator==(const pair& lhs, const pair& rhs) noexcept
+    {
+        return lhs.v1 == rhs.v1 && lhs.v2 == rhs.v2;
+    }
+};
+
+
+template<typename T>
 struct triplet final
 {
     T v1{};

--- a/unittest/encode_test.cpp
+++ b/unittest/encode_test.cpp
@@ -42,6 +42,45 @@ public:
         encode("DataFiles/16-bit-640-480-many-dots.pgm", 4138);
     }
 
+    TEST_METHOD(encode_2_components_8_bit_interleave_none)
+    {
+        constexpr array data{byte{10}, byte{20}, byte{30}, byte{40}, byte{50}, byte{60}, byte{70}, byte{80}};
+        encode({2, 2, 8, 2}, {data.cbegin(), data.cend()}, 53, interleave_mode::none);
+    }
+
+    TEST_METHOD(encode_2_components_8_bit_interleave_line)
+    {
+        constexpr array data{byte{10}, byte{20}, byte{30}, byte{40}, byte{50}, byte{60}, byte{70}, byte{80}};
+        encode({2, 2, 8, 2}, {data.cbegin(), data.cend()}, 43, interleave_mode::line);
+    }
+
+    TEST_METHOD(encode_2_components_8_bit_interleave_sample)
+    {
+        constexpr array data{byte{10}, byte{20}, byte{30}, byte{40}, byte{50}, byte{60}, byte{70}, byte{80}};
+        encode({2, 2, 8, 2}, {data.cbegin(), data.cend()}, 43, interleave_mode::sample);
+    }
+
+    TEST_METHOD(encode_2_components_16_bit_interleave_none)
+    {
+        constexpr array data{byte{10}, byte{1}, byte{20}, byte{1}, byte{30}, byte{1}, byte{40}, byte{1},
+                             byte{50}, byte{1}, byte{60}, byte{1}, byte{70}, byte{1}, byte{80}, byte{1}};
+        encode({2, 2, 16, 2}, {data.cbegin(), data.cend()}, 52, interleave_mode::none);
+    }
+
+    TEST_METHOD(encode_2_components_16_bit_interleave_line)
+    {
+        constexpr array data{byte{10}, byte{1}, byte{20}, byte{1}, byte{30}, byte{1}, byte{40}, byte{1},
+                             byte{50}, byte{1}, byte{60}, byte{1}, byte{70}, byte{1}, byte{80}, byte{1}};
+        encode({2, 2, 16, 2}, {data.cbegin(), data.cend()}, 44, interleave_mode::line);
+    }
+
+    TEST_METHOD(encode_2_components_16_bit_interleave_sample)
+    {
+        constexpr array data{byte{10}, byte{1}, byte{20}, byte{1}, byte{30}, byte{1}, byte{40}, byte{1},
+                             byte{50}, byte{1}, byte{60}, byte{1}, byte{70}, byte{1}, byte{80}, byte{1}};
+        encode({2, 2, 16, 2}, {data.cbegin(), data.cend()}, 44, interleave_mode::sample);
+    }
+
     TEST_METHOD(encode_color_8_bit_interleave_none_lossless) // NOLINT
     {
         encode("DataFiles/test8.ppm", 102248);


### PR DESCRIPTION
2 components in interleave mode none was already supported. But the options line and sample were not implemented. Add these 2 options to support all interleave options.