### PR TITLE
fix: Prevent encoding/decoding with unsupported color transformation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Support to retrieve the height from a DNL marker segment.
 - Support to encode and decode mixed interleaved mode scans.
 - The unit tests are now based on Google test instead of MSTest and can be used on all platforms.
+- Additional checks when encoding/decoding color transformation. Only 3 components, 8/16 bits per sample, lossless and interleave mode line/sample are supported.
 
 ### Fixed
 

--- a/charls.sln.DotSettings
+++ b/charls.sln.DotSettings
@@ -85,6 +85,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CHARLS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmove/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmyk/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=COLORXFORM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=comparepnm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=countl/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cpixel/@EntryIndexedValue">True</s:Boolean>

--- a/include/charls/public_types.h
+++ b/include/charls/public_types.h
@@ -586,6 +586,7 @@ using encoding_options = encoding_options_private::encoding_options;
 /// These color space transformation decrease the correlation between the 3 color components, resulting in better encoding
 /// ratio. These options are only implemented for backwards compatibility and NOT part of the JPEG-LS standard. The JPEG-LS
 /// ISO/IEC 14495-1:1999 standard provides no capabilities to transport which color space transformation was used.
+/// Color transformations are only supported for 3 component images with 8 or 16 bits per sample in lossless mode and not planar.
 /// </summary>
 enum class color_transformation : std::int32_t
 {

--- a/spelling.dic
+++ b/spelling.dic
@@ -11,6 +11,7 @@ charls
 charlstest
 choco
 cmove
+COLORXFORM
 countl
 cppcoreguidelines
 ctest

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -391,8 +391,7 @@ private:
         if (color_transformation_ == color_transformation::none)
             return;
 
-        if (UNLIKELY(!color_transformation_possible(frame_info_) || near_lossless_ != 0 ||
-                     interleave_mode_ == interleave_mode::none))
+        if (UNLIKELY(!color_transformation_possible(frame_info_, near_lossless_, interleave_mode_)))
             throw_jpegls_error(jpegls_errc::invalid_argument_color_transformation);
 
         writer_.write_color_transform_segment(color_transformation_);

--- a/src/charls_jpegls_encoder.cpp
+++ b/src/charls_jpegls_encoder.cpp
@@ -105,8 +105,8 @@ struct charls_jpegls_encoder final
     {
         check_operation(is_frame_info_configured());
         size_t size{checked_mul(checked_mul(checked_mul(frame_info_.width, frame_info_.height),
-                                                    static_cast<size_t>(frame_info_.component_count)),
-                                        bit_to_byte_count(frame_info_.bits_per_sample))};
+                                            static_cast<size_t>(frame_info_.component_count)),
+                                bit_to_byte_count(frame_info_.bits_per_sample))};
 
         // For the worst case: add 6.25% + extra bytes for the headers.
         size = add_sat(size, (size / 16U) + 1024 + spiff_header_size_in_bytes);
@@ -391,7 +391,8 @@ private:
         if (color_transformation_ == color_transformation::none)
             return;
 
-        if (UNLIKELY(!color_transformation_possible(frame_info_)))
+        if (UNLIKELY(!color_transformation_possible(frame_info_) || near_lossless_ != 0 ||
+                     interleave_mode_ == interleave_mode::none))
             throw_jpegls_error(jpegls_errc::invalid_argument_color_transformation);
 
         writer_.write_color_transform_segment(color_transformation_);

--- a/src/color_transform.hpp
+++ b/src/color_transform.hpp
@@ -16,7 +16,7 @@ inline bool color_transformation_possible(const frame_info& frame) noexcept
 // They are used to convert between decoded values and the internal line buffers.
 // Color transforms work best for computer generated images, but are outside the official JPEG-LS specifications.
 
-// COLORXFORM_HP1 :
+// COLORXFORM_HP1:
 // G = G
 // R = R - G
 // B = B - G
@@ -27,7 +27,7 @@ struct transform_hp1 final
 
     using sample_type = SampleType;
 
