### PR TITLE
refactor: Replace  NOLINT(bugprone-exception-escape) with noexcept(false)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,7 +32,7 @@ Checks:
   - 'cppcoreguidelines-*' # Checks related to C++ Core Guidelines.
   - '-cppcoreguidelines-avoid-magic-numbers' # Rationale: Alias for readability-magic-numbers.
   - '-cppcoreguidelines-pro-bounds-pointer-arithmetic' # Rationale: usage is required in codec implementation.
-  - '-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access' # Rationale: index is pre checked and access verified with runtime analyzers.
+  - '-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access' # Rationale: index is pre-checked and access verified with runtime analyzers.
   - '-cppcoreguidelines-init-variables' # Rationale reports false warnings for out parameters (other checkers are better to detect these problems)
   - '-cppcoreguidelines-pro-bounds-constant-array-index' # Rationale gsl:at is not used by design, memory access verified with other tools.
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,7 @@ Checks:
   - 'cppcoreguidelines-*' # Checks related to C++ Core Guidelines.
   - '-cppcoreguidelines-avoid-magic-numbers' # Rationale: Alias for readability-magic-numbers.
   - '-cppcoreguidelines-pro-bounds-pointer-arithmetic' # Rationale: usage is required in codec implementation.
+  - '-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access' # Rationale: index is pre checked and access verified with runtime analyzers.
   - '-cppcoreguidelines-init-variables' # Rationale reports false warnings for out parameters (other checkers are better to detect these problems)
   - '-cppcoreguidelines-pro-bounds-constant-array-index' # Rationale gsl:at is not used by design, memory access verified with other tools.
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,6 +136,9 @@
       "name": "linux-base",
       "description": "Linux configuration",
       "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
           "hostOS": [ "Linux" ]

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -67,7 +67,7 @@ int32_t get_color_transform_argument(const ArgumentParser& command)
 } // namespace
 
 
-int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-escape)
+int main(const int argc, const char* const argv[]) noexcept(false)
 {
     ArgumentParser program("charls-cli");
     program.add_description("CharLS command line interface");

--- a/fuzzing/afl/main.cpp
+++ b/fuzzing/afl/main.cpp
@@ -67,7 +67,7 @@ vector<uint8_t> generate_once()
 } // namespace
 
 
-int main(const int argc, const char* const argv[]) // NOLINT(bugprone-exception-escape)
+int main(const int argc, const char* const argv[]) noexcept(false)
 {
     int fd{};
     if (argc == 2)


### PR DESCRIPTION
Clang-tidy is aware of the hint that if main it marked with noexcept(false), then the intend is to allow exceptions to escape. main only catches runtime exceptions. Other exceptions should not happen, and when then they should trigger a crash\core dump.