### PR TITLE
Add precompiled header

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Copyright (c) Team CharLS.
+# SPDX-FileCopyrightText: © 2016 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
 root = true
@@ -22,4 +22,7 @@ insert_final_newline = true
 indent_size = 2
 
 [*.manifest]
+indent_size = 2
+
+[*.props, .runsettings]
 indent_size = 2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Team CharLS.
+# SPDX-FileCopyrightText: © 2018 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Define the library "charls" target
@@ -31,6 +31,8 @@ target_include_directories(charls PUBLIC
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(charls PUBLIC CHARLS_STATIC)
 endif()
+
+target_precompile_headers(charls PRIVATE ${CMAKE_CURRENT_LIST_DIR}/pch.hpp)
 
 # Use different DLL filenames on Windows. It allows platform neutral adapters to load dynamically the correct version.
 if(WIN32 AND BUILD_SHARED_LIBS)
@@ -128,6 +130,7 @@ target_sources(charls
     "${CMAKE_CURRENT_LIST_DIR}/lossless_traits.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/make_scan_codec.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/make_scan_codec.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/pch.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/quantization_lut.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/quantization_lut.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/regular_mode_context.hpp"

--- a/src/CharLS.vcxproj
+++ b/src/CharLS.vcxproj
@@ -114,8 +114,7 @@
     <ClCompile>
       <PreprocessorDefinitions>CHARLS_LIBRARY_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
     <Link>
     </Link>
@@ -213,6 +212,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="golomb_lut.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="quantization_lut.cpp" />
     <ClCompile Include="validate_spiff_header.cpp" />
     <ClCompile Include="version.cpp" />
@@ -242,6 +244,7 @@
     <ClInclude Include="color_transform.hpp" />
     <ClInclude Include="conditional_static_cast.hpp" />
     <ClInclude Include="constants.hpp" />
+    <ClInclude Include="pch.hpp" />
     <ClInclude Include="regular_mode_context.hpp" />
     <ClInclude Include="run_mode_context.hpp" />
     <ClInclude Include="copy_to_line_buffer.hpp" />

--- a/src/CharLS.vcxproj.filters
+++ b/src/CharLS.vcxproj.filters
@@ -31,8 +31,8 @@
     <ClCompile Include="quantization_lut.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\include\charls\charls.ixx">
-      <Filter>Header Files</Filter>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -156,6 +156,9 @@
     <ClInclude Include="..\include\charls\undef_macros.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="pch.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="charls.rc" />
@@ -171,6 +174,9 @@
       <Filter>Design</Filter>
     </None>
     <None Include="packages.config" />
+    <None Include="..\include\charls\charls.ixx">
+      <Filter>Header Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">

--- a/src/charls.rc
+++ b/src/charls.rc
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2011 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma code_page(65001)
 
-#include "charls/version.h"
+#include <charls/version.h>
 
 #include <winresrc.h>
 
@@ -41,7 +41,7 @@ BEGIN
             VALUE "FileVersion", VERSION_STR
             VALUE "InternalName", "CharLS.dll"
             VALUE "LegalCopyright", "Copyright (c) Team CharLS"
-            VALUE "OriginalFilename", "charls-2-x86/x64.dll"
+            VALUE "OriginalFilename", "charls-3-x86/x64.dll"
             VALUE "ProductName", "CharLS JPEG-LS codec"
             VALUE "ProductVersion", VERSION_STR
         END

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -1,7 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2019 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "charls/charls_jpegls_decoder.h"
+#include "pch.hpp"
+
+#include <charls/charls_jpegls_decoder.h>
 
 #include "constants.hpp"
 #include "jpeg_stream_reader.hpp"

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -1,9 +1,10 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2019 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "charls/charls_jpegls_encoder.h"
+#include "pch.hpp"
 
-#include "charls/version.h"
+#include <charls/charls_jpegls_encoder.h>
+#include <charls/version.h>
 
 #include "color_transform.hpp"
 #include "jpeg_stream_writer.hpp"

--- a/src/coding_parameters.hpp
+++ b/src/coding_parameters.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2020 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-#include "charls/public_types.h"
+#include <charls/public_types.h>
 
 namespace charls {
 

--- a/src/golomb_lut.cpp
+++ b/src/golomb_lut.cpp
@@ -1,5 +1,7 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2023 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.hpp"
 
 #include "golomb_lut.hpp"
 

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -1,5 +1,7 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2009 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.hpp"
 
 #include "jpeg_stream_reader.hpp"
 

--- a/src/jpeg_stream_reader.hpp
+++ b/src/jpeg_stream_reader.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2009 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-#include "charls/public_types.h"
+#include <charls/public_types.h>
 
 #include "coding_parameters.hpp"
 #include "span.hpp"

--- a/src/jpeg_stream_writer.cpp
+++ b/src/jpeg_stream_writer.cpp
@@ -1,5 +1,7 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2009 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.hpp"
 
 #include "jpeg_stream_writer.hpp"
 

--- a/src/jpeg_stream_writer.hpp
+++ b/src/jpeg_stream_writer.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2014 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-#include "charls/jpegls_error.hpp"
+#include <charls/jpegls_error.hpp>
 
 #include "constants.hpp"
 #include "jpeg_marker_code.hpp"

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2018 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "charls/jpegls_error.hpp"
+#include "pch.hpp"
 
-#include <string>
+#include <charls/jpegls_error.hpp>
 
 namespace charls {
 

--- a/src/jpegls_preset_coding_parameters.hpp
+++ b/src/jpegls_preset_coding_parameters.hpp
@@ -1,9 +1,10 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2018 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-#include "charls/public_types.h"
+#include <charls/public_types.h>
+
 #include "jpegls_algorithm.hpp"
 #include "util.hpp"
 

--- a/src/make_scan_codec.cpp
+++ b/src/make_scan_codec.cpp
@@ -1,5 +1,7 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2009 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.hpp"
 
 #include "make_scan_codec.hpp"
 

--- a/src/pch.cpp
+++ b/src/pch.cpp
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: © 2025 Team CharLS
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.hpp"

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Team CharLS
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <new>
+#include <numeric>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <vector>

--- a/src/quantization_lut.cpp
+++ b/src/quantization_lut.cpp
@@ -1,11 +1,12 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2023 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
+
+#include "pch.hpp"
 
 #include "quantization_lut.hpp"
 
-#include "charls/public_types.h"
+#include <charls/public_types.h>
 #include "jpegls_algorithm.hpp"
-
 #include "jpegls_preset_coding_parameters.hpp"
 
 namespace charls {

--- a/src/scan_decoder.hpp
+++ b/src/scan_decoder.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2009 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-#include "charls/jpegls_error.hpp"
+#include <charls/jpegls_error.hpp>
 
 #include "copy_from_line_buffer.hpp"
 #include "jpeg_marker_code.hpp"

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2009 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-#include "charls/jpegls_error.hpp"
+#include <charls/jpegls_error.hpp>
 
 #include <cassert>
 #include <cstdlib>

--- a/src/validate_spiff_header.cpp
+++ b/src/validate_spiff_header.cpp
@@ -1,8 +1,10 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2022 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "pch.hpp"
 
-#include "charls/validate_spiff_header.h"
+#include <charls/validate_spiff_header.h>
+
 #include "util.hpp"
 
 using namespace charls;

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,10 +1,11 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2019 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "charls/version.h"
+#include "pch.hpp"
+
+#include <charls/version.h>
 
 #include "util.hpp"
-
 
 using namespace charls;
 

--- a/unittest/CharLSUnitTest.vcxproj
+++ b/unittest/CharLSUnitTest.vcxproj
@@ -65,7 +65,7 @@
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(SolutionDir)build\intermediate\CharLS\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(SolutionDir)build\intermediate\CharLS\x86\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>make_scan_codec.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;validate_spiff_header.obj;golomb_lut.obj;quantization_lut.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pch.obj;make_scan_codec.obj;jpegls_error.obj;jpeg_stream_writer.obj;jpeg_stream_reader.obj;charls_jpegls_decoder.obj;charls_jpegls_encoder.obj;version.obj;validate_spiff_header.obj;golomb_lut.obj;quantization_lut.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
All modern C++ compiler support precompiled headers, add one to increase build performance.