### PR TITLE
fix: Add support for WebAssembly 3.0 Memory64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,14 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   message(STATUS "Building as main project, CMake version: ${CMAKE_VERSION}")
 endif()
 
+if(EMSCRIPTEN)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(STATUS "Building for 64-bit WASM target")
+  else()
+    message(STATUS "Building for 32-bit WASM target")
+  endif()
+endif()
+
 # The basic options to control what will be built besides the library.
 option(CHARLS_BUILD_TESTS "Build test application" OFF)
 option(CHARLS_BUILD_AFL_FUZZ_TEST "Build AFL test fuzzer application" OFF)

--- a/src/span.hpp
+++ b/src/span.hpp
@@ -11,8 +11,9 @@
 namespace charls {
 
 // Replacement for C++20 std::to_address, which is not available in C++17.
-template<typename Ptr>
-constexpr auto to_address(const Ptr& it)
+template<typename T>
+[[nodiscard]]
+constexpr auto to_address(const T& it)
 {
     return &*it;
 }


### PR DESCRIPTION
Add a missing specialization to make it possible to compile CharLS into a WASM64 module.