### PR TITLE
Clean up the .clang-tidy configuration file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,129 +1,58 @@
 # SPDX-FileCopyrightText: © 2020 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
-# The approach for using clang tidy is to enable all warnings unless it adds no practical value to the CharLS projects
-# Having all warnings enables helps to find problems when new code is added to the project. Some warnings are however
-# to noisy and adding NO_LINT suppressions make the code less readable.
-#
-# -fuchsia-* => Rationale: Rules only apply to Fuchsia projects are out of scope for CharLS
-# -google-* => Rationale: Rules only apply to Google projects are out of scope for CharLS
-# -android-* => Rationale: Rules only apply to Android projects are out of scope for CharLS
-# -llvmlibc-* => Rationale: Rules only apply to LLVM Libc and are out of scope for CharLS
-# -llvm-header-guard => Rationale: #pragma once is used
-# -hicpp-no-array-decay => Rationale: alias for cppcoreguidelines-pro-bounds-constant-array-index
-# -hicpp-signed-bitwise => Rationale: Bad test, types are checked, not values.
-# -clang-diagnostic-c++98-compat* => Rationale: CharLS targets C++17
-# -clang-diagnostic-c++98-c++11-compat => Rationale: CharLS targets C++17
-# -clang-diagnostic-c++98-c++11-c++14-compat => Rationale: CharLS targets C++17
-# -clang-diagnostic-pre-c++14-compat => Rationale: CharLS targets C++17
-# -clang-diagnostic-pre-c++17-compat => Rationale: CharLS targets C++17
-# -clang-diagnostic-unused-macros => Rationale: Macros defined in header are reported as problem
-# -clang-diagnostic-sign-conversion => Rationale: warning will be enabled in additional steps
-# -clang-diagnostic-switch-enum => Rationale: options are handled by default case
-# -clang-diagnostic-switch-default => Rationale: conflicts with warning that all enum cases must be handled
-# -clang-diagnostic-global-constructors => Rationale: Acceptable construction
-# -clang-diagnostic-exit-time-destructors => Rationale: Acceptable construction
-# -clang-diagnostic-pragma-once-outside-header => Rationale: Generates false warnings for usage in header files
-# -clang-diagnostic-unused-const-variable => Rationale: false warnings for constexpr in .h files
-# -clang-diagnostic-unused-command-line-argument => Rationale: false warning about option passed to MSVC
-# -clang-diagnostic-declaration-after-statement => Rationale: Target is C17 and higher
-# -clang-diagnostic-unsafe-buffer-usage => Rationale: Too many false warnings, access is verified with other tools.
-# -clang-analyzer-core.NonNullParamChecker => Rationale: cannot be effective disabled, already checked by other checkers.
-# -misc-non-private-member-variables-in-classes => Rationale: design can be ok, manual review is better
-# -misc-include-cleaner => complains about no direct includes
-# -modernize-use-trailing-return-type => Rationale: A style recommendation, this style is selected for CharLS
-# -readability-magic-numbers => Rationale: To critical rule, used numbers are logical
-# -readability-named-parameter => Rationale: to many non problematic warnings
-# -readability-implicit-bool-conversion => Rationale: style issue
-# -readability-identifier-length => Rationale: style
-# -cppcoreguidelines-avoid-magic-numbers => Rationale: Alias
-# -cppcoreguidelines-pro-bounds-pointer-arithmetic => Rationale: usage is required in codec implementation
-# -cppcoreguidelines-pro-type-reinterpret-cast => Rationale: To strict for conditions that require its usage
-# -cppcoreguidelines-macro-usage => Rationale: Many false warnings
-# -cppcoreguidelines-pro-bounds-array-to-pointer-decay => Span is not available
-# -cppcoreguidelines-pro-type-union-access => Rationale: usage of union is more efficient is used scenarios
-# -cppcoreguidelines-non-private-member-variables-in-classes => Warning is too strict, manual review code review is preferred
-# -cppcoreguidelines-pro-bounds-constant-array-index => gsl:at is not used by design
-# -cppcoreguidelines-init-variables => reports false warnings for out parameters (other checkers are better to detect these problems)
-# -cert-msc32-c => Rationale: predictable seed is by design (random used for testing, not crypto)
-# -cert-msc51-cpp => Rationale: alias for cert-msc32-c
-# -cert-err58-cpp => Rationale: Only exception that could be thrown is out of memory
-# -altera-struct-pack-align => Rationale: Not applicable (Altera is for openCL)
-# -readability-function-cognitive-complexity => Warning is too strict, manual review code review is preferred
-# -concurrency-mt-unsafe => Reports a false warning for strerror in main (not useful for CharLS)
-# -llvm-namespace-comment => complains about namespace issues in system header files
-# -hicpp-named-parameter => complains about issues in system header files
-# -altera-unroll-loops => Does not apply (is for openCL)
-# -altera-id-dependent-backward-branch => Does not apply (is for openCL)
-# -bugprone-easily-swappable-parameters => To many do not fix warnings
-# -performance-enum-size => No performance gain, enums are not used in arrays.
-# -boost-use-ranges => CharLS has by design not a dependency on Boost.
+# The approach for using clang tidy is to enable warnings that add practical value to the CharLS projects
+# Some warnings are however to noisy and adding NO_LINT suppressions make the code less readable.
 
