### PR TITLE
chores: The charls project should include its headers with double quotes

### DIFF
--- a/src/charls.rc
+++ b/src/charls.rc
@@ -3,7 +3,7 @@
 
 #pragma code_page(65001)
 
-#include <charls/version.h>
+#include "charls/version.h"
 
 #include <winresrc.h>
 

--- a/src/charls_jpegls_decoder.cpp
+++ b/src/charls_jpegls_decoder.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.hpp"
 
-#include <charls/charls_jpegls_decoder.h>
+#include "charls/charls_jpegls_decoder.h"
 
 #include "constants.hpp"
 #include "jpeg_stream_reader.hpp"

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -3,8 +3,8 @@
 
 #include "pch.hpp"
 
-#include <charls/charls_jpegls_encoder.h>
-#include <charls/version.hpp>
+#include "charls/charls_jpegls_encoder.h"
+#include "charls/version.hpp"
 
 #include "color_transform.hpp"
 #include "jpeg_stream_writer.hpp"

--- a/src/coding_parameters.hpp
+++ b/src/coding_parameters.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <charls/public_types.h>
+#include "charls/public_types.h"
 
 namespace charls {
 

--- a/src/jpeg_stream_reader.hpp
+++ b/src/jpeg_stream_reader.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <charls/public_types.h>
+#include "charls/public_types.h"
 
 #include "coding_parameters.hpp"
 #include "span.hpp"

--- a/src/jpeg_stream_writer.hpp
+++ b/src/jpeg_stream_writer.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <charls/jpegls_error.hpp>
+#include "charls/jpegls_error.hpp"
 
 #include "constants.hpp"
 #include "jpeg_marker_code.hpp"

--- a/src/jpegls_error.cpp
+++ b/src/jpegls_error.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.hpp"
 
-#include <charls/jpegls_error.hpp>
+#include "charls/jpegls_error.hpp"
 
 namespace charls {
 

--- a/src/jpegls_preset_coding_parameters.hpp
+++ b/src/jpegls_preset_coding_parameters.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <charls/public_types.h>
+#include "charls/public_types.h"
 
 #include "jpegls_algorithm.hpp"
 #include "assert.hpp"

--- a/src/quantization_lut.cpp
+++ b/src/quantization_lut.cpp
@@ -5,7 +5,7 @@
 
 #include "quantization_lut.hpp"
 
-#include <charls/public_types.h>
+#include "charls/public_types.h"
 
 #include "jpegls_algorithm.hpp"
 #include "jpegls_preset_coding_parameters.hpp"

--- a/src/scan_decoder.hpp
+++ b/src/scan_decoder.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <charls/jpegls_error.hpp>
+#include "charls/jpegls_error.hpp"
 
 #include "assert.hpp"
 #include "copy_from_line_buffer.hpp"

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <charls/jpegls_error.hpp>
+#include "charls/jpegls_error.hpp"
 
 #include "span.hpp"
 

--- a/src/validate_spiff_header.cpp
+++ b/src/validate_spiff_header.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.hpp"
 
-#include <charls/validate_spiff_header.h>
+#include "charls/validate_spiff_header.h"
 
 #include "util.hpp"
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.hpp"
 
-#include <charls/version.hpp>
+#include "charls/version.hpp"
 
 #include "util.hpp"
 


### PR DESCRIPTION
C++ provides 2 options to include headers. While <> makes sense as the public headers are in a different folder, many checking tools see headers included with angle brackets as system files and won't check them.