### PR TITLE
chores: Suppress CHARLS_ALL_WARNINGS

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -76,7 +76,7 @@
 // C++20 provides std::endian, use for now compiler macros.
 #ifdef _MSC_VER
 #define LITTLE_ENDIAN_ARCHITECTURE // MSVC++ compiler support only little endian platforms.
-#elif __GNUC__
+#elif defined(__GNUC__)
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define LITTLE_ENDIAN_ARCHITECTURE
 #endif
@@ -513,7 +513,7 @@ inline size_t checked_mul(const size_t a, const size_t b)
     if (high_bits != 0)
         impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
     return result;
-#elif _M_ARM64
+#elif defined(_M_ARM64)
     if (__umulh(a, b) > 0)
         impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
     return a * b;
@@ -523,7 +523,7 @@ inline size_t checked_mul(const size_t a, const size_t b)
         impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);
     return static_cast<size_t>(high_result);
 #endif
-#elif __GNUC__
+#elif defined(__GNUC__)
     size_t result;
     if (UNLIKELY(__builtin_mul_overflow(a, b, &result)))
         impl::throw_jpegls_error(jpegls_errc::parameter_value_not_supported);

--- a/unittest/jpegls_decoder_test.cpp
+++ b/unittest/jpegls_decoder_test.cpp
@@ -951,7 +951,7 @@ public:
         writer.write_start_of_frame_segment(0, 0, 8, 3);
         writer.write_start_of_scan_segment(0, 3, 0, interleave_mode::sample);
 
-        constexpr array<uint8_t, 4> entropy_data{0, 0, 0, 0};
+        constexpr array<uint8_t, 4> entropy_data{};
         writer.write_bytes(entropy_data.data(), entropy_data.size());
 
         jpegls_decoder decoder;


### PR DESCRIPTION
Suppress warnings that are reported when CHARLS_ALL_WARNINGS  is defined. This define is by default not enabled.