----
-Checks:          '*,
-                  -fuchsia-*,
-                  -google-*,
-                  -android-*,
-                  -llvmlibc-*,
-                  -llvm-header-guard,
-                  -llvm-namespace-comment,
-                  -hicpp-no-array-decay,
-                  -hicpp-signed-bitwise,
-                  -hicpp-named-parameter,
-                  -clang-diagnostic-c++98-compat*,
-                  -clang-diagnostic-c++98-c++11-compat,
-                  -clang-diagnostic-c++98-c++11-c++14-compat,
-                  -clang-diagnostic-pre-c++14-compat,
-                  -clang-diagnostic-pre-c++17-compat,
-                  -clang-diagnostic-unused-macros,
-                  -clang-diagnostic-sign-conversion,
-                  -clang-diagnostic-switch-enum,
-                  -clang-diagnostic-switch-default,
-                  -clang-diagnostic-global-constructors,
-                  -clang-diagnostic-exit-time-destructors,
-                  -clang-diagnostic-pragma-once-outside-header,
-                  -clang-diagnostic-unused-const-variable,
-                  -clang-diagnostic-unused-command-line-argument,
-                  -clang-diagnostic-declaration-after-statement,
-                  -clang-diagnostic-unsafe-buffer-usage,
-                  -clang-analyzer-core.NonNullParamChecker,
-                  -misc-non-private-member-variables-in-classes,
-                  -misc-include-cleaner,
-                  -modernize-use-trailing-return-type,
-                  -readability-magic-numbers,
-                  -readability-named-parameter,
-                  -readability-implicit-bool-conversion,
-                  -readability-identifier-length,
-                  -cppcoreguidelines-avoid-magic-numbers,
-                  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
-                  -cppcoreguidelines-pro-type-reinterpret-cast,
-                  -cppcoreguidelines-macro-usage,
-                  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
-                  -cppcoreguidelines-pro-type-union-access,
-                  -cppcoreguidelines-non-private-member-variables-in-classes,
-                  -cppcoreguidelines-pro-bounds-constant-array-index,
-                  -cppcoreguidelines-init-variables,
-                  -cert-msc32-c,
-                  -cert-msc51-cpp,
-                  -cert-err58-cpp,
-                  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
-                  -altera-struct-pack-align,
-                  -altera-unroll-loops,
-                  -altera-id-dependent-backward-branch,
-                  -readability-function-cognitive-complexity,
-                  -bugprone-easily-swappable-parameters,
-                  -concurrency-mt-unsafe,
-                  -performance-enum-size,
-                  -boost-use-ranges'
+Checks:
+  - 'bugprone-*' # Checks that target bug-prone code constructs.
+  - '-bugprone-easily-swappable-parameters' # Rationale: too many do not fix warnings, more an advice.
+
+  - 'readability-*' # Checks that target readability-related issues that don’t relate to any particular coding style.
+  - '-readability-magic-numbers' # Rationale: Too many false positives, most used numbers are logical in context.
+  - '-readability-identifier-length' # Rationale: Too many false positives, single characters names are used in formulas.
+  - '-readability-function-cognitive-complexity' # Rationale: manual review is preferred.
+
+  - 'portability-*' # Checks that target portability-related issues that don’t relate to any particular coding style.
+
+  - 'performance-*' # Checks that target performance-related issues.
+  - '-performance-enum-size' # Rationale: no real performance gain, enums are not used in arrays.
+
+  - 'concurrency-*' # Checks related to concurrent programming (including threads, fibers, coroutines, etc.).
+
+  - 'misc-*' # Checks that we didn’t have a better category for.
+  - '-misc-include-cleaner' # Rationale: also generates warnings when a direct include file is not used. Other tools are more practical.
+
+  - 'modernize-*' # Checks that advocate usage of modern (currently “modern” means “C++11”) language constructs.
+  - '-modernize-use-trailing-return-type' # Rationale: A style recommendation, this style is not selected for CharLS.
+
+  - 'clang-analyzer-*' # Clang Static Analyzer checks.
+
+  - 'cppcoreguidelines-*' # Checks related to C++ Core Guidelines.
+  - '-cppcoreguidelines-avoid-magic-numbers' # Rationale: Alias for readability-magic-numbers.
+  - '-cppcoreguidelines-pro-bounds-pointer-arithmetic' # Rationale: usage is required in codec implementation.
+  - '-cppcoreguidelines-init-variables' # Rationale reports false warnings for out parameters (other checkers are better to detect these problems)
+  - '-cppcoreguidelines-pro-bounds-constant-array-index' # Rationale gsl:at is not used by design, memory access verified with other tools.
+
+  - 'cert-*' # Checks related to CERT Secure Coding Guidelines.
+  - '-cert-err58-cpp' # Rationale: Only exception that can be thrown is out of memory
+  - '-cert-msc32-c' # Rationale: predictable seed is by design (random is used only for testing)
+  - '-cert-msc51-cpp'# Rationale: alias for cert-msc32-c
+
+  - 'hicpp-*' # Checks related to High Integrity C++ Coding Standard.
+  - '-hicpp-signed-bitwise' # Rationale: Bad test, types are checked, not values.
+
+  - '-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling' # Rationale: safe alternatives of memcpy are not always available.
+
 WarningsAsErrors: false
 HeaderFilterRegex: ''
 FormatStyle:     none
 CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '2'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '2'
