### PR TITLE
fix: UB and possible endless loop when the bit stream ends inside unary code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - Endless loop when decoding invalid JPEG-LS input data.
+- Endless loop when the encoded bit stream ends in the middle of a unary code.
 
 ### Changed
 

--- a/src/scan_decoder.hpp
+++ b/src/scan_decoder.hpp
@@ -258,7 +258,7 @@ private:
         {
             if (position_ >= end_position_)
             {
-                if (UNLIKELY(valid_bits_ == 0))
+                if (UNLIKELY(valid_bits_ <= 0))
                 {
                     // Decoding process expects at least some bits to be added to the cache.
                     impl::throw_jpegls_error(jpegls_errc::invalid_data);

--- a/test/scan_decoder_test.cpp
+++ b/test/scan_decoder_test.cpp
@@ -57,6 +57,12 @@ public:
     {
         return peek_0_bits();
     }
+
+    [[nodiscard]]
+    int32_t read_unary_code_forward()
+    {
+        return read_unary_code();
+    }
 };
 
 } // namespace
@@ -157,6 +163,23 @@ TEST(scan_decoder_test, peek_0_bits_empty_buffer)
 
     scan_decoder_tester scan_decoder(frame_info, parameters, buffer.data(), buffer.size());
     EXPECT_EQ(-1, scan_decoder.peek_0_bits_forward());
+}
+
+TEST(scan_decoder_test, read_unary_code_with_prefix_larger_than_buffer_throws_invalid_data)
+{
+    constexpr frame_info frame_info{1, 1, 8, 1};
+    constexpr coding_parameters parameters{};
+
+    // A unary code prefix of 15 zero bits, but only 8 bits are present in the buffer:
+    // valid_bits_ becomes negative and no bits can be added to the cache anymore.
+    array<byte, 1> buffer{};
+
+    scan_decoder_tester scan_decoder(frame_info, parameters, buffer.data(), buffer.size());
+
+    assert_expect_exception(jpegls_errc::invalid_data, [&scan_decoder] {
+        [[maybe_unused]]
+        const auto result{scan_decoder.read_unary_code_forward()};
+    });
 }
 
 TEST(scan_decoder_test, initialize_with_empty_buffer_throws_invalid_data)


### PR DESCRIPTION
If `valid_bits_ < 0` at end of buffer, `fill_read_cache()` returns without adding bits and `read_bit()` pulls zero bits out of a shifted-out cache until `valid_bits_` and the unary counter wrap around.