### PR TITLE
Fix typos found by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Typically CMake will select the latest C++ standard version that the used C++ co
 
 ### Added
 
-- The encoder API has been extended with a rewind method that can be used to re-use a configured encoder to encode multiple images in a loop.
+- The encoder API has been extended with a rewind method that can be used to reuse a configured encoder to encode multiple images in a loop.
 - Added support to decode JPEG-LS images that use restart markers [#92](https://github.com/team-charls/charls/issues/92).
 - Added support to write and read comment (COM) segments [#113](https://github.com/team-charls/charls/issues/113).
 - Added support to encode/decode oversized images (width or height larger then 65535).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       -Wthread-safety-beta
       -Wcomma
       -Wconversion
-      # -Weverything provides the option to discover usefull Clang warnings.
+      # -Weverything provides the option to discover useful Clang warnings.
       # The list below ignores not useful Weverything warnings.
       -Wno-weak-vtables                       # Ignore, linker will remove the couple of extra vtables.
       -Wno-padded                             # Ignore, padding optimization is not needed.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -172,4 +172,4 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
-</Project
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,7 +73,7 @@
       <!-- Use all cores to speed up the compilation (MS recommended best practice). -->
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
 
-      <!-- Explicit define that all projects are compiled according the latest offical C++17 standard -->
+      <!-- Explicit define that all projects are compiled according the latest official C++17 standard -->
       <LanguageStandard>stdcpp17</LanguageStandard>
 
       <!-- Explicit disable non conforming MSVC compiler options that are not compatible with the C++ standard -->
@@ -164,7 +164,7 @@
       <!-- Mark executable image compatible with the Control-flow Enforcement Technology (CET) Shadow Stack. -->
       <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
 
-      <!-- On the ARM64 plaftorm enable Pointer Authentication for return addresses. -->
+      <!-- On the ARM64 platform enable Pointer Authentication for return addresses. -->
       <GuardSignedReturns Condition="'$(Platform)'=='ARM64'">true</GuardSignedReturns>
     </Link>
 
@@ -172,4 +172,4 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
-</Project>
+</Project

--- a/doc/style_and_design.md
+++ b/doc/style_and_design.md
@@ -72,7 +72,7 @@ Java : by default integers are signed
 Javascript: only signed integers
 Python: only signed integers
 
-Having unsigned integers in the C and C++ application and signed integers in wrapping libaries should
+Having unsigned integers in the C and C++ application and signed integers in wrapping libraries should
 not be a practical problem. Most real world images can be expressed in signed integers,  8K Images = (7680×4320).
 
 ### ABI

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(charls PUBLIC CHARLS_STATIC)
 endif()
 
-# Use different DLL filenames on Windows. It allows platform neutral adapters to load dynamicly the correct version.
+# Use different DLL filenames on Windows. It allows platform neutral adapters to load dynamically the correct version.
 if(WIN32 AND BUILD_SHARED_LIBS)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM64")

--- a/unittest/CodeCoverage.runsettings
+++ b/unittest/CodeCoverage.runsettings
@@ -7,7 +7,7 @@
           <CodeCoverage>
 
             <!-- The CharLS source code is linked into the unit test DLL using .obj files. The DLL to cover is the unit test DLL -->
-            <!-- Only do code coverage on debug bulds. Release builds are optimized and provide poor code coverage results (inlining is a major factor)-->
+            <!-- Only do code coverage on debug builds. Release builds are optimized and provide poor code coverage results (inlining is a major factor)-->
             <ModulePaths>
               <Include>
                 <ModulePath>.*debug.*CharLSUnitTest\.dll$</ModulePath>


### PR DESCRIPTION
Some of these files might have been automatically generated. Should typos be fixed upstream instead?