### PR TITLE
ci: VS2019 is deprecated from standard runner

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,10 +63,10 @@ jobs:
       codeCoverageEnabled: true
       runSettingsFile: 'unittest\CodeCoverage.runsettings'
 
-- job: 'cppVS2022'
+- job: 'cppVS2026'
   pool:
-    vmImage: windows-2022
-  displayName: 'CMake - MSVC 2022'
+    vmImage: windows-2025
+  displayName: 'CMake - MSVC 2022-2025'
 
   strategy:
     matrix:
@@ -132,10 +132,10 @@ jobs:
       cmakeArgs: --build $(Build.BinariesDirectory)/build
 
 
-- job: 'cppVS2019'
+- job: 'cppVS2022'
   pool:
-    vmImage: windows-2019
-  displayName: 'CMake - MSVC 2019'
+    vmImage: windows-2022
+  displayName: 'CMake - MSVC 2022'
 
   strategy:
     matrix:
@@ -161,7 +161,7 @@ jobs:
 
   - task: BatchScript@1
     inputs:
-      filename: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+      filename: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"
       arguments: $(Architecture)
       modifyEnvironment: true
     displayName: Setup Environment Variables


### PR DESCRIPTION
VS2019 has been deprecated on the standard offered CI images. Switch to 2022. VS 2026 is not yet offered.