### PR TITLE
chores: Skip SonarCloud Analysis for Dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} msbuild CharLS.sln /t:charls:rebuild /p:Configuration="Release" /p:Platform="x64" /nodeReuse:false
 
       - name: SonarQube Scan
-        if: github.event.pull_request.head.repo.fork == false || github.event_name == 'push'
+        if: (github.event.pull_request.head.repo.fork == false || github.event_name == 'push') && github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           build-wrapper-win-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} msbuild CharLS.sln /t:charls:rebuild /p:Configuration="Release" /p:Platform="x64" /nodeReuse:false
 
       - name: SonarQube Scan
-        if: (github.event.pull_request.head.repo.fork == false || github.event_name == 'push') && github.actor != 'dependabot[bot]'
+        if: github.event_name == 'push' || (github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]')
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/spelling.dic
+++ b/spelling.dic
@@ -45,6 +45,7 @@ palletised
 Qube
 rect
 simd
+sonarqube
 STREQUAL
 subspan
 TOLOWER


### PR DESCRIPTION
Dependabot has no access to SONAR_TOKEN: skip the scan as it not critical and would always fail.