### PR TITLE
refactor: Build only the library target by default in CMake

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,4 +1,4 @@
-# Copyright (c) Team CharLS.
+# SPDX-FileCopyrightText: © 2023 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
 name: MSYS2
@@ -28,6 +28,10 @@ jobs:
         run: >-
           cmake
           -Bbuild
+          -DCHARLS_BUILD_TESTS=On
+          -DCHARLS_BUILD_AFL_FUZZ_TEST=On
+          -DCHARLS_BUILD_LIB_FUZZER_FUZZ_TEST=On
+          -DCHARLS_BUILD_SAMPLES=On
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_SHARED_LIBS=Off
           -DCHARLS_PEDANTIC_WARNINGS=On

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2009 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.16...4.01)
+cmake_minimum_required(VERSION 3.22...4.2)
 
 # Extract the version info from version.h
 file(READ "include/charls/version.h" version)
@@ -22,11 +22,11 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   message(STATUS "Building as main project, CMake version: ${CMAKE_VERSION}")
 endif()
 
-# The basic options to control what is build extra.
-option(CHARLS_BUILD_TESTS "Build test application" ${MAIN_PROJECT})
-option(CHARLS_BUILD_AFL_FUZZ_TEST "Build AFL test fuzzer application" ${MAIN_PROJECT})
-option(CHARLS_BUILD_LIBFUZZER_FUZZ_TEST "Build LibFuzzer test fuzzer application" ${MAIN_PROJECT})
-option(CHARLS_BUILD_SAMPLES "Build sample applications" ${MAIN_PROJECT})
+# The basic options to control what will be built besides the library.
+option(CHARLS_BUILD_TESTS "Build test application" OFF)
+option(CHARLS_BUILD_AFL_FUZZ_TEST "Build AFL test fuzzer application" OFF)
+option(CHARLS_BUILD_LIB_FUZZER_FUZZ_TEST "Build LibFuzzer test fuzzer application" OFF)
+option(CHARLS_BUILD_SAMPLES "Build sample applications" OFF)
 option(CHARLS_INSTALL "Generate the install target." ${MAIN_PROJECT})
 
 # Provide BUILD_SHARED_LIBS as an option for GUI tools
@@ -152,7 +152,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif()
 
   if(NOT APPLE)
-    set(LIBFUZZER_SUPPORTED 1)
+    set(LIB_FUZZER_SUPPORTED 1)
   endif()
 endif()
 
@@ -205,7 +205,7 @@ if(MSVC)
 
   # Enable LibFuzzer support for MSVC
   if(${ARM_DETECTED} EQUAL 0 AND MSVC_VERSION GREATER_EQUAL 1930)
-    set(LIBFUZZER_SUPPORTED 1)
+    set(LIB_FUZZER_SUPPORTED 1)
   endif()
 
 endif()
@@ -253,7 +253,7 @@ if(CHARLS_BUILD_AFL_FUZZ_TEST)
   add_subdirectory(fuzzing/afl)
 endif()
 
-if(CHARLS_BUILD_LIBFUZZER_FUZZ_TEST AND LIBFUZZER_SUPPORTED)
+if(CHARLS_BUILD_LIB_FUZZER_FUZZ_TEST AND LIB_FUZZER_SUPPORTED)
   add_subdirectory(fuzzing/libfuzzer)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The code is regularly compiled/tested on Windows and 64 bit Linux. Additionally,
 |---------------|------------------------|
 | C Version     | >= 17                  |
 | C++ Version   | >= 17                  |
-| CMake         | >= 3.16                |
+| CMake         | >= 3.22                |
 | GCC           | >= 9.1                 |
 | Clang         | >= 7.0.0               |
 | MSVC          | >= 2019                |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-# Copyright (c) Team CharLS.
+# SPDX-FileCopyrightText: © 2020 Team CharLS
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Branches that trigger a build on commit
@@ -119,6 +119,10 @@ jobs:
         -G Ninja
         -DCMAKE_C_COMPILER="cl.exe"
         -DCMAKE_CXX_COMPILER="cl.exe"
+        -DCHARLS_BUILD_TESTS=On
+        -DCHARLS_BUILD_AFL_FUZZ_TEST=On
+        -DCHARLS_BUILD_LIB_FUZZER_FUZZ_TEST=On
+        -DCHARLS_BUILD_SAMPLES=On
         -DCMAKE_BUILD_TYPE=$(buildType)
         -DBUILD_SHARED_LIBS=$(Shared)
         -DCHARLS_PEDANTIC_WARNINGS=On
@@ -174,6 +178,10 @@ jobs:
         -G Ninja
         -DCMAKE_C_COMPILER="cl.exe"
         -DCMAKE_CXX_COMPILER="cl.exe"
+        -DCHARLS_BUILD_TESTS=On
+        -DCHARLS_BUILD_AFL_FUZZ_TEST=On
+        -DCHARLS_BUILD_LIB_FUZZER_FUZZ_TEST=On
+        -DCHARLS_BUILD_SAMPLES=On
         -DCMAKE_BUILD_TYPE=$(buildType)
         -DCHARLS_PEDANTIC_WARNINGS=On
         -DCHARLS_TREAT_WARNING_AS_ERROR=On
@@ -249,6 +257,10 @@ jobs:
       workingDirectory: $(Build.BinariesDirectory)/build
       cmakeArgs:
         -DCMAKE_BUILD_TYPE=$(buildType)
+        -DCHARLS_BUILD_TESTS=On
+        -DCHARLS_BUILD_AFL_FUZZ_TEST=On
+        -DCHARLS_BUILD_LIB_FUZZER_FUZZ_TEST=On
+        -DCHARLS_BUILD_SAMPLES=On
         -DBUILD_SHARED_LIBS=$(Shared)
         -DCHARLS_PEDANTIC_WARNINGS=On
         -DCHARLS_TREAT_WARNING_AS_ERROR=On
@@ -290,6 +302,10 @@ jobs:
       workingDirectory: $(Build.BinariesDirectory)/build
       cmakeArgs:
         -DCMAKE_BUILD_TYPE=$(buildType
+        -DCHARLS_BUILD_TESTS=On
+        -DCHARLS_BUILD_AFL_FUZZ_TEST=On
+        -DCHARLS_BUILD_LIB_FUZZER_FUZZ_TEST=On
+        -DCHARLS_BUILD_SAMPLES=On
         -DBUILD_SHARED_LIBS=$(Shared)
         -DCHARLS_PEDANTIC_WARNINGS=On
         -DCHARLS_TREAT_WARNING_AS_ERROR=On


### PR DESCRIPTION
Consumers of CharLS are mainly interested in the library.  Update CMakeLists.txt for this: build by default only the library.
Update the CI build script to ensure everything is still build in the CI pipeline.