-  - key:             hicpp-braces-around-statements.ShortStatementLines
-    value:           '2'
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
     value:           '1'
+  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             hicpp-braces-around-statements.ShortStatementLines
+    value:           '2'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks:
   - '-modernize-use-trailing-return-type' # Rationale: A style recommendation, this style is not selected for CharLS.
 
   - 'clang-analyzer-*' # Clang Static Analyzer checks.
+  - '-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling' # Rationale: safe alternatives of memcpy are not always available.
 
   - 'cppcoreguidelines-*' # Checks related to C++ Core Guidelines.
   - '-cppcoreguidelines-avoid-magic-numbers' # Rationale: Alias for readability-magic-numbers.
@@ -42,7 +43,7 @@ Checks:
   - 'hicpp-*' # Checks related to High Integrity C++ Coding Standard.
   - '-hicpp-signed-bitwise' # Rationale: Bad test, types are checked, not values.
 
-  - '-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling' # Rationale: safe alternatives of memcpy are not always available.
+  - '-clang-diagnostic-ignored-gch' # Rationale: Ignore, triggered by compiling with GCC and running clang-tidy.
 
 WarningsAsErrors: false
 HeaderFilterRegex: ''
@@ -56,3 +57,5 @@ CheckOptions:
     value:           '1'
   - key:             hicpp-braces-around-statements.ShortStatementLines
     value:           '2'
+  - key:             readability-simplify-boolean-expr.IgnoreMacros
+    value:           '1'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Copyright (c) Team CharLS.
+# SPDX-FileCopyrightText: © 2009 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.16...3.31)
+cmake_minimum_required(VERSION 3.16...4.01)
 
 # Extract the version info from version.h
 file(READ "include/charls/version.h" version)
@@ -15,12 +15,12 @@ message(STATUS "CharLS version: ${version_major}.${version_minor}.${version_patc
 
 project(charls VERSION ${version_major}.${version_minor}.${version_patch} LANGUAGES C CXX)
 
-# Determine if project is built as a subproject (using add_subdirectory) or if it is the main project.
+# Determine if project is built as a sub-project (using add_subdirectory) or if it is the main project.
 set(MAIN_PROJECT OFF)
-if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MAIN_PROJECT ON)
   message(STATUS "Building as main project, CMake version: ${CMAKE_VERSION}")