-    FORCE_INLINE triplet<SampleType> operator()(const int red, const int green, const int blue) const noexcept
+    FORCE_INLINE triplet<SampleType> operator()(const int32_t red, const int32_t green, const int32_t blue) const noexcept
     {
         return {static_cast<SampleType>(red - green + bias), static_cast<SampleType>(green),
                 static_cast<SampleType>(blue - green + bias)};
@@ -35,19 +35,19 @@ struct transform_hp1 final
 
     struct inverse final
     {
-        FORCE_INLINE triplet<SampleType> operator()(const int v1, const int v2, const int v3) const noexcept
+        FORCE_INLINE triplet<SampleType> operator()(const int32_t v1, const int32_t v2, const int32_t v3) const noexcept
         {
-            return {static_cast<SampleType>(std::clamp(v1 + v2 - bias, 0, range - 1)), static_cast<SampleType>(v2),
-                    static_cast<SampleType>(std::clamp(v3 + v2 - bias, 0, range - 1))};
+            return {static_cast<SampleType>(v1 + v2 - bias), static_cast<SampleType>(v2),
+                    static_cast<SampleType>(v3 + v2 - bias)};
         }
     };
 
 private:
-    static constexpr int range{1 << (sizeof(SampleType) * 8)};
-    static constexpr int bias{range / 2};
+    static constexpr int32_t range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int32_t bias{range / 2};
 };
 
-// COLORXFORM_HP2 :
+// COLORXFORM_HP2:
 // G = G
 // B = B - (R + G) / 2
 // R = R - G
@@ -58,28 +58,32 @@ struct transform_hp2 final
 
     using sample_type = SampleType;
 
-    FORCE_INLINE triplet<SampleType> operator()(const int red, const int green, const int blue) const noexcept
+    FORCE_INLINE triplet<SampleType> operator()(const int32_t red, const int32_t green, const int32_t blue) const noexcept
     {
         return {static_cast<SampleType>(red - green + bias), static_cast<SampleType>(green),
-                static_cast<SampleType>(blue - ((red + green) / 2) - bias)}; // TODO: fix -> - to +?
+                static_cast<SampleType>(blue - ((red + green) / 2) + bias)};
     }
 
     struct inverse final
     {
-        FORCE_INLINE triplet<SampleType> operator()(const int v1, const int v2, const int v3) const noexcept
+        FORCE_INLINE triplet<SampleType> operator()(const int32_t v1, const int32_t v2, const int32_t v3) const noexcept
         {
-            const auto r{v1 + v2 - bias};
-            return {static_cast<SampleType>(std::clamp(r, 0, range - 1)), static_cast<SampleType>(v2),
-                    static_cast<SampleType>(std::clamp(v3 + ((r + v2) >> 1) - bias, 0, range - 1))};
+            const auto r{static_cast<SampleType>(v1 + v2 - bias)};
+            return {r, static_cast<SampleType>(v2),
+                    static_cast<SampleType>(v3 + ((r + static_cast<SampleType>(v2)) >> 1) - bias)};
         }
     };
 
 private:
-    static constexpr int range{1 << (sizeof(SampleType) * 8)};
-    static constexpr int bias{range / 2};
+    static constexpr int32_t range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int32_t bias{range / 2};
 };
 
 
+// COLORXFORM_HP3: (a lossless version of Y-Cb-Crm)
+// R = R - G
+// B = B - G
+// G = G + (R + B) / 4
 template<typename SampleType>
 struct transform_hp3 final
 {
@@ -87,27 +91,28 @@ struct transform_hp3 final
 
     using sample_type = SampleType;
 
-    FORCE_INLINE triplet<SampleType> operator()(const int red, const int green, const int blue) const noexcept
+    FORCE_INLINE triplet<SampleType> operator()(const int32_t red, const int32_t green, const int32_t blue) const noexcept
     {
-        const auto v2{static_cast<SampleType>(blue - green + range / 2)};
-        const auto v3{static_cast<SampleType>(red - green + range / 2)};
+        const auto v2{static_cast<SampleType>(blue - green + bias)};
+        const auto v3{static_cast<SampleType>(red - green + bias)};
 
-        return {static_cast<SampleType>(green + ((v2 + v3) >> 2) - range / 4),
-                static_cast<SampleType>(blue - green + range / 2), static_cast<SampleType>(red - green + range / 2)};
+        return {static_cast<SampleType>(green + ((v2 + v3) >> 2) - range / 4), static_cast<SampleType>(blue - green + bias),
+                static_cast<SampleType>(red - green + bias)};
     }
 
     struct inverse final
     {
-        FORCE_INLINE triplet<SampleType> operator()(const int v1, const int v2, const int v3) const noexcept
+        FORCE_INLINE triplet<SampleType> operator()(const int32_t v1, const int32_t v2, const int32_t v3) const noexcept
         {
-            const auto g{static_cast<int>(v1 - ((v3 + v2) >> 2) + range / 4)};
-            return {static_cast<SampleType>(v3 + g - range / 2), static_cast<SampleType>(g),
-                    static_cast<SampleType>(v2 + g - range / 2)};
+            const auto g{v1 - ((v3 + v2) >> 2) + range / 4};
+            return {static_cast<SampleType>(v3 + g - bias), static_cast<SampleType>(g),
+                    static_cast<SampleType>(v2 + g - bias)};
         }
     };
 
 private:
-    static constexpr size_t range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int32_t range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int32_t bias{range / 2};
 };
 
 } // namespace charls

