### PR TITLE
Re-enable warning C26493

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@
 # -clang-diagnostic-unused-macros => Rationale: Macros defined in header are reported as problem
 # -clang-diagnostic-sign-conversion => Rationale: warning will be enabled in additional steps
 # -clang-diagnostic-switch-enum => Rationale: options are handled by default case
+# -clang-diagnostic-switch-default => Rationale: conflicts with warning that all enum cases must be handled
 # -clang-diagnostic-global-constructors => Rationale: Acceptable construction
 # -clang-diagnostic-exit-time-destructors => Rationale: Acceptable construction
 # -clang-diagnostic-pragma-once-outside-header => Rationale: Generates false warnings for usage in header files
@@ -55,6 +56,7 @@
 # -altera-unroll-loops => Does not apply (is for openCL)
 # -altera-id-dependent-backward-branch => Does not apply (is for openCL)
 # -bugprone-easily-swappable-parameters => To many do not fix warnings
+# -performance-enum-size => No performance gain, enums are not used in arrays.
 
 ---
 Checks:          '*,
@@ -75,6 +77,7 @@ Checks:          '*,
                   -clang-diagnostic-unused-macros,
                   -clang-diagnostic-sign-conversion,
                   -clang-diagnostic-switch-enum,
+                  -clang-diagnostic-switch-default,
                   -clang-diagnostic-global-constructors,
                   -clang-diagnostic-exit-time-destructors,
                   -clang-diagnostic-pragma-once-outside-header,
@@ -108,7 +111,8 @@ Checks:          '*,
                   -altera-id-dependent-backward-branch,
                   -readability-function-cognitive-complexity,
                   -bugprone-easily-swappable-parameters,
-                  -concurrency-mt-unsafe'
+                  -concurrency-mt-unsafe,
+                  -performance-enum-size'
 WarningsAsErrors: false
 HeaderFilterRegex: ''
 FormatStyle:     none

--- a/default.ruleset
+++ b/default.ruleset
@@ -11,7 +11,6 @@
     <Rule Id="C26482" Action="None" />
     <Rule Id="C26485" Action="None" />
     <Rule Id="C26490" Action="None" />
-    <Rule Id="C26493" Action="None" />
     <Rule Id="C26494" Action="None" />
   </Rules>
 </RuleSet>

--- a/default.ruleset.md
+++ b/default.ruleset.md
@@ -22,10 +22,7 @@ C26482: Only index into arrays using constant expressions.
 -> Rationale: static analysis can verify access, std::array during runtime (debug)
 
 C26490: Don't use reinterpret_cast
--> Rationale: required to cast unsigned char* to char*.
-
-C26493: Don't use C-style casts (type.4).
--> Rationale: False positives in Visual Studio 2022 17.11.0 Preview 3.0
+-> Rationale: required to cast unsigned char\* to char\*.
 
 C26494: Variable 'x' is uninitialized. Always initialize an object
 -> Rationale: many false warnings, other analyzers are better.

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -563,6 +563,8 @@ enum class encoding_options : unsigned
 constexpr encoding_options operator|(const encoding_options lhs, const encoding_options rhs) noexcept
 {
     using T = std::underlying_type_t<encoding_options>;
+
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) - warning cannot handle flags (known limitation).
     return static_cast<encoding_options>(static_cast<T>(lhs) | static_cast<T>(rhs));
 }
 


### PR DESCRIPTION
- The MSVC warning C26493 was broken in VS 2022 17.11. It has been fixed in 17.12
- Update .clang-tidy. Disable new but not useful warnings.