### PR TITLE
Fix triplet problem with vcpkg and ARM64 platform

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -363,7 +363,7 @@ BENCHMARK(bm_has_ff_byte_classic);
 static bool has_ff_byte_loop(const unsigned int value) noexcept
 {
     // Iterate over each byte and check if it is equal to 0xFF
-    for (int i = 0; i < sizeof(unsigned int); ++i)
+    for (size_t i = 0; i < sizeof(unsigned int); ++i)
     {
         if ((value & (0xFF << (8 * i))) == (0xFFU << (8 * i)))
         {
@@ -383,7 +383,7 @@ static void bm_has_ff_byte_loop(benchmark::State& state)
 BENCHMARK(bm_has_ff_byte_loop);
 
 #if !defined(_M_ARM64)
-static bool has_ff_byte_simd(const unsigned int value) {
+static bool has_ff_byte_simd(const unsigned int value) noexcept {
      // Use SSE instructions for parallel comparison
      const __m128i xmm_value = _mm_set1_epi32(value);
      const __m128i xmm_ff = _mm_set1_epi32(0xFF);
@@ -488,7 +488,7 @@ T read_big_endian_unaligned(const void* buffer) noexcept
 }
 
 #if !defined(_M_ARM64)
-static uint32_t read_all_bytes_with_ff_check(const std::byte* position, const std::byte* end_position)
+static uint32_t read_all_bytes_with_ff_check(const std::byte* position, const std::byte* end_position) noexcept
 {
     uint32_t result{};
 
@@ -521,7 +521,7 @@ BENCHMARK(bm_read_all_bytes_with_ff_check);
 #endif
 
 #if !defined(_M_ARM64)
-static bool has_ff_byte_simd64(const uint64_t value)
+static bool has_ff_byte_simd64(const uint64_t value) noexcept
 {
     // Use SSE instructions for parallel comparison
     const __m128i xmm_value = _mm_set1_epi64x(value);
@@ -534,7 +534,7 @@ static bool has_ff_byte_simd64(const uint64_t value)
     return _mm_testz_si128(comparison, comparison) == 0;
 }
 
-static uint64_t read_all_bytes_with_ff_check64(const std::byte* position, const std::byte* end_position)
+static uint64_t read_all_bytes_with_ff_check64(const std::byte* position, const std::byte* end_position) noexcept
 {
     uint64_t result{};
 

--- a/benchmark/benchmark.vcxproj
+++ b/benchmark/benchmark.vcxproj
@@ -49,6 +49,7 @@
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
     <VcpkgEnabled>true</VcpkgEnabled>
     <VcpkgManifestInstall>true</VcpkgManifestInstall>
+    <VcpkgPlatformTarget Condition="'$(Platform)'=='ARM64'">arm64</VcpkgPlatformTarget>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>

--- a/benchmark/golomb_lut_constexpr.cpp
+++ b/benchmark/golomb_lut_constexpr.cpp
@@ -5,10 +5,13 @@
 
 #include "../src/golomb_lut.hpp"
 #include "../src/jpegls_algorithm.hpp"
+#include "../src/conditional_static_cast.hpp"
+
+#pragma warning(disable : 26409) // Avoid calling new explicitly (triggered by BENCHMARK macro)
 
 using namespace charls;
 
-std::pair<int32_t, int32_t> create_encoded_value(const int32_t k, const int32_t mapped_error) noexcept
+static std::pair<int32_t, int32_t> create_encoded_value(const int32_t k, const int32_t mapped_error) noexcept
 {
     const int32_t high_bits{mapped_error >> k};
     return std::make_pair(high_bits + k + 1, (1 << k) | (mapped_error & ((1 << k) - 1)));

--- a/benchmark/vcpkg.json
+++ b/benchmark/vcpkg.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-  "dependencies": [ { "name": "benchmark", "version>=":"1.8.5" } ],
+  "dependencies": [ { "name": "benchmark", "version>=":"1.9.0" } ],
   "builtin-baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da"
 }

--- a/cpp.hint
+++ b/cpp.hint
@@ -35,3 +35,4 @@
 #define USE_DECL_ANNOTATIONS
 #define ASSERT(x)
 #define UNLIKELY(x)
+#define BENCHMARK_MAIN()

--- a/spelling.dic
+++ b/spelling.dic
@@ -24,3 +24,4 @@ cmove
 Fuzzer
 argv'
 argc'
+simd


### PR DESCRIPTION
vcpkg requires lowercase triplet names. Using ARM64 will trigger a failure. Add an explicit override to resolve this.