--- a/src/color_transform.hpp
+++ b/src/color_transform.hpp
@@ -7,9 +7,11 @@
 
 namespace charls {
 
-inline bool color_transformation_possible(const frame_info& frame) noexcept
+inline bool color_transformation_possible(const frame_info& frame, const int32_t near_lossless,
+                                          const interleave_mode mode) noexcept
 {
-    return frame.component_count == 3 && (frame.bits_per_sample == 8 || frame.bits_per_sample == 16);
+    return frame.component_count == 3 && (frame.bits_per_sample == 8 || frame.bits_per_sample == 16) && near_lossless == 0 &&
+           mode != interleave_mode::none;
 }
 
 // This file defines simple classes that define (lossless) color transforms.

--- a/src/color_transform.hpp
+++ b/src/color_transform.hpp
@@ -7,6 +7,7 @@
 
 namespace charls {
 
+[[nodiscard]]
 inline bool color_transformation_possible(const frame_info& frame, const int32_t near_lossless,
                                           const interleave_mode mode) noexcept
 {
@@ -82,7 +83,7 @@ private:
 };
 
 
-// COLORXFORM_HP3: (a lossless version of Y-Cb-Crm)
+// COLORXFORM_HP3: (a lossless version of Y-Cb-Cr)
 // R = R - G
 // B = B - G
 // G = G + (R + B) / 4
@@ -97,9 +98,7 @@ struct transform_hp3 final
     {
         const auto v2{static_cast<SampleType>(blue - green + bias)};
         const auto v3{static_cast<SampleType>(red - green + bias)};
-
-        return {static_cast<SampleType>(green + ((v2 + v3) >> 2) - range / 4), static_cast<SampleType>(blue - green + bias),
-                static_cast<SampleType>(red - green + bias)};
+        return {static_cast<SampleType>(green + ((v2 + v3) >> 2) - range / 4), v2, v3};
     }
 
     struct inverse final

--- a/src/color_transform.hpp
+++ b/src/color_transform.hpp
@@ -16,7 +16,10 @@ inline bool color_transformation_possible(const frame_info& frame) noexcept
 // They are used to convert between decoded values and the internal line buffers.
 // Color transforms work best for computer generated images, but are outside the official JPEG-LS specifications.
 
-
+// COLORXFORM_HP1 :
+// G = G
+// R = R - G
+// B = B - G
 template<typename SampleType>
 struct transform_hp1 final
 {
@@ -26,22 +29,28 @@ struct transform_hp1 final
 
     FORCE_INLINE triplet<SampleType> operator()(const int red, const int green, const int blue) const noexcept
     {
-        return {static_cast<SampleType>(red - green + range / 2), static_cast<SampleType>(green), static_cast<SampleType>(blue - green + range / 2)};
+        return {static_cast<SampleType>(red - green + bias), static_cast<SampleType>(green),
+                static_cast<SampleType>(blue - green + bias)};
     }
 
     struct inverse final
     {
         FORCE_INLINE triplet<SampleType> operator()(const int v1, const int v2, const int v3) const noexcept
         {
-            return {static_cast<SampleType>(v1 + v2 - range / 2), static_cast<SampleType>(v2), static_cast<SampleType>(v3 + v2 - range / 2)};
+            return {static_cast<SampleType>(std::clamp(v1 + v2 - bias, 0, range - 1)), static_cast<SampleType>(v2),
+                    static_cast<SampleType>(std::clamp(v3 + v2 - bias, 0, range - 1))};
         }
     };
 
 private:
-    static constexpr size_t range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int bias{range / 2};
 };
 
-
+// COLORXFORM_HP2 :
+// G = G
+// B = B - (R + G) / 2
+// R = R - G
 template<typename SampleType>
 struct transform_hp2 final
 {
@@ -51,21 +60,23 @@ struct transform_hp2 final
 
     FORCE_INLINE triplet<SampleType> operator()(const int red, const int green, const int blue) const noexcept
     {
-        return {static_cast<SampleType>(red - green + range / 2), static_cast<SampleType>(green),
-                static_cast<SampleType>(blue - ((red + green) >> 1) - range / 2)};
+        return {static_cast<SampleType>(red - green + bias), static_cast<SampleType>(green),
+                static_cast<SampleType>(blue - ((red + green) / 2) - bias)}; // TODO: fix -> - to +?
     }
 
     struct inverse final
     {
         FORCE_INLINE triplet<SampleType> operator()(const int v1, const int v2, const int v3) const noexcept
         {
-            const auto r{static_cast<SampleType>(v1 + v2 - range / 2)};
-            return {r, static_cast<SampleType>(v2), static_cast<SampleType>(v3 + ((r + static_cast<SampleType>(v2)) >> 1) - range / 2)};
+            const auto r{v1 + v2 - bias};
+            return {static_cast<SampleType>(std::clamp(r, 0, range - 1)), static_cast<SampleType>(v2),
+                    static_cast<SampleType>(std::clamp(v3 + ((r + v2) >> 1) - bias, 0, range - 1))};
         }
     };
 
 private:
-    static constexpr size_t range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int range{1 << (sizeof(SampleType) * 8)};
+    static constexpr int bias{range / 2};
 };
 
 
@@ -81,8 +92,8 @@ struct transform_hp3 final
         const auto v2{static_cast<SampleType>(blue - green + range / 2)};
         const auto v3{static_cast<SampleType>(red - green + range / 2)};
 
-        return {static_cast<SampleType>(green + ((v2 + v3) >> 2) - range / 4), static_cast<SampleType>(blue - green + range / 2),
-                static_cast<SampleType>(red - green + range / 2)};
+        return {static_cast<SampleType>(green + ((v2 + v3) >> 2) - range / 4),
+                static_cast<SampleType>(blue - green + range / 2), static_cast<SampleType>(red - green + range / 2)};
     }
 
     struct inverse final
@@ -90,7 +101,8 @@ struct transform_hp3 final
         FORCE_INLINE triplet<SampleType> operator()(const int v1, const int v2, const int v3) const noexcept
         {
             const auto g{static_cast<int>(v1 - ((v3 + v2) >> 2) + range / 4)};
-            return {static_cast<SampleType>(v3 + g - range / 2), static_cast<SampleType>(g), static_cast<SampleType>(v2 + g - range / 2)};
+            return {static_cast<SampleType>(v3 + g - range / 2), static_cast<SampleType>(g),
+                    static_cast<SampleType>(v2 + g - range / 2)};
         }
     };
 

