### PR TITLE
Extend API of jpeg_encoder with encode_components methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Support to encode and decode mapping tables.
 - Support to retrieve the height from a DNL marker segment.
+- Support to encode and decode mixed interleaved mode scans.
 
 ### Changed
 
 - BREAKING: Updated the minimal required C++ language version to C++17.
 - BREAKING: encoding_options::include_pc_parameters_jai is not enabled by default anymore.
 - BREAKING: charls::jpegls_decoder and charls::jpegls_encoder follow the same const pattern as the C API.
-- BREAKING: the failure values of the enum charls::jpegls_errc are now divided in 2 groups: runtime failures and logic.
+- BREAKING: the failure values of the enum charls::jpegls_errc are now divided in 2 groups: runtime errors and logic errors.
 - BREAKING: The public charls.h header has been split into charls.h (C applications) and charls.hpp (C++ applications).
+- BREAKING: Method charls_jpegls_decoder_get_interleave_mode has an additional extra parameter: component_index.
 
 ### Removed
 
-- BREAKING: Legacy 1.x API methods have been removed.
+- BREAKING: Deprecated legacy 1.x API methods have been removed.
 
 ## [2.4.2] - 2023-5-16
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ The following JPEG-LS options are not supported by the CharLS implementation. Mo
   Decoding is supported, but no recovery mechanism is implemented for corrupted JPEG-LS files.
 * No support for sub-sampled scans.
   Sub-sampling is a lossly encoding mechanism and not used in lossless scenarios.
-* No support for multi component frames with mixed component counts in a single scan.
-  While technical possible all known JPEG-LS codecs put multi-component (color) images in a single scan
-  or in multiple scans, but not use a mix of these in one file.
 * No support for point transform.
   Point transform is a lossly encoding mechanism and not used in lossless scenarios.
 

--- a/include/charls/charls_jpegls_decoder.h
+++ b/include/charls/charls_jpegls_decoder.h
@@ -92,11 +92,11 @@ charls_jpegls_decoder_get_frame_info(CHARLS_IN const charls_jpegls_decoder* deco
 /// Function should be called after calling the function charls_jpegls_decoder_read_header.
 /// </remarks>
 /// <param name="decoder">Reference to the decoder instance.</param>
-/// <param name="component">The component index for which the NEAR parameter should be retrieved.</param>
+/// <param name="component_index">The component index for which the NEAR parameter should be retrieved.</param>
 /// <param name="near_lossless">Reference that will hold the value of the NEAR parameter.</param>
 /// <returns>The result of the operation: success or a failure code.</returns>
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
-charls_jpegls_decoder_get_near_lossless(CHARLS_IN const charls_jpegls_decoder* decoder, int32_t component,
+charls_jpegls_decoder_get_near_lossless(CHARLS_IN const charls_jpegls_decoder* decoder, int32_t component_index,
                                         CHARLS_OUT int32_t* near_lossless) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull));
 
 /// <summary>
