### PR TITLE
Remove duplicate code from make_scan_codec + undef_macros.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,19 +15,19 @@ message(STATUS "CharLS version: ${version_major}.${version_minor}.${version_patc
 
 project(charls VERSION ${version_major}.${version_minor}.${version_patch} LANGUAGES C CXX)
 
-# Determine if project is built as a subproject (using add_subdirectory) or if it is the master project.
-set(MASTER_PROJECT OFF)
+# Determine if project is built as a subproject (using add_subdirectory) or if it is the main project.
+set(MAIN_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(MASTER_PROJECT ON)
-  message(STATUS "Building as master project, CMake version: ${CMAKE_VERSION}")
+  set(MAIN_PROJECT ON)
+  message(STATUS "Building as main project, CMake version: ${CMAKE_VERSION}")
 endif ()
 
 # The basic options to control what is build extra.
-option(CHARLS_BUILD_TESTS "Build test application" ${MASTER_PROJECT})
-option(CHARLS_BUILD_AFL_FUZZ_TEST "Build AFL test fuzzer application" ${MASTER_PROJECT})
-option(CHARLS_BUILD_LIBFUZZER_FUZZ_TEST "Build LibFuzzer test fuzzer application" ${MASTER_PROJECT})
-option(CHARLS_BUILD_SAMPLES "Build sample applications" ${MASTER_PROJECT})
-option(CHARLS_INSTALL "Generate the install target." ${MASTER_PROJECT})
+option(CHARLS_BUILD_TESTS "Build test application" ${MAIN_PROJECT})
+option(CHARLS_BUILD_AFL_FUZZ_TEST "Build AFL test fuzzer application" ${MAIN_PROJECT})
+option(CHARLS_BUILD_LIBFUZZER_FUZZ_TEST "Build LibFuzzer test fuzzer application" ${MAIN_PROJECT})
+option(CHARLS_BUILD_SAMPLES "Build sample applications" ${MAIN_PROJECT})
+option(CHARLS_INSTALL "Generate the install target." ${MAIN_PROJECT})
 
 # Provide BUILD_SHARED_LIBS as an option for GUI tools
 option(BUILD_SHARED_LIBS "Will control if charls lib is build as shared lib/DLL or static library")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,8 +70,8 @@ target_compile_definitions(charls PRIVATE CHARLS_LIBRARY_BUILD)
 target_compile_features(charls PUBLIC cxx_std_17)
 
 set(HEADERS
-    "include/charls/api_abi.h"
     "include/charls/annotations.h"
+    "include/charls/api_abi.h"
     "include/charls/charls.h"
     "include/charls/charls.hpp"
     "include/charls/charls_jpegls_decoder.h"
@@ -81,6 +81,7 @@ set(HEADERS
     "include/charls/jpegls_error.h"
     "include/charls/jpegls_error.hpp"
     "include/charls/public_types.h"
+    "include/charls/undef_macros.h"
     "include/charls/validate_spiff_header.h"
     "include/charls/version.h"
 )

--- a/src/make_scan_codec.cpp
+++ b/src/make_scan_codec.cpp
@@ -17,18 +17,6 @@ using std::unique_ptr;
 
 namespace {
 
-/// <summary>
-/// scan_codec_factory receives the actual frame info.
-/// scan_codec expects 1 when encoding/decoding a single scan in interleave mode none.
-/// </summary>
-[[nodiscard]]
-frame_info update_component_count(const frame_info& frame, const coding_parameters& parameters) noexcept
-{
-    return {frame.width, frame.height, frame.bits_per_sample,
-            parameters.interleave_mode == interleave_mode::none ? 1 : frame.component_count};
-}
-
-
 template<typename ScanProcess, typename Traits>
 [[nodiscard]]
 unique_ptr<ScanProcess> make_codec(const frame_info& frame, const jpegls_pc_parameters& pc_parameters,
@@ -36,24 +24,24 @@ unique_ptr<ScanProcess> make_codec(const frame_info& frame, const jpegls_pc_para
 {
     if constexpr (std::is_same_v<ScanProcess, scan_encoder>)
     {
-        return make_unique<scan_encoder_impl<Traits>>(update_component_count(frame, parameters), pc_parameters, parameters,
-                                                      traits);
+        return make_unique<scan_encoder_impl<Traits>>(frame, pc_parameters, parameters, traits);
     }
     else
     {
-        return make_unique<scan_decoder_impl<Traits>>(update_component_count(frame, parameters), pc_parameters, parameters,
-                                                      traits);
+        return make_unique<scan_decoder_impl<Traits>>(frame, pc_parameters, parameters, traits);
     }
 }
 
+} // namespace
+
+
 template<typename ScanProcess>
-[[nodiscard]]
-unique_ptr<ScanProcess> try_make_optimized_codec(const frame_info& frame, const jpegls_pc_parameters& pc_parameters,
-                                                 const coding_parameters& parameters)
+unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame, const jpegls_pc_parameters& pc_parameters,
+                                        const coding_parameters& parameters)
 {
 #ifndef DISABLE_SPECIALIZATIONS
 
-    // optimized lossless versions common formats
+    // Optimized lossless versions common formats
     if (parameters.near_lossless == 0)
     {
         if (parameters.interleave_mode == interleave_mode::sample)
@@ -79,7 +67,8 @@ unique_ptr<ScanProcess> try_make_optimized_codec(const frame_info& frame, const 
                 case 2:
                     return make_codec<ScanProcess>(frame, pc_parameters, parameters, lossless_traits<pair<uint16_t>, 16>());
                 case 3:
-                    return make_codec<ScanProcess>(frame, pc_parameters, parameters, lossless_traits<triplet<uint16_t>, 16>());
+                    return make_codec<ScanProcess>(frame, pc_parameters, parameters,
+                                                   lossless_traits<triplet<uint16_t>, 16>());
                 default:
                     ASSERT(frame.component_count == 4);
                     return make_codec<ScanProcess>(frame, pc_parameters, parameters, lossless_traits<quad<uint16_t>, 16>());
@@ -136,68 +125,32 @@ unique_ptr<ScanProcess> try_make_optimized_codec(const frame_info& frame, const 
                                        default_traits<uint8_t, uint8_t>(maximum_sample_value, parameters.near_lossless));
     }
 
-    if (frame.bits_per_sample <= 16)
+    if (parameters.interleave_mode == interleave_mode::sample)
     {
-        if (parameters.interleave_mode == interleave_mode::sample)
+        if (frame.component_count == 2)
         {
-            if (frame.component_count == 2)
-            {
-                return make_codec<ScanProcess>(
-                    frame, pc_parameters, parameters,
-                    default_traits<uint16_t, pair<uint16_t>>(maximum_sample_value, parameters.near_lossless));
-            }
-
-            if (frame.component_count == 3)
-            {
-                return make_codec<ScanProcess>(
-                    frame, pc_parameters, parameters,
-                    default_traits<uint16_t, triplet<uint16_t>>(maximum_sample_value, parameters.near_lossless));
-            }
-
-            if (frame.component_count == 4)
-            {
-                return make_codec<ScanProcess>(
-                    frame, pc_parameters, parameters,
-                    default_traits<uint16_t, quad<uint16_t>>(maximum_sample_value, parameters.near_lossless));
-            }
+            return make_codec<ScanProcess>(
+                frame, pc_parameters, parameters,
+                default_traits<uint16_t, pair<uint16_t>>(maximum_sample_value, parameters.near_lossless));
         }
 
-        return make_codec<ScanProcess>(frame, pc_parameters, parameters,
-                                       default_traits<uint16_t, uint16_t>(maximum_sample_value, parameters.near_lossless));
-    }
-
-    return nullptr;
-}
-
-
-} // namespace
-
-
-template<typename ScanProcess>
-unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame, const jpegls_pc_parameters& pc_parameters,
-                                        const coding_parameters& c_parameters)
-{
-    unique_ptr<ScanProcess> codec{try_make_optimized_codec<ScanProcess>(frame, pc_parameters, c_parameters)};
-
-    if (!codec)
-    {
-        if (frame.bits_per_sample <= 8)
+        if (frame.component_count == 3)
         {
-            default_traits<uint8_t, uint8_t> traits(calculate_maximum_sample_value(frame.bits_per_sample),
-                                                    c_parameters.near_lossless);
-            traits.maximum_sample_value = pc_parameters.maximum_sample_value;
-            codec = make_codec<ScanProcess, default_traits<uint8_t, uint8_t>>(frame, pc_parameters, c_parameters, traits);
+            return make_codec<ScanProcess>(
+                frame, pc_parameters, parameters,
+                default_traits<uint16_t, triplet<uint16_t>>(maximum_sample_value, parameters.near_lossless));
         }
-        else
+
+        if (frame.component_count == 4)
         {
-            default_traits<uint16_t, uint16_t> traits(calculate_maximum_sample_value(frame.bits_per_sample),
-                                                      c_parameters.near_lossless);
-            traits.maximum_sample_value = pc_parameters.maximum_sample_value;
-            codec = make_codec<ScanProcess, default_traits<uint16_t, uint16_t>>(frame, pc_parameters, c_parameters, traits);
+            return make_codec<ScanProcess>(
+                frame, pc_parameters, parameters,
+                default_traits<uint16_t, quad<uint16_t>>(maximum_sample_value, parameters.near_lossless));
         }
     }
 
-    return codec;
+    return make_codec<ScanProcess>(frame, pc_parameters, parameters,
+                                   default_traits<uint16_t, uint16_t>(maximum_sample_value, parameters.near_lossless));
 }
 
 

--- a/src/make_scan_codec.hpp
+++ b/src/make_scan_codec.hpp
@@ -13,7 +13,7 @@ namespace charls {
 template<typename ScanProcess>
 [[nodiscard]]
 std::unique_ptr<ScanProcess> make_scan_codec(const frame_info& frame,
-                                             const jpegls_pc_parameters& pc_parameters, const coding_parameters& c_parameters);
+                                             const jpegls_pc_parameters& pc_parameters, const coding_parameters& parameters);
 
 
 extern template std::unique_ptr<class scan_decoder>

--- a/src/scan_decoder_impl.hpp
+++ b/src/scan_decoder_impl.hpp
@@ -89,7 +89,7 @@ private:
                     {
                         decode_sample_line();
                     }
-                    if constexpr (std::is_same_v<pixel_type, pair<sample_type>>)
+                    else if constexpr (std::is_same_v<pixel_type, pair<sample_type>>)
                     {
                         decode_pair_line();
                     }
@@ -97,8 +97,9 @@ private:
                     {
                         decode_triplet_line();
                     }
-                    else if constexpr (std::is_same_v<pixel_type, quad<sample_type>>)
+                    else
                     {
+                        static_assert(std::is_same_v<pixel_type, quad<sample_type>>);
                         decode_quad_line();
                     }
 


### PR DESCRIPTION
- Remove code from make_scan_codec that was not used
- Unsure that undef_macro.h file is added to the list of public headers in CMakeLists.txt