--- a/src/jpeg_stream_reader.cpp
+++ b/src/jpeg_stream_reader.cpp
@@ -878,7 +878,8 @@ void jpeg_stream_reader::check_width() const
 
 void jpeg_stream_reader::check_coding_parameters() const
 {
-    if (parameters_.transformation != color_transformation::none && !color_transformation_possible(frame_info_))
+    if (parameters_.transformation != color_transformation::none &&
+        !color_transformation_possible(frame_info_, get_near_lossless(0), get_interleave_mode(0)))
         throw_jpegls_error(jpegls_errc::invalid_parameter_color_transformation);
 }
 

--- a/test/charls_jpegls_encoder_test.cpp
+++ b/test/charls_jpegls_encoder_test.cpp
@@ -5,14 +5,12 @@
 
 #include "support.hpp"
 
-#include <charls/charls.hpp>
+#include "charls/charls_jpegls_encoder.h"
 
 #include <array>
 
 using std::array;
 using std::byte;
-using std::ignore;
-using std::vector;
 
 MSVC_WARNING_SUPPRESS(6387) // '_Param_(x)' could be '0': this does not adhere to the specification for the function.
 
@@ -248,30 +246,6 @@ TEST(charls_jpegls_encoder_test, create_tables_only_null_ptr)
 {
     const auto error{charls_jpegls_encoder_create_abbreviated_format(nullptr)};
     EXPECT_EQ(jpegls_errc::invalid_argument, error);
-}
-
-TEST(charls_jpegls_encoder_test, encode_non_8_or_16_bit_with_color_transformation_throws)
-{
-    constexpr frame_info frame_info{2, 1, 10, 3};
-    jpegls_encoder encoder;
-
-    vector<byte> destination(40);
-    encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
-    const vector<byte> source(20);
-    assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
-                            [&encoder, &source] { ignore = encoder.encode(source); });
-}
-
-TEST(charls_jpegls_encoder_test, encode_non_3_components_that_is_not_supported_throws)
-{
-    constexpr frame_info frame_info{2, 1, 8, 4};
-    jpegls_encoder encoder;
-
-    vector<byte> destination(40);
-    encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp3);
-    const vector<byte> source(20);
-    assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
-                            [&encoder, &source] { ignore = encoder.encode(source); });
 }
 
 } // namespace charls::test