@@ -106,10 +106,11 @@ charls_jpegls_decoder_get_near_lossless(CHARLS_IN const charls_jpegls_decoder* d
 /// Function should be called after calling the function charls_jpegls_decoder_read_header.
 /// </remarks>
 /// <param name="decoder">Reference to the decoder instance.</param>
+/// <param name="component_index">The component index for which the interleave mode should be retrieved.</param>
 /// <param name="interleave_mode">Reference that will hold the value of the interleave mode.</param>
 /// <returns>The result of the operation: success or a failure code.</returns>
 CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
-charls_jpegls_decoder_get_interleave_mode(CHARLS_IN const charls_jpegls_decoder* decoder,
+charls_jpegls_decoder_get_interleave_mode(CHARLS_IN const charls_jpegls_decoder* decoder, int32_t component_index, 
                                           CHARLS_OUT charls_interleave_mode* interleave_mode) CHARLS_NOEXCEPT
     CHARLS_ATTRIBUTE((nonnull));
 

--- a/include/charls/charls_jpegls_encoder.h
+++ b/include/charls/charls_jpegls_encoder.h
@@ -280,6 +280,26 @@ charls_jpegls_encoder_encode_from_buffer(CHARLS_IN charls_jpegls_encoder* encode
                                          size_t source_size_bytes, uint32_t stride) CHARLS_NOEXCEPT
     CHARLS_ATTRIBUTE((nonnull));
 
+/// <summary>
+/// Encodes the passed buffer with the source image data to the destination.
+/// This is an advanced method that provides more control how image data is encoded in JPEG-LS scans.
+/// It should be called until all components are encoded.
+/// </summary>
+/// <param name="encoder">Reference to the encoder instance.</param>
+/// <param name="source_buffer">Byte array that holds the image data that needs to be encoded.</param>
+/// <param name="source_size_bytes">Length of the array in bytes.</param>
+/// <param name="source_component_count">The number of components present in the input source.</param>
+/// <param name="stride">
+/// The number of bytes from one row of pixels in memory to the next row of pixels in memory.
+/// Stride is sometimes called pitch. If padding bytes are present, the stride is wider than the width of the image.
+/// </param>
+/// <returns>The result of the operation: success or a failure code.</returns>
+CHARLS_ATTRIBUTE_ACCESS((access(read_only, 2, 3)))
+CHARLS_CHECK_RETURN CHARLS_API_IMPORT_EXPORT charls_jpegls_errc CHARLS_API_CALLING_CONVENTION
+charls_jpegls_encoder_encode_components_from_buffer(CHARLS_IN charls_jpegls_encoder* encoder,
+                                                    CHARLS_IN_READS_BYTES(source_size_bytes) const void* source_buffer,
+                                                    size_t source_size_bytes, int32_t source_component_count,
+                                                    uint32_t stride) CHARLS_NOEXCEPT CHARLS_ATTRIBUTE((nonnull));
 
 /// <summary>
 /// Creates a JPEG-LS stream in the abbreviated format that only contain mapping tables (See JPEG-LS standard, C.4).

--- a/include/charls/jpegls_decoder.hpp
+++ b/include/charls/jpegls_decoder.hpp
@@ -48,7 +48,7 @@ public:
         destination.resize(destination_size / sizeof(DestinationContainerValueType));
         decoder.decode(destination);
 
-        return std::make_pair(decoder.frame_info(), decoder.interleave_mode());
+        return std::make_pair(decoder.frame_info(), decoder.get_interleave_mode());
     }
 
     jpegls_decoder() = default;
@@ -258,13 +258,14 @@ public:
     /// <summary>
     /// Returns the interleave mode that was used to encode the scan.
     /// </summary>
+    /// <param name="component_index">The component index for which the interleave mode should be retrieved.</param>
     /// <exception cref="charls::jpegls_error">An error occurred during the operation.</exception>
     /// <returns>The value of the interleave mode.</returns>
     [[nodiscard]]
-    charls::interleave_mode interleave_mode() const
+    interleave_mode get_interleave_mode(const int32_t component_index = 0) const
     {
-        charls::interleave_mode interleave_mode;
-        check_jpegls_errc(charls_jpegls_decoder_get_interleave_mode(decoder(), &interleave_mode));
+        interleave_mode interleave_mode;
+        check_jpegls_errc(charls_jpegls_decoder_get_interleave_mode(decoder(), component_index, &interleave_mode));
         return interleave_mode;
     }
 

--- a/include/charls/jpegls_encoder.hpp
+++ b/include/charls/jpegls_encoder.hpp
@@ -328,6 +328,14 @@ public:
         return bytes_written();
     }
 
+    size_t encode_components(CHARLS_IN_READS_BYTES(source_size_bytes) const void* source_buffer, const size_t source_size_bytes,
+                  const int32_t source_component_count, const uint32_t stride = 0)
+    {
+        check_jpegls_errc(charls_jpegls_encoder_encode_components_from_buffer(encoder(), source_buffer, source_size_bytes,
+                                                                              source_component_count, stride));
+        return bytes_written();
+    }
+
     /// <summary>
     /// Encodes the passed STL like container with the source image data to the destination.
     /// </summary>
