### PR TITLE
perf: Merge Golomb code writes into single append_to_bit_stream call

### DIFF
--- a/src/scan_encoder_impl.hpp
+++ b/src/scan_encoder_impl.hpp
@@ -289,8 +289,16 @@ private:
                 append_to_bit_stream(0, high_bits / 2);
                 high_bits = high_bits - high_bits / 2;
             }
-            append_to_bit_stream(1, high_bits + 1);
-            append_to_bit_stream(static_cast<uint32_t>(mapped_error & ((1 << k) - 1)), k);
+            if (const int32_t total_bits{high_bits + 1 + k}; total_bits < 32)
+            {
+                // Merge unary prefix (high_bits zeros + 1) and k-bit remainder into a single call.
+                append_to_bit_stream((1U << k) | static_cast<uint32_t>(mapped_error & ((1 << k) - 1)), total_bits);
+            }
+            else
+            {
+                append_to_bit_stream(1, high_bits + 1);
+                append_to_bit_stream(static_cast<uint32_t>(mapped_error & ((1 << k) - 1)), k);
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary

In `encode_mapped_value()`, the Golomb code is written as two separate calls to `append_to_bit_stream`: first the unary prefix (`high_bits` zeros + 1), then the k-bit binary remainder. When `total_bits = high_bits + 1 + k < 32`, these can be merged into a single call.

The merged value `(1U << k) | (mapped_error & ((1 << k) - 1))` placed in `total_bits` width produces the identical bit pattern:
- Upper `high_bits` bits: zeros (unary prefix)
- Bit at position k: 1 (unary terminator)
- Lower k bits: error remainder

The guard `total_bits < 32` ensures the `append_to_bit_stream` precondition (`bit_count < 32`) is met. For edge cases with high bit depths where `high_bits + k >= 31`, the original two-call path is used.

## Safety

This produces bit-identical output — the merged value is a mathematical rearrangement of the two-call sequence. This can be verified by construction: the bit pattern `[high_bits zeros][1][k remainder bits]` is the same whether written as one or two calls. No platform-specific code or intrinsics are used, only standard C++ integer arithmetic on `uint32_t`.

## Performance

Measured on 7680×4320 12-bit mono (10 iterations, median):

| Platform | Before | After | Δ |
|----------|--------|-------|---|
| x86 Ryzen 9 9950X (GCC 14) | 473 ms | 447 ms | -5.5% |
| ARM Apple Silicon (Apple Clang 17) | 428 ms | 402 ms | -6.1% |

Decoder performance unchanged (encoder-only change).