--- a/test/color_transform_test.cpp
+++ b/test/color_transform_test.cpp
@@ -90,7 +90,7 @@ TEST(color_transform_test, transform_hp2_round_trip_near_lossless_8)
 
     sample.v1 -= 8;
 
-    // The color transformation require that the encoding is lossless, otherwise they will fail.
+    // The color transformation requires that the encoding is lossless, otherwise they will fail.
     // Clamping the values, would make some transformations work, but cause other transformations to fail.
     constexpr transform_hp2<uint8_t>::inverse inverse{};
     const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};

--- a/test/color_transform_test.cpp
+++ b/test/color_transform_test.cpp
@@ -30,9 +30,9 @@ TEST(color_transform_test, transform_hp1_round_trip)
 
                 const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
 
-                EXPECT_TRUE(static_cast<uint8_t>(red) == round_trip.v1);
-                EXPECT_TRUE(static_cast<uint8_t>(green) == round_trip.v2);
-                EXPECT_TRUE(static_cast<uint8_t>(blue) == round_trip.v3);
+                ASSERT_EQ(static_cast<uint8_t>(red), round_trip.v1);
+                ASSERT_EQ(static_cast<uint8_t>(green), round_trip.v2);
+                ASSERT_EQ(static_cast<uint8_t>(blue), round_trip.v3);
             }
         }
     }
@@ -57,20 +57,54 @@ TEST(color_transform_test, transform_hp2_round_trip)
 
                 const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
 
-                EXPECT_TRUE(static_cast<uint8_t>(red) == round_trip.v1);
-                EXPECT_TRUE(static_cast<uint8_t>(green) == round_trip.v2);
-                EXPECT_TRUE(static_cast<uint8_t>(blue) == round_trip.v3);
+                ASSERT_EQ(static_cast<uint8_t>(red), round_trip.v1);
+                ASSERT_EQ(static_cast<uint8_t>(green), round_trip.v2);
+                ASSERT_EQ(static_cast<uint8_t>(blue), round_trip.v3);
             }
         }
     }
+}
+
+TEST(color_transform_test, transform_hp2_neutral_grey)
+{
+    constexpr int red{128};
+    constexpr int green{128};
+    constexpr int blue{128};
+
+    constexpr transform_hp2<uint8_t> transform{};
+    const auto sample{transform(red, green, blue)};
+
+    ASSERT_EQ(static_cast<uint8_t>(red), sample.v1);
+    ASSERT_EQ(static_cast<uint8_t>(green), sample.v2);
+    ASSERT_EQ(static_cast<uint8_t>(blue), sample.v3);
+}
+
+TEST(color_transform_test, transform_hp2_round_trip_near_lossless_8)
+{
+    constexpr int red{};
+    constexpr int green{};
+    constexpr int blue{};
+
+    constexpr transform_hp2<uint8_t> transform{};
+    auto sample{transform(red, green, blue)};
+
+    sample.v1 -= 8;
+
+    // The color transformation require that the encoding is lossless, otherwise they will fail.
+    // Clamping the values, would make some transformations work, but cause other transformations to fail.
+    constexpr transform_hp2<uint8_t>::inverse inverse{};
+    const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
+    ASSERT_NE(static_cast<uint8_t>(red), round_trip.v1);
+    ASSERT_EQ(static_cast<uint8_t>(green), round_trip.v2);
+    ASSERT_NE(static_cast<uint8_t>(blue), round_trip.v3);
 }
 
 TEST(color_transform_test, transform_hp3_round_trip)
 {
     // For the normal unit test keep the range small for a quick test.
     // For a complete test which will take a while set the start and end to 0 and 256.
-    constexpr uint8_t start_value{123};
-    constexpr uint8_t end_value{124};
+    constexpr int start_value{123};
+    constexpr int end_value{124};
 
     for (int red{start_value}; red != end_value; ++red)
     {
@@ -83,12 +117,33 @@ TEST(color_transform_test, transform_hp3_round_trip)
                 constexpr transform_hp3<uint8_t>::inverse inverse{};
                 const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
 
-                EXPECT_TRUE(static_cast<uint8_t>(red) == round_trip.v1);
-                EXPECT_TRUE(static_cast<uint8_t>(green) == round_trip.v2);
-                EXPECT_TRUE(static_cast<uint8_t>(blue) == round_trip.v3);
+                ASSERT_EQ(static_cast<uint8_t>(red), round_trip.v1);
+                ASSERT_EQ(static_cast<uint8_t>(green), round_trip.v2);
+                ASSERT_EQ(static_cast<uint8_t>(blue), round_trip.v3);
             }
         }
     }