@@ -341,6 +349,26 @@ public:
     size_t encode(const Container& source_container, const uint32_t stride = 0)
     {
         return encode(source_container.data(), source_container.size() * sizeof(ContainerValueType), stride);
+    }
+
+    /// <summary>
+    /// Encodes the passed STL like container with the source image data to the destination.
+    /// This is an advanced method that provides more control how image data is encoded in JPEG-LS scans.
+    /// It should be called until all components are encoded.
+    /// </summary>
+    /// <param name="source_container">Container that holds the image data that needs to be encoded.</param>
+    /// <param name="source_component_count">The number of components present in the input source.</param>
+    /// <param name="stride">
+    /// The number of bytes from one row of pixels in memory to the next row of pixels in memory.
+    /// Stride is sometimes called pitch. If padding bytes are present, the stride is wider than the width of the image.
+    /// </param>
+    /// <returns>The number of bytes written to the destination.</returns>
+    template<typename Container, typename ContainerValueType = typename Container::value_type>
+    size_t encode_components(const Container& source_container, const int32_t source_component_count,
+                             const uint32_t stride = 0)
+    {
+        return encode_components(source_container.data(), source_container.size() * sizeof(ContainerValueType),
+                                 source_component_count, stride);
     }
 
     /// <summary>

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -13,7 +13,7 @@ constexpr int32_t default_reset_threshold{64}; // Default RESET value as defined
 
 constexpr int32_t minimum_component_count{1};
 constexpr int32_t maximum_component_count{255};
-constexpr size_t maximum_component_count_in_scan{4};
+constexpr int32_t maximum_component_count_in_scan{4};
 constexpr int32_t minimum_component_index{};
 constexpr int32_t maximum_component_index{maximum_component_count - 1};
 constexpr int32_t minimum_bits_per_sample{2};

--- a/test/compliance.cpp
+++ b/test/compliance.cpp
@@ -62,7 +62,7 @@ bool verify_encoded_bytes(const void* uncompressed_data, const size_t uncompress
         jpegls_encoder encoder;
         encoder.destination(our_encoded_bytes);
         encoder.frame_info(decoder.frame_info());
-        encoder.interleave_mode(decoder.interleave_mode());
+        encoder.interleave_mode(decoder.get_interleave_mode());
         encoder.near_lossless(decoder.get_near_lossless());
         encoder.preset_coding_parameters(decoder.preset_coding_parameters());
         std::ignore = encoder.encode(uncompressed_data, uncompressed_length);
@@ -143,7 +143,7 @@ void decompress_file(const char* name_encoded, const char* name_raw, const int o
         fix_endian(&raw_buffer, false);
     }
 
-    if (decoder.interleave_mode() == interleave_mode::none && component_count == 3)
+    if (decoder.get_interleave_mode() == interleave_mode::none && component_count == 3)
     {
         triplet2_planar(raw_buffer, {width, height});
     }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -290,7 +290,7 @@ void test_too_small_output_buffer()
         error = e.code();
     }
 
-    assert::is_true(error == jpegls_errc::destination_too_small);
+    assert::is_true(error == jpegls_errc::invalid_argument_size);
 }
 
 

--- a/unittest/charls_jpegls_decoder_test.cpp
+++ b/unittest/charls_jpegls_decoder_test.cpp
@@ -110,11 +110,11 @@ public:
     TEST_METHOD(get_interleave_mode_nullptr) // NOLINT
     {
         interleave_mode interleave_mode;
-        auto error{charls_jpegls_decoder_get_interleave_mode(nullptr, &interleave_mode)};
+        auto error{charls_jpegls_decoder_get_interleave_mode(nullptr, 0, &interleave_mode)};
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
 
         const auto decoder{get_initialized_decoder()};
-        error = charls_jpegls_decoder_get_interleave_mode(decoder.get(), nullptr);
+        error = charls_jpegls_decoder_get_interleave_mode(decoder.get(), 0, nullptr);
         Assert::AreEqual(jpegls_errc::invalid_argument, error);
     }
 
