### PR TITLE
perf: Add CLZ-based Golomb parameter computation for encoder

### DIFF
--- a/src/scan_encoder_impl.hpp
+++ b/src/scan_encoder_impl.hpp
@@ -268,7 +268,7 @@ private:
     {
         const int32_t sign{bit_wise_sign(qs)};
         regular_mode_context& context{regular_mode_contexts_[apply_sign_for_index(qs, sign)]};
-        const int32_t k{context.compute_golomb_coding_parameter()};
+        const int32_t k{context.compute_golomb_coding_parameter_for_encoder()};
         const int32_t predicted_value{traits_.correct_prediction(predicted + apply_sign(context.c(), sign))};
         const int32_t error_value{traits_.compute_error_value(apply_sign(x - predicted_value, sign))};
 


### PR DESCRIPTION
## Summary

Adds `compute_golomb_coding_parameter_for_encoder()` to `regular_mode_context` that computes the Golomb coding parameter k in O(1) using the existing `countl_zero` implementation from `util.hpp`, instead of the linear loop.

Only the encoder's `encode_regular()` calls this new method. The decoder retains the original loop-based `compute_golomb_coding_parameter()`.

### Why separate methods?

The decoder and encoder have different microarchitectural profiles for this computation:

- **Decoder**: k feeds directly into variable-length bit reads on the critical latency path. The branch predictor can speculate on k (it changes slowly between adjacent pixels), effectively overlapping the loop with subsequent stream reads. Replacing the loop with CLZ introduces a non-speculative data dependency chain (`lzcnt → sub → max → cmp`) that serializes the pipeline, causing a measurable decode regression.

- **Encoder**: k is not on the critical latency path — `encode_mapped_value()` follows with bit-write operations that are less latency-sensitive. The CLZ approach provides better throughput here.

### Algorithm

```cpp
k = max(0, countl_zero(n) - countl_zero(a));
if (n << k < a) ++k;
```

This computes `ceil(log2(a/n))`. The CLZ difference approximates `floor(log2(a/n))`, and the single correction step handles all cases where a and n are not exact powers of two.

## Safety

- The `countl_zero` function is already implemented in `util.hpp` for MSVC (`_BitScanReverse`), GCC/Clang (`__builtin_clz`), and WASM (Emscripten/Clang). Zero inputs return 32.
- `n_` is always ≥ 1 (initialized to 1, only incremented). `a_` is always ≥ 1 (from `initialization_value_for_a`).
- The error check uses `k >= max_k_value` (more defensive than the loop's `k == max_k_value`).
- The decoder is completely untouched.

## Performance

Measured on 7680×4320 12-bit mono, combined with the other two encoder optimizations (10 iterations, median):

| Platform | Before (all opts) | After (+CLZ) | Δ Encode | Δ Decode |
|----------|-------------------|--------------|----------|----------|
| x86 Ryzen 9 9950X (GCC 14) | 426 ms | 366 ms | -14.1% | +0.5% (noise) |
| ARM Apple Silicon (Apple Clang 17) | 341 ms | 278 ms | -18.5% | -1.1% (noise) |