+}
+
+TEST(color_transform_test, transform_hp3_sample_values_from_appendix_f)
+{
+    // ISO/IEC 14495-2:2003 appendix F.2: contains a sample transformation of the RCT
+    constexpr int red{200};
+    constexpr int green{10};
+    constexpr int blue{55};
+
+    constexpr transform_hp3<uint8_t> transform{};
+    const auto sample{transform(red, green, blue)};
+
+    ASSERT_EQ(static_cast<uint8_t>(4), sample.v1);
+    ASSERT_EQ(static_cast<uint8_t>(173), sample.v2);
+    ASSERT_EQ(static_cast<uint8_t>(62), sample.v3);
+
+    constexpr transform_hp3<uint8_t>::inverse inverse{};
+    const auto round_trip{inverse(sample.v1, sample.v2, sample.v3)};
+    ASSERT_EQ(static_cast<uint8_t>(red), round_trip.v1);
+    ASSERT_EQ(static_cast<uint8_t>(green), round_trip.v2);
+    ASSERT_EQ(static_cast<uint8_t>(blue), round_trip.v3);
 }
 
 TEST(color_transform_test, hp_transformation_sample_images)

--- a/test/jpeg_stream_reader_test.cpp
+++ b/test/jpeg_stream_reader_test.cpp
@@ -73,7 +73,7 @@ void read_hp_color_transform(const color_transformation transformation)
     writer.write_start_of_image();
     writer.write_hp_color_transform_segment(transformation);
     writer.write_start_of_frame_segment(512, 512, 8, 3);
-    writer.write_start_of_scan_segment(0, 1, 0, interleave_mode::none);
+    writer.write_start_of_scan_segment(0, 3, 0, interleave_mode::sample);
 
     jpeg_stream_reader reader;
     reader.source({writer.buffer.data(), writer.buffer.size()});
@@ -948,12 +948,13 @@ TEST(jpeg_stream_reader_test, read_hp_color_transform_two_color_segments_present
     writer.write_hp_color_transform_segment(color_transformation::hp1);
     writer.write_start_of_frame_segment(512, 512, 8, 3);
     writer.write_hp_color_transform_segment(color_transformation::hp2);
-    writer.write_start_of_scan_segment(0, 1, 0, interleave_mode::none);
+    writer.write_start_of_scan_segment(0, 3, 0, interleave_mode::line);
 
     jpeg_stream_reader reader;
     reader.source({writer.buffer.data(), writer.buffer.size()});
     reader.read_header();
 
+    // Follow the common pattern that the last marker segment wins.
     EXPECT_EQ(color_transformation::hp2, reader.parameters().transformation);
 }
 

--- a/test/jpegls_decoder_test.cpp
+++ b/test/jpegls_decoder_test.cpp
@@ -1500,7 +1500,7 @@ TEST(jpegls_decoder_test, read_header_lossy_with_color_transformation_throws)
     jpeg_test_stream_writer writer;
     writer.write_start_of_image();
     writer.write_hp_color_transform_segment(color_transformation::hp1);
-    writer.write_start_of_frame_segment(1, 1, 8, 4);
+    writer.write_start_of_frame_segment(1, 1, 8, 3);
     writer.write_start_of_scan_segment(0, 3, 1, interleave_mode::sample);
 
     jpegls_decoder decoder{writer.buffer, false};