-endif ()
+endif()
 
 # The basic options to control what is build extra.
 option(CHARLS_BUILD_TESTS "Build test application" ${MAIN_PROJECT})
@@ -34,6 +34,9 @@ option(BUILD_SHARED_LIBS "Will control if charls lib is build as shared lib/DLL 
 
 # Provide option to build CharLS with address sanitizer
 option(CHARLS_ENABLE_ASAN "Build with address sanitizer enabled." OFF)
+
+# Provide option to build CharLS with clang-tidy
+option(CHARLS_ENABLE_CLANG_TIDY "Enable clang-tidy static analysis." OFF)
 
 # These options are used by the CI pipeline to ensure new warnings are detected quickly.
 # Not enabled by default to ensure the CharLS package is end-user friendly.
@@ -187,7 +190,7 @@ if(MSVC)
     add_compile_options("/permissive-")
   endif()
 
-  # /ZH:SHA_256: Wiill use SHA 256 for checksums between source code and debug symbols (more secure)
+  # /ZH:SHA_256: Will use SHA 256 for checksums between source code and debug symbols (more secure)
   add_compile_options("/ZH:SHA_256")
 
   # /guard:cf: Will enable Control Flow Guard, which provides addition compile time and runtime checks.
@@ -205,6 +208,16 @@ if(MSVC)
     set(LIBFUZZER_SUPPORTED 1)
   endif()
 
+endif()
+
+if(CHARLS_ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+    if(CLANG_TIDY_EXE)
+        message(STATUS "Clang-tidy enabled and found at: ${CLANG_TIDY_EXE}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+    else()
+        message(WARNING "Clang-tidy enabled, but not found!")
+    endif()
 endif()
 
 # When enabled apply the pedantic warnings options and warnings as errors to globally.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,46 +197,46 @@ jobs:
 
   strategy:
     matrix:
-      GCC-9 Debug:
+      GCC-12 Debug:
         buildType: Debug
-        CC: gcc-9
-        CXX: g++-9
-        Shared: 'OFF'
-
-      GCC-10 Release:
-        buildType: Release
-        CC: gcc-10
-        CXX: g++-10
-        Shared: 'OFF'
-
-      GCC-11 Debug Shared:
-        buildType: Debug
-        CC: gcc-11
-        CXX: g++-11
-        Shared: 'ON'
-
-      GCC-12 Release Shared:
-        buildType: Release
         CC: gcc-12
         CXX: g++-12
+        Shared: 'OFF'
+
+      GCC-13 Release:
+        buildType: Release
+        CC: gcc-13
+        CXX: g++-13
+        Shared: 'OFF'
+
+      GCC-14 Debug Shared:
+        buildType: Debug
+        CC: gcc-14
+        CXX: g++-14
         Shared: 'ON'
 
-      Clang-13 Debug:
+      GCC-14 Release Shared:
+        buildType: Release
+        CC: gcc-14
+        CXX: g++-14
+        Shared: 'ON'
+
+      Clang-16 Debug:
         buildType: Debug
-        CC: clang-13
-        CXX: clang++-13
+        CC: clang-16
+        CXX: clang++-16
         Shared: 'OFF'
 
-      Clang-13 Release:
+      Clang-17 Release:
         buildType: Release
-        CC: clang-13
-        CXX: clang++-13
+        CC: clang-17
+        CXX: clang++-17
         Shared: 'OFF'
 
-      Clang-14 Release Shared:
+      Clang-18 Release Shared:
         buildType: Release
-        CC: clang-14
-        CXX: clang++-14
+        CC: clang-18
+        CXX: clang++-18
         Shared: 'ON'
 
   steps:

--- a/fuzzing/afl/main.cpp
+++ b/fuzzing/afl/main.cpp
@@ -92,7 +92,7 @@ int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-
             return EXIT_FAILURE;
         }
 
-        fd = _open(argv[1], O_RDONLY);
+        fd = _open(argv[1], O_RDONLY); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
         if (fd < 0)
         {
             std::cerr << "Failed to open: " << argv[1] << strerror(errno) << '\n';  // NOLINT(concurrency-mt-unsafe)

--- a/fuzzing/afl/main.cpp
+++ b/fuzzing/afl/main.cpp
@@ -36,7 +36,7 @@ using std::vector;
 
 #ifndef __AFL_LOOP
 // ReSharper disable once CppInconsistentNaming
-#define __AFL_LOOP(a) true // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define __AFL_LOOP(a) true // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,cppcoreguidelines-macro-usage)
 #define AFL_LOOP_FOREVER
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ target_sources(charls
   PUBLIC
     ${CHARLS_PUBLIC_HEADERS}
   PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/assert.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/charls_jpegls_decoder.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/charls_jpegls_encoder.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/coding_parameters.hpp"

--- a/src/CharLS.vcxproj
+++ b/src/CharLS.vcxproj
@@ -240,6 +240,7 @@
     <ClInclude Include="..\include\charls\undef_macros.h" />
     <ClInclude Include="..\include\charls\validate_spiff_header.h" />
     <ClInclude Include="..\include\charls\version.h" />
+    <ClInclude Include="assert.hpp" />
     <ClInclude Include="coding_parameters.hpp" />
     <ClInclude Include="color_transform.hpp" />
     <ClInclude Include="conditional_static_cast.hpp" />

--- a/src/CharLS.vcxproj.filters
+++ b/src/CharLS.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="pch.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="assert.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="charls.rc" />

--- a/src/assert.hpp
+++ b/src/assert.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Team CharLS
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cassert>
+
+// Use an uppercase alias for assert to make it clear that ASSERT is a pre-processor macro.
+#ifdef _MSC_VER
+// C26493 = Don't use C-style casts
+#define ASSERT(expression) \
+    __pragma(warning(push)) __pragma(warning(disable : 26493)) assert(expression) __pragma(warning(pop))
+#else
+#define ASSERT(expression) assert(expression)
+#endif

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -22,7 +22,7 @@ struct charls_jpegls_decoder final
 {
     void source(const span<const byte> source)
     {
-        check_argument(source.data() || source.empty());
+        check_argument(source);
         check_operation(state_ == state::initial);
 
         reader_.source(source);
@@ -167,14 +167,14 @@ struct charls_jpegls_decoder final
     void get_mapping_table_data(const int32_t mapping_table_index, const span<byte> table_data) const
     {
         check_mapping_table_index(mapping_table_index);
-        check_argument(table_data.data() || table_data.empty());
+        check_argument(table_data);
 
         reader_.get_mapping_table_data(mapping_table_index, table_data);
     }
 
     void decode(span<byte> destination, const size_t stride)
     {
-        check_argument(destination.data() || destination.empty());
+        check_argument(destination);
         check_operation(state_ == state::header_read);
 
         for (size_t component{};;)

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -33,7 +33,7 @@ struct charls_jpegls_encoder final
 {
     void destination(const span<byte> destination)
     {
-        check_argument(destination.data() || destination.empty());
+        check_argument(destination);
         check_operation(state_ == state::initial);
 
         writer_.destination(destination);
@@ -127,9 +127,9 @@ struct charls_jpegls_encoder final
 
     void write_spiff_entry(const uint32_t entry_tag, const span<const byte> entry_data)
     {
-        check_argument(entry_data.data() || entry_data.empty());
+        check_argument(entry_data);
         check_argument(entry_tag != spiff_end_of_directory_entry_type);
-        check_argument(entry_data.size() <= 65528, jpegls_errc::invalid_argument_size);
+        check_argument(entry_data.size() <= spiff_entry_max_data_size, jpegls_errc::invalid_argument_size);
         check_operation(state_ == state::spiff_header);
 
         writer_.write_spiff_directory_entry(entry_tag, entry_data);
@@ -143,7 +143,7 @@ struct charls_jpegls_encoder final
 
     void write_comment(const span<const byte> comment)
     {
-        check_argument(comment.data() || comment.empty());
+        check_argument(comment);
         check_argument(comment.size() <= segment_max_data_size, jpegls_errc::invalid_argument_size);
         check_state_can_write();
 
@@ -154,7 +154,7 @@ struct charls_jpegls_encoder final
     void write_application_data(const int32_t application_data_id, const span<const byte> application_data)
     {
         check_argument_range(minimum_application_data_id, maximum_application_data_id, application_data_id);
-        check_argument(application_data.data() || application_data.empty());
+        check_argument(application_data);
         check_argument(application_data.size() <= segment_max_data_size, jpegls_errc::invalid_argument_size);
         check_state_can_write();
 
@@ -166,7 +166,7 @@ struct charls_jpegls_encoder final
     {
         check_argument_range(minimum_mapping_table_id, maximum_mapping_table_id, table_id);
         check_argument_range(minimum_mapping_entry_size, maximum_mapping_entry_size, entry_size);
-        check_argument(table_data.data() || table_data.empty());
+        check_argument(table_data);
         check_argument(table_data.size() >= static_cast<size_t>(entry_size), jpegls_errc::invalid_argument_size);
         check_state_can_write();
 
@@ -181,7 +181,7 @@ struct charls_jpegls_encoder final
 
     void encode_components(span<const byte> source, const int32_t source_component_count, const size_t stride)
     {
-        check_argument(source.data() || source.empty());
+        check_argument(source);
         check_state_can_write();
         check_operation(is_frame_info_configured());
         check_interleave_mode_against_component_count();
@@ -354,7 +354,7 @@ private:
         {
             constexpr std::string_view version_number{"charls " TO_STRING(CHARLS_VERSION_MAJOR) "." TO_STRING(
                 CHARLS_VERSION_MINOR) "." TO_STRING(CHARLS_VERSION_PATCH)};
-            writer_.write_comment_segment({reinterpret_cast<const byte*>(version_number.data()), version_number.size() + 1});
+            writer_.write_comment_segment(as_bytes(span{version_number.data(), version_number.size() + 1}));
         }
 
         state_ = state::tables_and_miscellaneous;

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -40,6 +40,9 @@ constexpr uint8_t spiff_end_of_directory_entry_type{1};
 // The size of a SPIFF header when serialized to a JPEG byte stream.
 constexpr size_t spiff_header_size_in_bytes{34};
 
+// The maximum size of the data bytes that fit in a spiff entry.
+constexpr size_t spiff_entry_max_data_size{65528};
+
 // The special value to indicate that the stride should be calculated.
 constexpr size_t auto_calculate_stride{};
 

--- a/src/default_traits.hpp
+++ b/src/default_traits.hpp
@@ -5,9 +5,8 @@
 
 #include "constants.hpp"
 #include "jpegls_algorithm.hpp"
+#include "util.hpp"
 
-#include <cassert>
-#include <cmath>
 #include <cstdlib>
 
 // Default traits that support all JPEG LS parameters: custom limit, near, maxval (not power of 2)

--- a/src/jpegls_algorithm.hpp
+++ b/src/jpegls_algorithm.hpp
@@ -4,7 +4,9 @@
 #pragma once
 
 #include "constants.hpp"
-#include "util.hpp"
+#include "assert.hpp"
+
+#include <algorithm>
 
 namespace charls {
 

--- a/src/span.hpp
+++ b/src/span.hpp
@@ -3,14 +3,14 @@
 
 #pragma once
 
+#include "assert.hpp"
+
 #include <array>
 #include <cstddef>
 
-#include "util.hpp"
-
 namespace charls {
 
-// Replacement for std::to_address, which is not available in C++17.
+// Replacement for C++20 std::to_address, which is not available in C++17.
 template<typename Ptr>
 constexpr auto to_address(const Ptr& it)
 {
@@ -18,7 +18,7 @@ constexpr auto to_address(const Ptr& it)
 }
 
 
-// Replacement for std::span, which is not available in C++17.
+// Replacement for C++20 type std::span, which is not available in C++17.
 template<typename T>
 class span final
 {
@@ -47,6 +47,12 @@ public:
     constexpr size_t size() const noexcept
     {
         return size_;
+    }
+
+    [[nodiscard]]
+    constexpr size_t size_bytes() const noexcept
+    {
+        return sizeof(T) * size_;
     }
 
     [[nodiscard]]
@@ -87,5 +93,13 @@ private:
 
 template<typename T>
 span(T) -> span<T>;
+
+
+template<typename T>
+[[nodiscard]]
+span<const std::byte> as_bytes(span<T> source) noexcept
+{
+    return {reinterpret_cast<const std::byte*>(source.data()), source.size_bytes()};
+}
 
 } // namespace charls

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -5,20 +5,11 @@
 
 #include <charls/jpegls_error.hpp>
 
-#include <cassert>
+#include "span.hpp"
+
 #include <cstdlib>
 #include <cstring>
 #include <type_traits>
-
-
-// Use an uppercase alias for assert to make it clear that ASSERT is a pre-processor macro.
-#ifdef _MSC_VER
-// C26493 = Don't use C-style casts
-#define ASSERT(expression) \
-    __pragma(warning(push)) __pragma(warning(disable : 26493)) assert(expression) __pragma(warning(pop))
-#else
-#define ASSERT(expression) assert(expression)
-#endif
 
 // Use forced inline for supported C++ compilers in release builds.
 // Note: usage of FORCE_INLINE may be reduced in the future as the latest generation of C++ compilers
@@ -289,6 +280,13 @@ inline void check_argument(const bool expression, const jpegls_errc error_value 
 {
     if (UNLIKELY(!expression))
         impl::throw_jpegls_error(error_value);
+}
+
+
+template<typename T>
+void check_argument(span<T> argument, const jpegls_errc error_value = jpegls_errc::invalid_argument)
+{
+    check_argument(argument.data() != nullptr || argument.empty(), error_value);
 }
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -81,10 +81,16 @@ uint32_t max_value_to_bits_per_sample(const uint32_t max_value) noexcept
 }
 
 
+void read(istream& input, void* buffer, const size_t size)
+{
+    input.read(static_cast<char*>(buffer), static_cast<std::streamsize>(size));
+}
+
+
 template<typename Container>
 void read(istream& input, Container& destination_container)
 {
-    input.read(reinterpret_cast<char*>(destination_container.data()), destination_container.size());
+    read(input, destination_container.data(), destination_container.size());
 }
 
 
@@ -297,13 +303,14 @@ void test_too_small_output_buffer()
 void test_decode_bit_stream_with_no_marker_start()
 {
     constexpr array encoded_data{byte{0x33}, byte{0x33}};
-    array<byte, 1000> output{};
 
     error_code error;
     try
     {
         jpegls_decoder decoder;
         decoder.source(encoded_data).read_header();
+
+        array<byte, 1000> output{};
         decoder.decode(output);
     }
     catch (const jpegls_error& e)
@@ -322,13 +329,14 @@ void test_decode_bit_stream_with_unsupported_encoding()
         byte{0xFF}, byte{0xC3}, // Start Of Frame (lossless, Huffman) (JPEG_SOF_3)
         byte{0x00}, byte{0x00}  // Length of data of the marker
     };
-    array<byte, 1000> output{};
 
     error_code error;
     try
     {
         jpegls_decoder decoder;
         decoder.source(encoded_data).read_header();
+
+        array<byte, 1000> output{};
         decoder.decode(output);
     }
     catch (const jpegls_error& e)
@@ -347,13 +355,14 @@ void test_decode_bit_stream_with_unknown_jpeg_marker()
         byte{0xFF}, byte{0x01}, // Undefined marker
         byte{0x00}, byte{0x00}  // Length of data of the marker
     };
-    array<byte, 1000> output{};
 
     error_code error;
     try
     {
         jpegls_decoder decoder;
         decoder.source(encoded_data).read_header();
+
+        array<byte, 1000> output{};
         decoder.decode(output);
     }
     catch (const jpegls_error& e)

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -34,7 +34,7 @@ MSVC_WARNING_SUPPRESS(26497) // cannot be marked constexpr, check must be execut
 bool is_machine_little_endian() noexcept
 {
     constexpr int a = 0xFF000001; // NOLINT(bugprone-narrowing-conversions, cppcoreguidelines-narrowing-conversions)
-    const auto* chars{reinterpret_cast<const char*>(&a)};
+    const auto* chars{reinterpret_cast<const char*>(&a)}; //NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     return chars[0] == 0x01;
 }
 

--- a/unittest/jpeg_test_stream_writer.hpp
+++ b/unittest/jpeg_test_stream_writer.hpp
@@ -6,6 +6,7 @@
 #include "../src/jpeg_marker_code.hpp"
 #include "../src/jpegls_preset_parameters_type.hpp"
 #include "../src/util.hpp"
+#include "../src/assert.hpp"
 
 #include <vector>
 #include <array>

--- a/unittest/util_test.cpp
+++ b/unittest/util_test.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.hpp"
 
+#include "../src/assert.hpp"
 #include "../src/util.hpp"
 
 using Microsoft::VisualStudio::CppUnitTestFramework::Assert;


### PR DESCRIPTION
Newer versions of clang-tidy support a configuration format, that allows to have the rationals inline when a warning is disabled.
Switch to this configuration format and also only not all warnings, but only the standard and useful warning groups.
Many warning group are designed for a specific project and are not univeral usable.