@@ -167,10 +167,10 @@ public:
 
     TEST_METHOD(decode_to_zero_size_buffer) // NOLINT
     {
-        auto decoder{get_initialized_decoder()};
+        const auto decoder{get_initialized_decoder()};
 
         const auto error{charls_jpegls_decoder_decode_to_buffer(decoder.get(), nullptr, 0, 0)};
-        Assert::AreEqual(jpegls_errc::destination_too_small, error);
+        Assert::AreEqual(jpegls_errc::invalid_argument_size, error);
     }
 
     TEST_METHOD(at_comment_nullptr) // NOLINT

--- a/unittest/compliance_test.cpp
+++ b/unittest/compliance_test.cpp
@@ -208,7 +208,7 @@ private:
         const jpegls_decoder decoder{encoded_source, true};
 
         portable_anymap_file reference_file{
-            read_anymap_reference_file(raw_filename, decoder.interleave_mode(), decoder.frame_info())};
+            read_anymap_reference_file(raw_filename, decoder.get_interleave_mode(), decoder.frame_info())};
 
         test_compliance(encoded_source, reference_file.image_data(), check_encode);
     }

--- a/unittest/documentation_test.cpp
+++ b/unittest/documentation_test.cpp
@@ -147,7 +147,7 @@ private:
         Assert::AreEqual(static_cast<uint32_t>(reference_file.height()), frame_info.height);
         Assert::AreEqual(reference_file.component_count(), frame_info.component_count);
         Assert::AreEqual(reference_file.bits_per_sample(), frame_info.bits_per_sample);
-        Assert::AreEqual(interleave_mode, decoder.interleave_mode());
+        Assert::AreEqual(interleave_mode, decoder.get_interleave_mode());
 
         vector<std::byte> destination(decoder.get_destination_size());
         decoder.decode(destination);

--- a/unittest/jpeg_stream_reader_test.cpp
+++ b/unittest/jpeg_stream_reader_test.cpp
@@ -893,7 +893,7 @@ public:
         jpeg_test_stream_writer writer;
         writer.write_start_of_image();
         writer.write_start_of_frame_segment(1, 0, 2, 3);
-        writer.write_start_of_scan_segment(0, 3, 0, interleave_mode::none);
+        writer.write_start_of_scan_segment(0, 1, 0, interleave_mode::none);
         writer.write_define_number_of_lines(1, 3);
         writer.write_start_of_scan_segment(1, 1, 0, interleave_mode::none);
 

--- a/unittest/jpegls_encoder_test.cpp
+++ b/unittest/jpegls_encoder_test.cpp
@@ -1892,7 +1892,7 @@ private:
         Assert::AreEqual(source_frame_info.height, frame_info.height);
         Assert::AreEqual(source_frame_info.bits_per_sample, frame_info.bits_per_sample);
         Assert::AreEqual(source_frame_info.component_count, frame_info.component_count);
-        Assert::IsTrue(interleave_mode == decoder.interleave_mode());
+        Assert::IsTrue(interleave_mode == decoder.get_interleave_mode());
         Assert::IsTrue(color_transformation == decoder.color_transformation());
 
         vector<byte> destination(decoder.get_destination_size());

--- a/unittest/util.cpp
+++ b/unittest/util.cpp
@@ -182,7 +182,7 @@ bool verify_encoded_bytes(const vector<byte>& uncompressed_source, const vector<
 
     jpegls_encoder encoder;
     encoder.frame_info(decoder.frame_info())
-        .interleave_mode(decoder.interleave_mode())
+        .interleave_mode(decoder.get_interleave_mode())
         .near_lossless(decoder.get_near_lossless())
         .preset_coding_parameters(decoder.preset_coding_parameters());
 


### PR DESCRIPTION
Add an additional method for advanced encodings scenarios. This methods allow to encode components with different coding parameters like: near lossless, jpeg-ls preset coding parameters or scans with different interleave modes. Extend the decoder to also be able to decode scans with different interleave modes.