@@ -1513,8 +1513,8 @@ TEST(jpegls_decoder_test, read_header_interleave_mode_none_with_color_transforma
     jpeg_test_stream_writer writer;
     writer.write_start_of_image();
     writer.write_hp_color_transform_segment(color_transformation::hp1);
-    writer.write_start_of_frame_segment(1, 1, 8, 4);
-    writer.write_start_of_scan_segment(0, 3, 0, interleave_mode::none);
+    writer.write_start_of_frame_segment(1, 1, 8, 3);
+    writer.write_start_of_scan_segment(0, 1, 0, interleave_mode::none);
 
     jpegls_decoder decoder{writer.buffer, false};
 

--- a/test/jpegls_decoder_test.cpp
+++ b/test/jpegls_decoder_test.cpp
@@ -1482,4 +1482,43 @@ TEST(jpegls_decoder_test, read_header_non_8_or_16_bit_with_color_transformation_
     assert_expect_exception(jpegls_errc::invalid_parameter_color_transformation, [&decoder] { decoder.read_header(); });
 }
 
+TEST(jpegls_decoder_test, read_header_4_components_with_color_transformation_throws)
+{
+    jpeg_test_stream_writer writer;
+    writer.write_start_of_image();
+    writer.write_hp_color_transform_segment(color_transformation::hp1);
+    writer.write_start_of_frame_segment(1, 1, 8, 4);
+    writer.write_start_of_scan_segment(0, 4, 0, interleave_mode::sample);
+
+    jpegls_decoder decoder{writer.buffer, false};
+
+    assert_expect_exception(jpegls_errc::invalid_parameter_color_transformation, [&decoder] { decoder.read_header(); });
+}
+
+TEST(jpegls_decoder_test, read_header_lossy_with_color_transformation_throws)
+{
+    jpeg_test_stream_writer writer;
+    writer.write_start_of_image();
+    writer.write_hp_color_transform_segment(color_transformation::hp1);
+    writer.write_start_of_frame_segment(1, 1, 8, 4);
+    writer.write_start_of_scan_segment(0, 3, 1, interleave_mode::sample);
+
+    jpegls_decoder decoder{writer.buffer, false};
+
+    assert_expect_exception(jpegls_errc::invalid_parameter_color_transformation, [&decoder] { decoder.read_header(); });
+}
+
+TEST(jpegls_decoder_test, read_header_interleave_mode_none_with_color_transformation_throws)
+{
+    jpeg_test_stream_writer writer;
+    writer.write_start_of_image();
+    writer.write_hp_color_transform_segment(color_transformation::hp1);
+    writer.write_start_of_frame_segment(1, 1, 8, 4);
+    writer.write_start_of_scan_segment(0, 3, 0, interleave_mode::none);
+
+    jpegls_decoder decoder{writer.buffer, false};
+
+    assert_expect_exception(jpegls_errc::invalid_parameter_color_transformation, [&decoder] { decoder.read_header(); });
+}
+
 } // namespace charls::test

--- a/test/jpegls_encoder_test.cpp
+++ b/test/jpegls_encoder_test.cpp
@@ -2042,7 +2042,7 @@ TEST(jpegls_encoder_test, encode_to_buffer_with_uint16_size_works)
     }
 }
 
-TEST(charls_jpegls_encoder_test, encode_non_8_or_16_bit_with_color_transformation_throws)
+TEST(jpegls_encoder_test, encode_non_8_or_16_bit_with_color_transformation_throws)
 {
     constexpr frame_info frame_info{2, 1, 10, 3};
     jpegls_encoder encoder;
@@ -2057,7 +2057,7 @@ TEST(charls_jpegls_encoder_test, encode_non_8_or_16_bit_with_color_transformatio
                             [&encoder, &source] { ignore = encoder.encode(source); });
 }
 
-TEST(charls_jpegls_encoder_test, encode_non_3_components_with_color_transformations_throws)
+TEST(jpegls_encoder_test, encode_non_3_components_with_color_transformations_throws)
 {
     constexpr frame_info frame_info{2, 1, 8, 4};
     jpegls_encoder encoder;
@@ -2072,7 +2072,7 @@ TEST(charls_jpegls_encoder_test, encode_non_3_components_with_color_transformati
                             [&encoder, &source] { ignore = encoder.encode(source); });
 }
 
-TEST(charls_jpegls_encoder_test, encode_lossy_with_color_transformations_throws)
+TEST(jpegls_encoder_test, encode_lossy_with_color_transformations_throws)
 {
     constexpr frame_info frame_info{2, 1, 8, 3};
     jpegls_encoder encoder;
@@ -2088,7 +2088,7 @@ TEST(charls_jpegls_encoder_test, encode_lossy_with_color_transformations_throws)
                             [&encoder, &source] { ignore = encoder.encode(source); });
 }
 
-TEST(charls_jpegls_encoder_test, encode_planar_with_color_transformations_throws)
+TEST(jpegls_encoder_test, encode_planar_with_color_transformations_throws)
 {
     constexpr frame_info frame_info{2, 1, 8, 3};
     jpegls_encoder encoder;

--- a/test/jpegls_encoder_test.cpp
+++ b/test/jpegls_encoder_test.cpp
@@ -1373,14 +1373,14 @@ TEST(jpegls_encoder_test, encode_with_color_transformation)
     constexpr frame_info frame_info{2, 1, 8, 3};
 
     jpegls_encoder encoder;
-    encoder.frame_info(frame_info).color_transformation(color_transformation::hp1);
+    encoder.frame_info(frame_info).color_transformation(color_transformation::hp1).interleave_mode(interleave_mode::sample);
     vector<byte> destination(encoder.estimated_destination_size());
     encoder.destination(destination);
 
     const size_t bytes_written{encoder.encode(source)};
     destination.resize(bytes_written);
 
-    test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::none,
+    test_by_decoding(destination, frame_info, source.data(), source.size(), interleave_mode::sample,
                      color_transformation::hp1);
 }
 
@@ -2040,6 +2040,64 @@ TEST(jpegls_encoder_test, encode_to_buffer_with_uint16_size_works)
         // size2 is not a perfect match and needs a conversion.
         ignore = encoder.encode(data2, size2);
     }
+}
+
+TEST(charls_jpegls_encoder_test, encode_non_8_or_16_bit_with_color_transformation_throws)
+{
+    constexpr frame_info frame_info{2, 1, 10, 3};
+    jpegls_encoder encoder;
+
+    vector<byte> destination(40);
+    encoder.destination(destination)
+        .frame_info(frame_info)
+        .color_transformation(color_transformation::hp3)
+        .interleave_mode(interleave_mode::sample);
+    const vector<byte> source(20);
+    assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
+                            [&encoder, &source] { ignore = encoder.encode(source); });
+}
+
+TEST(charls_jpegls_encoder_test, encode_non_3_components_with_color_transformations_throws)
+{
+    constexpr frame_info frame_info{2, 1, 8, 4};
+    jpegls_encoder encoder;
+
+    vector<byte> destination(40);
+    encoder.destination(destination)
+        .frame_info(frame_info)
+        .color_transformation(color_transformation::hp3)
+        .interleave_mode(interleave_mode::sample);
+    const vector<byte> source(20);
+    assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
+                            [&encoder, &source] { ignore = encoder.encode(source); });
+}
+
+TEST(charls_jpegls_encoder_test, encode_lossy_with_color_transformations_throws)
+{
+    constexpr frame_info frame_info{2, 1, 8, 3};
+    jpegls_encoder encoder;
+
+    vector<byte> destination(40);
+    encoder.destination(destination)
+        .frame_info(frame_info)
+        .color_transformation(color_transformation::hp1)
+        .interleave_mode(interleave_mode::sample)
+        .near_lossless(1);
+    const vector<byte> source(20);
+    assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
+                            [&encoder, &source] { ignore = encoder.encode(source); });
+}
+
+TEST(charls_jpegls_encoder_test, encode_planar_with_color_transformations_throws)
+{
+    constexpr frame_info frame_info{2, 1, 8, 3};
+    jpegls_encoder encoder;
+
+    vector<byte> destination(40);
+    encoder.destination(destination).frame_info(frame_info).color_transformation(color_transformation::hp2);
+    const vector<byte> source(20);
+    assert_expect_exception(jpegls_errc::invalid_argument_color_transformation,
+                            [&encoder, &source] { ignore = encoder.encode(source); });
 }
 
 } // namespace charls::test


### PR DESCRIPTION
The HP color transformations can only used when near_lossless = 0. The transformations require that modulo 2^8 (for 8 bit, 2^16 for 16 bit)  work correctly. Using near_lossless != 0 prevent this and can cause artifacts. The original HP implementation also shows artifacts when near_lossless != 0.
To prevent incorrect usage and incorrect decoding (artifacts may sometimes be hard to see) the existing checks have been extended to block unsupported options.

Remark: CharLS only supports color transformations for interleave mode line and sample.  The original HP also supports this for mode none. As this option has never been implemented in the past and would not round-trip correctly, this option is also checked. The main technical implementation problem with interleave mode none during encoding is that the source buffer is read-only and only 1 color at a time can be forwarded to the encoder. The color transformation needs 3 colors at the same time. I could technically be implemented during decoding as a post-decoding step as the buffer is writable, but providing only the decode path would not make much sense.